### PR TITLE
fix: prevent mobile menu visibility on zoom

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Snow-Flow | Enterprise ServiceNow Development Platform</title>
     <meta name="description" content="AI-powered ServiceNow development with 410+ tools, seat-based licensing with developer & stakeholder roles, managed SaaS infrastructure, and 99.9% SLA. Built for enterprise teams.">
 
@@ -879,7 +879,9 @@
 
                 /* Hidden by default - slide from right */
                 transform: translateX(100%);
-                transition: transform 0.3s ease;
+                visibility: hidden;
+                opacity: 0;
+                transition: transform 0.3s ease, visibility 0s 0.3s, opacity 0.3s ease;
 
                 /* Enable scrolling */
                 overflow-y: auto;
@@ -889,6 +891,9 @@
             /* Show menu when active */
             .nav-links.active {
                 transform: translateX(0);
+                visibility: visible;
+                opacity: 1;
+                transition: transform 0.3s ease, visibility 0s 0s, opacity 0.3s ease;
             }
 
             /* Menu items styling */


### PR DESCRIPTION
- Added viewport restrictions (maximum-scale=1.0, user-scalable=no)
- Added visibility:hidden and opacity:0 to mobile menu when inactive
- Fixed transitions for smooth menu animations
- Prevents menu from appearing when users zoom out on mobile