### PR TITLE
feat: improve mobile comparison table visual separation

### DIFF
--- a/website/css/mobile-responsive-complete.css
+++ b/website/css/mobile-responsive-complete.css
@@ -167,8 +167,9 @@ html, body {
     display: block;
     margin-bottom: 1.5rem;
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: 1rem;
+    background: var(--brand-darker);
   }
 
   .comparison-table td {
@@ -180,23 +181,51 @@ html, body {
 
   .comparison-table td:first-child {
     font-weight: 700;
-    font-size: 1rem;
+    font-size: 1.05rem;
     color: var(--brand-cyan);
-    margin-bottom: 0.5rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border) !important;
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid var(--border) !important;
+    text-align: center;
+  }
+
+  /* Snow-Flow column - distinctive cyan styling */
+  .comparison-table td:nth-child(2) {
+    background: rgba(0, 217, 255, 0.08);
+    border-left: 3px solid var(--brand-cyan);
+    padding: 1rem !important;
+    margin-bottom: 0.75rem;
+    border-radius: 6px;
   }
 
   .comparison-table td:nth-child(2)::before {
-    content: "Snow-Flow: ";
-    font-weight: 600;
-    color: var(--text-gray);
+    content: "✅ Snow-Flow";
+    display: block;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--brand-cyan);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  /* ServiceNow column - neutral gray styling */
+  .comparison-table td:nth-child(3) {
+    background: rgba(255, 255, 255, 0.03);
+    border-left: 3px solid var(--gray-600);
+    padding: 1rem !important;
+    border-radius: 6px;
   }
 
   .comparison-table td:nth-child(3)::before {
-    content: "ServiceNow: ";
-    font-weight: 600;
-    color: var(--text-gray);
+    content: "⚪ ServiceNow";
+    display: block;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--gray-400);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 
   /* Pricing grid - single column on mobile */


### PR DESCRIPTION
- Added distinct visual styling for Snow-Flow vs ServiceNow columns
- Snow-Flow: cyan background (rgba(0, 217, 255, 0.08)) with cyan border
- ServiceNow: subtle gray background with gray border
- Added prominent labels with icons (✅ Snow-Flow, ⚪ ServiceNow)
- Labels are uppercase with letter-spacing for better readability
- Increased spacing between columns (margin-bottom: 0.75rem)
- Made feature title centered and more prominent (1.05rem)
- Added rounded corners (6px) to individual columns
- Better visual hierarchy with 3px left borders
- Clear color coding: cyan for Snow-Flow, gray for ServiceNow

Much clearer comparison on mobile devices - users can instantly distinguish which feature belongs to which platform.