### PR TITLE
fix: improve mobile menu visibility with proper z-index stacking

### DIFF
--- a/website/components/navigation/Navigation.css
+++ b/website/components/navigation/Navigation.css
@@ -5,7 +5,7 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 9999;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -280,14 +280,18 @@
     flex-direction: column;
     padding: 2rem 0;
     gap: 0;
-    transform: translateX(-100%);
-    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    z-index: 999;
   }
 
   .sf-nav__menu--open {
-    transform: translateX(0);
+    max-height: 100vh;
+    opacity: 1;
   }
 
   .sf-nav__item {

--- a/website/index.html
+++ b/website/index.html
@@ -61,7 +61,7 @@
             backdrop-filter: blur(10px);
             border-bottom: 1px solid var(--border);
             padding: 1.25rem 0;
-            z-index: 999;
+            z-index: 1002;
         }
 
         .nav-content {
@@ -147,7 +147,7 @@
             position: relative;
             width: 32px;
             height: 32px;
-            z-index: 1002;
+            z-index: 1005;
             padding: 0;
         }
 
@@ -197,9 +197,9 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
-            backdrop-filter: blur(4px);
-            z-index: 1000;
+            background: rgba(0, 0, 0, 0.7);
+            backdrop-filter: blur(10px);
+            z-index: 1003;
             opacity: 0;
             transition: opacity 0.3s ease;
         }
@@ -849,7 +849,7 @@
                 opacity: 0;
                 visibility: hidden;
                 transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s 0.4s;
-                z-index: 1001;
+                z-index: 1004;
                 overflow-y: auto;
                 pointer-events: none;
             }


### PR DESCRIPTION
- Increased z-index hierarchy to ensure proper layering:
  * nav: 1002 (base navigation bar)
  * mobile-menu-backdrop: 1003 (overlay background)
  * nav-links: 1004 (mobile menu content)
  * mobile-menu-btn: 1005 (hamburger button, always on top)

- Enhanced backdrop visibility:
  * Increased opacity from 0.5 to 0.7 for darker overlay
  * Improved backdrop-filter blur from 4px to 10px

- Updated Navigation component CSS:
  * Changed mobile animation from translateX to max-height/opacity
  * Increased nav z-index to 9999 for component version
  * Set menu z-index to 999

This fix resolves the issue where users could see the overlay
but the menu items were not visible on mobile devices.