### PR TITLE
fix: Prevent horizontal overflow on mobile devices

### DIFF
--- a/website/src/pages/[lang]/docs.astro
+++ b/website/src/pages/[lang]/docs.astro
@@ -1225,13 +1225,16 @@ snow_update_set_manage(&#123; action: <span class="string">'complete'</span> &#1
         /* Mobile Tables */
         .table-wrapper {
             margin: 1rem -1rem;
-            padding: 0 1rem;
+            padding: 0;
             border-radius: 0;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
         }
 
-        table {
+        .table-wrapper table {
             font-size: 0.8125rem;
-            min-width: 500px;
+            min-width: 420px;
+            margin: 0;
         }
 
         th, td {

--- a/website/src/styles/mobile-responsive-complete.css
+++ b/website/src/styles/mobile-responsive-complete.css
@@ -4,14 +4,41 @@
    ========================================= */
 
 /* Prevent horizontal overflow globally */
-* {
-  max-width: 100%;
-  word-wrap: break-word;
-}
-
 html, body {
   overflow-x: hidden;
   width: 100%;
+  max-width: 100vw;
+}
+
+/* Ensure all content respects viewport */
+.container,
+.docs-content,
+.docs-layout,
+main,
+article,
+section {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/* Allow scrollable elements to overflow internally */
+.table-wrapper,
+.code-block,
+.code-content,
+pre,
+code {
+  max-width: 100%;
+}
+
+pre {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Word breaking for long text */
+p, li, td, th, span, a {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 /* =========================================
@@ -59,11 +86,27 @@ html, body {
    MOBILE OPTIMIZATIONS (max-width: 768px)
    ========================================= */
 @media (max-width: 768px) {
+  /* CRITICAL: Prevent all horizontal overflow */
+  html, body {
+    overflow-x: hidden !important;
+    width: 100% !important;
+    max-width: 100vw !important;
+  }
+
+  /* Clip any overflowing decorative elements */
+  .hero-glow,
+  .bg-grid,
+  .bg-gradient {
+    max-width: 100vw !important;
+    overflow: hidden !important;
+  }
+
   /* Global container fixes */
   .container {
     max-width: 100%;
     padding: 0 1rem !important;
     margin: 0 auto;
+    overflow-x: hidden;
   }
 
   /* Section spacing - much tighter on mobile */


### PR DESCRIPTION
- Add critical overflow-x: hidden to html/body on mobile
- Clip decorative elements (hero-glow, bg-grid) to viewport
- Fix table wrapper with proper overflow scrolling
- Add word-wrap and overflow-wrap for long text
- Ensure containers respect max-width on mobile