### PR TITLE
fix: use node instead of bun to run bundled MCP servers

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -269,9 +269,9 @@ export namespace Config {
       log.info("checking bundled path", { bundledPath, exists })
       if (exists) {
         log.info("found bundled MCP server", { serverName, path: bundledPath })
-        // Use bun for bundled JS - it works with both bun-targeted and node-targeted builds
-        // Node.js doesn't support import.meta.require used in bun-targeted builds
-        return ["bun", "run", bundledPath]
+        // Bundled MCP servers are built with target: "node", so use node as the runtime.
+        // This ensures it works on systems where bun is not installed.
+        return ["node", bundledPath]
       }
     }
 

--- a/packages/opencode/src/servicenow/index.ts
+++ b/packages/opencode/src/servicenow/index.ts
@@ -35,7 +35,7 @@ export {
  *   "mcp": {
  *     "servicenow-unified": {
  *       "type": "local",
- *       "command": ["bun", "run", "node_modules/snow-flow/mcp/servicenow-unified.js"],
+ *       "command": ["node", "node_modules/snow-flow/mcp/servicenow-unified.js"],
  *       "environment": {
  *         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
  *         "SERVICENOW_CLIENT_ID": "your-client-id",

--- a/packages/opencode/src/servicenow/mcp-config.ts
+++ b/packages/opencode/src/servicenow/mcp-config.ts
@@ -146,7 +146,7 @@ export const SERVICENOW_MCP_CONFIG_EXAMPLE = `
   "mcp": {
     "servicenow-unified": {
       "type": "local",
-      "command": ["bun", "run", "node_modules/snow-flow/mcp/servicenow-unified.js"],
+      "command": ["node", "node_modules/snow-flow/mcp/servicenow-unified.js"],
       "environment": {
         "SERVICENOW_INSTANCE_URL": "https://your-instance.service-now.com",
         "SERVICENOW_CLIENT_ID": "your-oauth-client-id",


### PR DESCRIPTION
The bundled MCP servers are built with target: "node", so they don't require bun. Using "node" as the runtime ensures the MCP server works on systems where only node is installed (most npm users).
