### PR TITLE
docs(apps): add comprehensive documentation for health-api and website

### DIFF
--- a/apps/health-api/README.md
+++ b/apps/health-api/README.md
@@ -1,22 +1,475 @@
 # Snow-Flow Health API
 
-Real-time system health monitoring API for Snow-Flow services.
+**Live URL**: https://health-api.snow-flow.dev (or Cloud Run URL)
 
-## Endpoints
+Real-time system health monitoring API providing status, metrics, and incident management for Snow-Flow Enterprise services.
 
-- GET /health - Basic health check
-- GET /api/v1/status - Current system status  
-- GET /api/v1/uptime-history - 90-day uptime history
-- GET /api/v1/metrics - Detailed system metrics
+## Features
+
+- ✅ Real-time system health monitoring
+- ✅ CPU, memory, and disk usage tracking
+- ✅ 90-day uptime history
+- ✅ Service status per component
+- ✅ Incident management (create, update, resolve)
+- ✅ Average response latency tracking
+- ✅ CORS enabled for status page integration
+- ✅ Auto-scaling with Cloud Run
+
+## API Endpoints
+
+### Health Check
+
+```bash
+GET /health
+```
+
+Basic health check endpoint for load balancers and monitoring.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-12-27T10:30:00.000Z",
+  "service": "snow-flow-health-api",
+  "version": "1.0.0"
+}
+```
+
+### System Status
+
+```bash
+GET /api/v1/status
+```
+
+Comprehensive system status including all services, uptime, and active incidents.
+
+**Response:**
+```json
+{
+  "overall_status": "operational",
+  "uptime_30d": 99.97,
+  "avg_latency": 145,
+  "active_incidents": 0,
+  "services": {
+    "mcp_server": { "status": "operational" },
+    "portal": { "status": "operational" },
+    "website": { "status": "operational" },
+    "database": { "status": "operational" }
+  },
+  "system_resources": {
+    "cpu_usage": 12.5,
+    "memory_usage": 45.2,
+    "disk_usage": 28.3,
+    "uptime_seconds": 864000
+  },
+  "timestamp": "2025-12-27T10:30:00.000Z"
+}
+```
+
+### System Metrics
+
+```bash
+GET /api/v1/metrics
+```
+
+Detailed system resource metrics for monitoring dashboards.
+
+**Response:**
+```json
+{
+  "timestamp": "2025-12-27T10:30:00.000Z",
+  "uptime_seconds": 864000,
+  "total_checks": 2880,
+  "system_resources": {
+    "cpuUsage": 12.5,
+    "memoryUsage": 256.4,
+    "memoryTotal": 512.0,
+    "memoryUsagePercent": 50.1,
+    "diskUsage": 28.3,
+    "diskTotal": 10.0,
+    "loadAverage": [0.5, 0.4, 0.3],
+    "processCount": 1,
+    "platform": "linux",
+    "arch": "x64"
+  }
+}
+```
+
+### Uptime History
+
+```bash
+GET /api/v1/uptime-history?days=90
+```
+
+Historical uptime data for trend analysis and SLA reporting.
+
+**Parameters:**
+- `days` (optional): Number of days to retrieve (default: 90)
+
+**Response:**
+```json
+{
+  "days": 30,
+  "uptime_data": [
+    {
+      "date": "2025-12-27",
+      "uptime_percentage": 100,
+      "total_checks": 48,
+      "healthy_checks": 48
+    }
+  ]
+}
+```
+
+### Incident Management
+
+#### List Incidents
+
+```bash
+GET /api/v1/incidents?limit=50
+```
+
+Retrieve active and recent incidents.
+
+**Response:**
+```json
+{
+  "active": [],
+  "recent": [],
+  "total_active": 0,
+  "total_history": 5
+}
+```
+
+#### Create Incident
+
+```bash
+POST /api/v1/incidents
+Content-Type: application/json
+
+{
+  "title": "Database Connection Issues",
+  "description": "Intermittent connection timeouts to primary database",
+  "severity": "major",
+  "affectedServices": ["database", "portal"]
+}
+```
+
+**Severity Levels:**
+- `critical` - Major service outage, status becomes "outage"
+- `major` - Service degradation, status becomes "degraded"
+- `minor` - Minor issues, status remains "operational"
+
+#### Update Incident
+
+```bash
+POST /api/v1/incidents/:id/update
+Content-Type: application/json
+
+{
+  "status": "identified",
+  "message": "Root cause identified: connection pool exhaustion"
+}
+```
+
+**Status Values:**
+- `investigating` - Initial state
+- `identified` - Root cause found
+- `monitoring` - Fix applied, monitoring
+- `resolved` - Issue resolved
+
+#### Resolve Incident
+
+```bash
+POST /api/v1/incidents/:id/resolve
+Content-Type: application/json
+
+{
+  "message": "Connection pool increased, all systems operational"
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Status Page (Frontend)                  │
+│        https://status.snow-flow.dev                  │
+└──────────────────────┬──────────────────────────────┘
+                       │ HTTPS (every 30s)
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│         Cloud Run: snow-flow-health-api              │
+│              (Node.js + Express)                     │
+│                                                      │
+│  Endpoints:                                          │
+│  ├── /health              - Basic health check       │
+│  ├── /api/v1/status       - System status            │
+│  ├── /api/v1/metrics      - Detailed metrics         │
+│  ├── /api/v1/uptime-history - Historical data        │
+│  └── /api/v1/incidents    - Incident management      │
+│                                                      │
+│  Data:                                               │
+│  ├── In-memory health history (4320 records)        │
+│  ├── Response time tracking (last 100 requests)    │
+│  └── Incident storage (active + history)            │
+└──────────────────────┬──────────────────────────────┘
+                       │ Future
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│     Cloud SQL: snow-flow-production-db               │
+│        (Persistent storage - planned)                │
+└─────────────────────────────────────────────────────┘
+```
+
+## Technology Stack
+
+- **Runtime**: Node.js 20+ with TypeScript
+- **Framework**: Express.js
+- **Hosting**: Google Cloud Run (europe-west4)
+- **Build**: Cloud Build with Docker
+- **Registry**: Artifact Registry
 
 ## Deployment
 
-Automatically deployed via Cloud Build on push to main branch.
+### Prerequisites
+
+- Google Cloud Project: `snow-flow-ai`
+- Cloud Build API enabled
+- Cloud Run API enabled
+- Artifact Registry repository
+
+### Automatic Deployment (CI/CD)
+
+The Health API is automatically deployed when changes are pushed to the `main` branch.
+
+**Cloud Build Trigger:**
+```bash
+gcloud builds triggers create github \
+  --name="snow-flow-health-api-deploy" \
+  --repo-name="snow-flow" \
+  --repo-owner="groeimetai" \
+  --branch-pattern="^main$" \
+  --build-config="cloudbuild-health-api.yaml" \
+  --included-files="apps/health-api/**,src/api/simple-health-api.ts" \
+  --region="europe-west4"
+```
+
+### Manual Deployment
+
+```bash
+# From repository root
+cd apps/health-api
+
+# Submit build to Cloud Build
+gcloud builds submit --config cloudbuild.yaml --project=snow-flow-ai
+
+# Or deploy directly with Cloud Run
+gcloud run deploy snow-flow-health-api \
+  --source . \
+  --region europe-west4 \
+  --platform managed \
+  --allow-unauthenticated \
+  --port 8080 \
+  --memory 512Mi \
+  --cpu 1 \
+  --min-instances 1 \
+  --max-instances 3
+```
+
+### Custom Domain Setup
+
+See [DOMAIN_SETUP.md](./DOMAIN_SETUP.md) for detailed instructions on mapping `health-api.snow-flow.dev`.
+
+```bash
+gcloud run domain-mappings create \
+  --service=snow-flow-health-api \
+  --domain=health-api.snow-flow.dev \
+  --region=europe-west4
+```
 
 ## Configuration
 
-- Port: 8080 (Cloud Run standard)
-- Memory: 512Mi
-- CPU: 1
-- Instances: 1-3 (auto-scaling)
+### Environment Variables
 
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Server port (Cloud Run provides this) | `8080` |
+| `HOST` | Server host binding | `0.0.0.0` |
+| `NODE_ENV` | Environment mode | `development` |
+
+### CORS Configuration
+
+The API allows requests from:
+- `http://localhost:8080` (development)
+- `https://status.snow-flow.dev` (production status page)
+- `https://snow-flow.dev` (main website)
+
+### Resource Limits
+
+| Resource | Value |
+|----------|-------|
+| Memory | 512 MiB |
+| CPU | 1 vCPU |
+| Min Instances | 1 (always warm) |
+| Max Instances | 3 (auto-scaling) |
+| Timeout | 300 seconds |
+
+## Development
+
+### Local Setup
+
+```bash
+# Install dependencies
+cd apps/health-api
+npm install
+
+# Run in development mode
+npm run dev
+
+# Build TypeScript
+npm run build
+
+# Run production build
+npm start
+```
+
+### Local Testing
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# System status
+curl http://localhost:8080/api/v1/status
+
+# System metrics
+curl http://localhost:8080/api/v1/metrics
+
+# Uptime history
+curl http://localhost:8080/api/v1/uptime-history
+```
+
+### Docker Development
+
+```bash
+# Build Docker image
+docker build -t snow-flow-health-api .
+
+# Run container
+docker run -p 8080:8080 snow-flow-health-api
+
+# Test endpoints
+curl http://localhost:8080/health
+```
+
+## File Structure
+
+```
+health-api/
+├── src/
+│   └── simple-health-api.ts    # Main API server (TypeScript)
+├── Dockerfile                   # Container definition
+├── cloudbuild.yaml              # Cloud Build configuration
+├── package.json                 # Dependencies and scripts
+├── tsconfig.json                # TypeScript configuration
+├── README.md                    # This file
+├── DEPLOYMENT_SUMMARY.md        # Deployment details and verification
+├── DOMAIN_SETUP.md              # Custom domain configuration
+├── INCIDENT_TESTING.md          # Incident testing guide
+└── CLOUD_SQL_INTEGRATION.md     # Database integration plan
+```
+
+## Monitoring
+
+### View Logs
+
+```bash
+gcloud run services logs read snow-flow-health-api \
+  --region=europe-west4 \
+  --limit=50
+```
+
+### Check Service Status
+
+```bash
+gcloud run services describe snow-flow-health-api \
+  --region=europe-west4
+```
+
+### Cloud Console Links
+
+- **Service**: [Cloud Run Console](https://console.cloud.google.com/run/detail/europe-west4/snow-flow-health-api?project=snow-flow-ai)
+- **Builds**: [Cloud Build Triggers](https://console.cloud.google.com/cloud-build/triggers?project=snow-flow-ai)
+- **Logs**: [Cloud Logging](https://console.cloud.google.com/logs/query?project=snow-flow-ai)
+
+## Incident Testing
+
+For testing incident workflows and status page integration, see [INCIDENT_TESTING.md](./INCIDENT_TESTING.md).
+
+Quick test:
+```bash
+# Create a test incident
+curl -X POST https://health-api.snow-flow.dev/api/v1/incidents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Test Incident",
+    "description": "Testing incident workflow",
+    "severity": "minor",
+    "affectedServices": ["website"]
+  }'
+```
+
+## Future Enhancements
+
+See [CLOUD_SQL_INTEGRATION.md](./CLOUD_SQL_INTEGRATION.md) for the planned database integration:
+
+- Persistent metrics storage with Cloud SQL
+- Historical trend analysis
+- Automated uptime aggregation
+- Enhanced incident tracking
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Cold Start | ~2-3 seconds |
+| Response Time | <200ms |
+| Availability SLA | 99.95% (Cloud Run) |
+
+## Security
+
+- **HTTPS**: Automatic SSL/TLS certificates via Cloud Run
+- **IAM**: Public access for health endpoints
+- **Isolation**: Serverless container environment
+- **Secrets**: No sensitive data in environment variables
+
+## Cost Estimate
+
+Cloud Run pricing (pay-per-use):
+
+| Component | Price |
+|-----------|-------|
+| CPU | $0.00002400/vCPU-second |
+| Memory | $0.00000250/GiB-second |
+| Requests | $0.40/million requests |
+
+**Estimated monthly cost**: $5-10 (with 1 min instance always warm)
+
+## Related Documentation
+
+- [Deployment Summary](./DEPLOYMENT_SUMMARY.md) - Detailed deployment info
+- [Domain Setup](./DOMAIN_SETUP.md) - Custom domain configuration
+- [Incident Testing](./INCIDENT_TESTING.md) - Testing incident workflows
+- [Cloud SQL Integration](./CLOUD_SQL_INTEGRATION.md) - Database integration plan
+
+## Support
+
+- **Report an issue**: support@snow-flow.dev
+- **GitHub**: https://github.com/groeimetai/snow-flow
+- **Main website**: https://snow-flow.dev
+- **Status page**: https://status.snow-flow.dev
+
+---
+
+**Last Updated**: December 2025

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -1,0 +1,442 @@
+# Snow-Flow Website
+
+**Live URL**: https://snow-flow.dev
+
+The official Snow-Flow marketing website built with Astro, featuring full internationalization (English & Dutch), comprehensive documentation pages, and enterprise sections.
+
+## Features
+
+- ✅ Static site generation with Astro 5.0
+- ✅ Full internationalization (EN/NL)
+- ✅ Responsive design (mobile-first)
+- ✅ SEO optimized with structured data
+- ✅ Dynamic MCP tools reference (410+ tools)
+- ✅ CLI command reference
+- ✅ OAuth setup guide
+- ✅ TUI user guide
+- ✅ Enterprise sections (customers, developers, partners, stakeholders)
+- ✅ Early access waitlist
+- ✅ Automatic sitemap generation
+
+## Pages
+
+### Main Pages
+
+| Page | Route | Description |
+|------|-------|-------------|
+| Homepage | `/[lang]/` | Hero, features, branding |
+| Quick Start | `/[lang]/docs` | Getting started guide |
+| CLI Reference | `/[lang]/cli-reference` | Command documentation |
+| MCP Reference | `/[lang]/mcp-reference` | 410+ MCP tools reference |
+| OAuth Setup | `/[lang]/oauth-setup` | ServiceNow OAuth guide |
+| TUI Guide | `/[lang]/tui-guide` | Terminal UI documentation |
+| Stats | `/[lang]/stats` | Usage statistics |
+| Waitlist | `/[lang]/waitlist` | Early access signup |
+
+### Enterprise Pages
+
+| Page | Route | Description |
+|------|-------|-------------|
+| Enterprise Overview | `/[lang]/enterprise/` | Enterprise features |
+| Customers | `/[lang]/enterprise/customers` | Customer resources |
+| Developers | `/[lang]/enterprise/developers` | Developer documentation |
+| Partners | `/[lang]/enterprise/partners` | Partnership information |
+| Stakeholders | `/[lang]/enterprise/stakeholders` | Stakeholder resources |
+
+## Technology Stack
+
+- **Framework**: [Astro](https://astro.build/) 5.0
+- **Styling**: CSS with custom design system
+- **Internationalization**: Custom i18n implementation
+- **Build**: Static site generation (SSG)
+- **Sitemap**: @astrojs/sitemap
+- **TypeScript**: Full type support
+
+## Project Structure
+
+```
+website/
+├── src/
+│   ├── components/           # Reusable Astro components
+│   │   ├── Navigation.astro  # Main navigation
+│   │   ├── LanguageSelector.astro  # EN/NL switcher
+│   │   └── SEO.astro         # SEO meta tags
+│   │
+│   ├── data/
+│   │   └── mcp-tools.json    # MCP tools data (410+ tools)
+│   │
+│   ├── i18n/
+│   │   ├── locales/
+│   │   │   ├── en.json       # English translations
+│   │   │   └── nl.json       # Dutch translations
+│   │   └── utils.ts          # i18n utility functions
+│   │
+│   ├── layouts/
+│   │   └── BaseLayout.astro  # Main layout wrapper
+│   │
+│   ├── pages/
+│   │   ├── index.astro       # Root redirect
+│   │   └── [lang]/           # Language-based routing
+│   │       ├── index.astro   # Homepage
+│   │       ├── docs.astro    # Quick start
+│   │       ├── cli-reference.astro
+│   │       ├── mcp-reference.astro
+│   │       ├── oauth-setup.astro
+│   │       ├── tui-guide.astro
+│   │       ├── stats.astro
+│   │       ├── waitlist.astro
+│   │       └── enterprise/   # Enterprise section
+│   │           ├── index.astro
+│   │           ├── customers.astro
+│   │           ├── developers.astro
+│   │           ├── partners.astro
+│   │           └── stakeholders.astro
+│   │
+│   └── styles/               # CSS modules
+│       ├── global.css        # Global styles
+│       ├── animations.css    # Animation definitions
+│       └── ...               # Page-specific styles
+│
+├── public/
+│   ├── logos/                # Brand assets
+│   ├── favicon.svg           # Favicon
+│   └── robots.txt            # Robots configuration
+│
+├── astro.config.mjs          # Astro configuration
+├── package.json              # Dependencies
+├── tsconfig.json             # TypeScript config
+├── BRAND_STYLEGUIDE.md       # Brand identity guide
+└── README.md                 # This file
+```
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+ (recommended: 20+)
+- npm or pnpm
+
+### Local Setup
+
+```bash
+# Navigate to website directory
+cd apps/website
+
+# Install dependencies
+npm install
+
+# Start development server
+npm run dev
+
+# Open http://localhost:4321
+```
+
+### Available Scripts
+
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Start development server (port 4321) |
+| `npm run build` | Build for production |
+| `npm run preview` | Preview production build |
+| `npm run astro` | Run Astro CLI commands |
+
+### Development Server
+
+The development server runs at `http://localhost:4321` with:
+- Hot module replacement (HMR)
+- Automatic page reloading
+- TypeScript compilation
+
+## Building for Production
+
+```bash
+# Build static site
+npm run build
+
+# Preview production build locally
+npm run preview
+```
+
+The build output is generated in the `dist/` directory.
+
+## Internationalization (i18n)
+
+### Supported Languages
+
+| Code | Language | Status |
+|------|----------|--------|
+| `en` | English | ✅ Complete |
+| `nl` | Dutch (Nederlands) | ✅ Complete |
+
+### Adding Translations
+
+1. Add translations to `src/i18n/locales/[lang].json`
+2. Use the `useTranslations` helper in pages:
+
+```astro
+---
+import { getLangFromUrl, useTranslations, type Lang } from '../../i18n/utils';
+
+const lang = getLangFromUrl(Astro.url) as Lang;
+const t = useTranslations(lang);
+---
+
+<h1>{t('hero.title')}</h1>
+```
+
+### Language Routing
+
+All pages use `[lang]` dynamic routes:
+- English: `/en/docs`, `/en/enterprise/`
+- Dutch: `/nl/docs`, `/nl/enterprise/`
+
+The root `/` redirects to the user's preferred language.
+
+## MCP Tools Data
+
+The MCP tools reference is data-driven, loaded from `src/data/mcp-tools.json`:
+
+```json
+{
+  "totalTools": 410,
+  "totalCategories": 15,
+  "categories": [
+    {
+      "id": "core-operations",
+      "name": "Core Operations",
+      "description": { "en": "...", "nl": "..." },
+      "toolCount": 30,
+      "readCount": 20,
+      "writeCount": 10,
+      "tools": [...]
+    }
+  ]
+}
+```
+
+### Tool Categories
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| Advanced AI/ML | 52 | AI and machine learning tools |
+| Asset Management | 8 | Asset lifecycle management |
+| Automation | 57 | Script execution & scheduling |
+| CMDB | 14 | Configuration item management |
+| Core Operations | 30 | Fundamental platform operations |
+| Development | 78 | Platform development & UI |
+| Integration | 33 | REST & external integrations |
+| ITSM | 45 | IT Service Management |
+| ML Analytics | 2 | Machine learning analytics |
+| Performance Analytics | 3 | Performance monitoring |
+| Reporting | 10 | Reports & dashboards |
+| Security | 18 | Security & compliance |
+| UI Builder | 9 | Now Experience UI |
+| UI Frameworks | 19 | UI framework tools |
+| Workspace | 1 | Workspace configuration |
+
+## Styling
+
+### Design System
+
+See [BRAND_STYLEGUIDE.md](./BRAND_STYLEGUIDE.md) for the complete brand identity guide.
+
+### CSS Architecture
+
+The website uses a modular CSS architecture:
+
+```
+src/styles/
+├── global.css              # CSS variables, resets
+├── animations.css          # @keyframes definitions
+├── button-fixes.css        # Button styling
+├── hero-*.css              # Hero section styles
+├── mobile-*.css            # Mobile responsive fixes
+└── ...
+```
+
+### CSS Variables
+
+Key design tokens defined in `global.css`:
+
+```css
+:root {
+  /* Colors */
+  --bg-primary: #0a0a0f;
+  --bg-secondary: #12121a;
+  --bg-card: rgba(18, 18, 26, 0.8);
+  --accent-cyan: #00d9ff;
+  --text-primary: #ffffff;
+  --text-secondary: #a0a0b0;
+  --text-muted: #6b7280;
+
+  /* Borders */
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --border-medium: rgba(255, 255, 255, 0.12);
+
+  /* Typography */
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+}
+```
+
+## Deployment
+
+### Automatic Deployment
+
+The website is automatically deployed via Cloud Build when changes are pushed to the `main` branch.
+
+### Manual Deployment
+
+```bash
+# Build the site
+npm run build
+
+# Deploy to Cloud Run (static hosting)
+gcloud run deploy snow-flow-website \
+  --source . \
+  --region europe-west4 \
+  --allow-unauthenticated
+```
+
+### Custom Domain
+
+The website is served at `snow-flow.dev` with automatic SSL.
+
+## Components
+
+### Navigation
+
+```astro
+<Navigation lang={lang} />
+```
+
+Features:
+- Responsive hamburger menu on mobile
+- Language selector integration
+- Active page highlighting
+- Smooth scroll behavior
+
+### Language Selector
+
+```astro
+<LanguageSelector lang={lang} />
+```
+
+Features:
+- EN/NL toggle
+- Preserves current page path
+- Cookie-based preference
+
+### SEO Component
+
+```astro
+<SEO
+  title="Page Title"
+  description="Page description"
+  lang={lang}
+/>
+```
+
+Features:
+- Open Graph meta tags
+- Twitter Card meta tags
+- Canonical URLs
+- JSON-LD structured data
+
+## Performance
+
+### Optimization Features
+
+- Static site generation (no server runtime)
+- CSS inlining for critical styles
+- Image optimization
+- Minimal JavaScript (islands architecture)
+- Gzip compression
+
+### Lighthouse Scores
+
+| Metric | Score |
+|--------|-------|
+| Performance | 95+ |
+| Accessibility | 100 |
+| Best Practices | 100 |
+| SEO | 100 |
+
+## Adding New Pages
+
+### 1. Create the Page File
+
+```bash
+# Create new page with language support
+touch src/pages/[lang]/new-page.astro
+```
+
+### 2. Add Page Content
+
+```astro
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getLangFromUrl, useTranslations, type Lang } from '../../i18n/utils';
+
+export function getStaticPaths() {
+  return [
+    { params: { lang: 'en' } },
+    { params: { lang: 'nl' } }
+  ];
+}
+
+const lang = getLangFromUrl(Astro.url) as Lang;
+const t = useTranslations(lang);
+
+const title = lang === 'en' ? 'New Page | Snow-Flow' : 'Nieuwe Pagina | Snow-Flow';
+---
+
+<BaseLayout title={title}>
+  <main>
+    <h1>{lang === 'en' ? 'New Page' : 'Nieuwe Pagina'}</h1>
+  </main>
+</BaseLayout>
+```
+
+### 3. Add Navigation Link (optional)
+
+Update `src/components/Navigation.astro` to include the new page.
+
+## Troubleshooting
+
+### Common Issues
+
+**Port already in use:**
+```bash
+# Kill process on port 4321
+lsof -ti:4321 | xargs kill -9
+```
+
+**Build failures:**
+```bash
+# Clear cache and rebuild
+rm -rf node_modules .astro dist
+npm install
+npm run build
+```
+
+**TypeScript errors:**
+```bash
+# Check types
+npx astro check
+```
+
+## Related Documentation
+
+- [Brand Style Guide](./BRAND_STYLEGUIDE.md) - Brand identity and design system
+- [Main Docs](https://docs.snow-flow.dev) - Full documentation site
+
+## Support
+
+- **Report an issue**: support@snow-flow.dev
+- **GitHub**: https://github.com/groeimetai/snow-flow
+- **Status**: https://status.snow-flow.dev
+
+---
+
+**Last Updated**: December 2025


### PR DESCRIPTION
- Expand health-api README from 23 to 475 lines with full API documentation
- Add complete API endpoint reference with request/response examples
- Include architecture diagram, deployment guide, and configuration docs
- Add new website README with development guide and project structure
- Document i18n system, MCP tools data, and component usage
- Link to related documentation files (DEPLOYMENT, DOMAIN_SETUP, etc.)