### PR TITLE
fix(website): Prevent mobile nav from showing duplicate navigation

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -301,7 +301,9 @@
             transform: translateX(100%);
             visibility: hidden;
             opacity: 0;
-            transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.4s, opacity 0.4s;
+            pointer-events: none;
+            clip-path: inset(0 0 0 100%);
+            transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.4s, opacity 0.4s, clip-path 0.4s;
             border-left: 1px solid var(--border-medium);
             overflow-y: auto;
             display: flex;
@@ -323,6 +325,8 @@
             transform: translateX(0);
             visibility: visible;
             opacity: 1;
+            pointer-events: auto;
+            clip-path: inset(0 0 0 0);
         }
 
         .mobile-nav-header {
@@ -528,12 +532,14 @@
             z-index: 998;
             opacity: 0;
             visibility: hidden;
+            pointer-events: none;
             transition: all 0.3s ease;
         }
 
         .mobile-backdrop.active {
             opacity: 1;
             visibility: visible;
+            pointer-events: auto;
         }
 
         /* =====================================================


### PR DESCRIPTION
Add clip-path and pointer-events to ensure mobile-nav is completely
hidden by default, preventing visual overlap with the main navbar on
mobile devices.