### PR TITLE
Update MCP server packaging and configuration

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -54,11 +54,12 @@ for (const tag of tags) {
 
 if (!Script.preview) {
   // Create archives for GitHub release
+  // Include both bin/ and mcp/ directories so postinstall gets the MCP server files
   for (const key of Object.keys(binaries)) {
     if (key.includes("linux")) {
-      await $`tar -czf ../../${key}.tar.gz *`.cwd(`dist/${key}/bin`)
+      await $`tar -czf ../${key}.tar.gz bin mcp`.cwd(`dist/${key}`)
     } else {
-      await $`zip -r ../../${key}.zip *`.cwd(`dist/${key}/bin`)
+      await $`zip -r ../${key}.zip bin mcp`.cwd(`dist/${key}`)
     }
   }
 

--- a/packages/opencode/src/servicenow/index.ts
+++ b/packages/opencode/src/servicenow/index.ts
@@ -10,6 +10,8 @@
  * They are automatically injected when credentials are present in the auth store.
  */
 
+import { Config } from "../config/config"
+
 // Auth - these are in the main auth module
 export { ServiceNowOAuth } from "../auth/servicenow-oauth"
 export type { ServiceNowAuthResult, ServiceNowOAuthOptions } from "../auth/servicenow-oauth"
@@ -33,7 +35,7 @@ export {
  *   "mcp": {
  *     "servicenow-unified": {
  *       "type": "local",
- *       "command": ["node", "node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js"],
+ *       "command": ["bun", "run", "node_modules/snow-flow/mcp/servicenow-unified.js"],
  *       "environment": {
  *         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
  *         "SERVICENOW_CLIENT_ID": "your-client-id",
@@ -46,10 +48,7 @@ export {
 export function getDefaultServiceNowMcpConfig() {
   return {
     type: "local" as const,
-    command: [
-      "node",
-      "node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js",
-    ],
+    command: Config.getMcpServerCommand("servicenow-unified"),
     environment: {
       SERVICENOW_INSTANCE_URL: process.env.SERVICENOW_INSTANCE_URL ?? "",
       SERVICENOW_CLIENT_ID: process.env.SERVICENOW_CLIENT_ID ?? "",

--- a/packages/opencode/src/servicenow/mcp-config.ts
+++ b/packages/opencode/src/servicenow/mcp-config.ts
@@ -5,7 +5,7 @@
  * when ServiceNow credentials are available in the auth store.
  */
 
-import type { Config } from "../config/config"
+import { Config } from "../config/config"
 
 /**
  * Get the default ServiceNow MCP server configuration
@@ -40,10 +40,7 @@ export function getServiceNowMcpConfig(options?: {
 
   return {
     type: "local",
-    command: [
-      "node",
-      "node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js",
-    ],
+    command: Config.getMcpServerCommand("servicenow-unified"),
     environment,
     enabled: true,
   }
@@ -119,10 +116,7 @@ export async function getServiceNowMcpConfigFromAuth(): Promise<Config.Mcp | nul
       // For basic auth, we use different env vars
       return {
         type: "local",
-        command: [
-          "node",
-          "node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js",
-        ],
+        command: Config.getMcpServerCommand("servicenow-unified"),
         environment: {
           SERVICENOW_INSTANCE_URL: snAuth.instance,
           SERVICENOW_USERNAME: snAuth.username,
@@ -152,7 +146,7 @@ export const SERVICENOW_MCP_CONFIG_EXAMPLE = `
   "mcp": {
     "servicenow-unified": {
       "type": "local",
-      "command": ["node", "node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js"],
+      "command": ["bun", "run", "node_modules/snow-flow/mcp/servicenow-unified.js"],
       "environment": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_CLIENT_ID": "your-oauth-client-id",


### PR DESCRIPTION
### What does this PR do?

This PR updates the MCP (Model Context Protocol) server packaging and configuration to support the new distribution structure:

1. **Archive Creation**: Modified the publish script to include both `bin/` and `mcp/` directories when creating release archives (tar.gz for Linux, zip for others). This ensures the MCP server files are available during postinstall.

2. **Configuration Centralization**: Replaced hardcoded MCP server command paths with a call to `Config.getMcpServerCommand()`, centralizing the command configuration logic and making it easier to maintain across multiple locations.

3. **Updated Command Path**: Changed the MCP server command from:
   - `node node_modules/@groeimetai/snow-flow-ts/dist/servicenow/servicenow-mcp-unified/index.js`
   
   To:
   - `bun run node_modules/snow-flow/mcp/servicenow-unified.js`
   
   This reflects the new package structure and uses `bun` as the runtime.

4. **Import Updates**: Changed `mcp-config.ts` to use a named import for `Config` instead of a type-only import, enabling runtime access to the `getMcpServerCommand()` method.

### How did you verify your code works?

- Verified that the archive creation commands now correctly reference both `bin` and `mcp` directories from the parent `dist/{key}` directory
- Confirmed that `Config.getMcpServerCommand()` is properly imported and callable in all locations where hardcoded paths were replaced
- Ensured the new command path aligns with the updated package structure for the MCP server

https://claude.ai/code/session_0128aE6mb2gCvcbAMDuuF1Nt