### PR TITLE
docs: Update LLM Provider requirements to reference models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ snow-flow status        # System status
 
 - **Node.js** 18+
 - **ServiceNow** instance with OAuth configured
-- **LLM Provider** - API key or Ollama for free local models
+- **LLM Provider** - Any provider supported by [models.dev](https://models.dev) (Claude, GPT-4, Gemini, Mistral, DeepSeek, Groq, and more) or Ollama for free local models
 
 ---
 


### PR DESCRIPTION
Expanded the requirements section to accurately reflect the full range of supported LLM providers via models.dev, instead of only mentioning API keys or Ollama.