### PR TITLE
fix: Mobile menu volledig klikbaar maken

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -61,7 +61,7 @@
             backdrop-filter: blur(10px);
             border-bottom: 1px solid var(--border);
             padding: 1.25rem 0;
-            z-index: 1000;
+            z-index: 999;
         }
 
         .nav-content {
@@ -147,7 +147,8 @@
             position: relative;
             width: 32px;
             height: 32px;
-            z-index: 1001;
+            z-index: 1002;
+            padding: 0;
         }
 
         .mobile-menu-btn span {
@@ -198,7 +199,7 @@
             bottom: 0;
             background: rgba(0, 0, 0, 0.5);
             backdrop-filter: blur(4px);
-            z-index: 999;
+            z-index: 1000;
             opacity: 0;
             transition: opacity 0.3s ease;
         }
@@ -831,6 +832,7 @@
         /* Responsive */
         @media (max-width: 768px) {
             .nav-links {
+                display: flex;
                 position: fixed;
                 top: 0;
                 left: 0;
@@ -839,13 +841,17 @@
                 background: linear-gradient(135deg, var(--brand-darker) 0%, var(--brand-dark) 100%);
                 backdrop-filter: blur(20px);
                 flex-direction: column;
+                justify-content: flex-start;
+                align-items: stretch;
                 padding: 6rem 2rem 2rem;
                 gap: 0.5rem;
                 transform: translateX(100%);
                 opacity: 0;
-                transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-                z-index: 1000;
+                visibility: hidden;
+                transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s 0.4s;
+                z-index: 1001;
                 overflow-y: auto;
+                pointer-events: none;
             }
 
             .nav-links::before {
@@ -864,9 +870,11 @@
             }
 
             .nav-links.active {
-                display: flex;
                 transform: translateX(0);
                 opacity: 1;
+                visibility: visible;
+                transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s 0s;
+                pointer-events: auto;
             }
 
             .nav-links li {
@@ -913,6 +921,8 @@
                 transition: all 0.3s ease;
                 position: relative;
                 overflow: hidden;
+                cursor: pointer;
+                z-index: 1;
             }
 
             .nav-links a:not(.nav-cta) {


### PR DESCRIPTION
Probleem: Mobiel menu opende niet volledig en links waren niet klikbaar

Oplossing:
- Display flex altijd actief voor mobiel menu (niet alleen bij .active)
- Pointer-events: none standaard, auto bij open menu
- Visibility property toegevoegd voor betere show/hide animaties
- Z-index hiërarchie gecorrigeerd (navbar:999, backdrop:1000, menu:1001, button:1002)
- Betere layout met justify-content en align-items
- Smooth transitions met cubic-bezier easing

Resultaat: Menu opent volledig van rechts en alle links zijn klikbaar