### PR TITLE
refactor(automation): rename snow_schedule_script_job to snow_execute_script

### DIFF
--- a/packages/opencode/src/bundled-skills/acl-security/SKILL.md
+++ b/packages/opencode/src/bundled-skills/acl-security/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_review_access_control
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # ACL Security Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/agent-workspace/SKILL.md
+++ b/packages/opencode/src/bundled-skills/agent-workspace/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_workspace_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Agent Workspace for ServiceNow
@@ -445,7 +445,7 @@ action.insert()
 | `snow_find_artifact`              | Find workspace configs   |
 | `snow_query_table`                | Query workspace tables   |
 | `snow_deploy`                     | Deploy workspace widgets |
-| `snow_execute_script_with_output` | Test workspace scripts   |
+| `snow_execute_script` | Test workspace scripts   |
 
 ### Example Workflow
 
@@ -465,7 +465,7 @@ await snow_query_table({
 })
 
 // 3. Test similar incident finder
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var finder = new SimilarIncidentFinder();
         var similar = finder.findSimilar('incident_sys_id');

--- a/packages/opencode/src/bundled-skills/approval-workflows/SKILL.md
+++ b/packages/opencode/src/bundled-skills/approval-workflows/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_approval_rule_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Approval Workflows for ServiceNow
@@ -355,7 +355,7 @@ function sendApprovalNotification(approvalSysId) {
 | --------------------------------- | ------------------------ |
 | `snow_query_table`                | Query approvals          |
 | `snow_find_artifact`              | Find approval rules      |
-| `snow_execute_script_with_output` | Test approval scripts    |
+| `snow_execute_script` | Test approval scripts    |
 | `snow_create_business_rule`       | Create approval triggers |
 
 ### Example Workflow
@@ -376,7 +376,7 @@ await snow_query_table({
 })
 
 // 3. Check delegations
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var delegates = getActiveDelegates(gs.getUserID());
         gs.info('Active delegates: ' + JSON.stringify(delegates));

--- a/packages/opencode/src/bundled-skills/asset-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/asset-management/SKILL.md
@@ -384,7 +384,7 @@ function getAssetInventorySummary() {
 | --------------------------------- | ------------------------- |
 | `snow_query_table`                | Query assets and licenses |
 | `snow_cmdb_search`                | Search CMDB for CIs       |
-| `snow_execute_script_with_output` | Test asset scripts        |
+| `snow_execute_script` | Test asset scripts        |
 | `snow_find_artifact`              | Find asset configurations |
 
 ### Example Workflow
@@ -398,7 +398,7 @@ await snow_query_table({
 })
 
 // 2. Check license compliance
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var license = new GlideRecord('alm_license');
         license.addQuery('remainingRELATIVELT@integer@0');

--- a/packages/opencode/src/bundled-skills/business-rule-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/business-rule-patterns/SKILL.md
@@ -6,7 +6,7 @@ tools:
   - snow_create_business_rule
   - snow_find_artifact
   - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Business Rule Best Practices for ServiceNow

--- a/packages/opencode/src/bundled-skills/code-review/SKILL.md
+++ b/packages/opencode/src/bundled-skills/code-review/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_analyze_artifact
 ---
 

--- a/packages/opencode/src/bundled-skills/csm-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/csm-patterns/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_csm_case_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Customer Service Management for ServiceNow
@@ -374,7 +374,7 @@ function checkEntitlement(accountSysId, entitlementType) {
 | --------------------------------- | ----------------------- |
 | `snow_query_table`                | Query CSM tables        |
 | `snow_find_artifact`              | Find CSM configurations |
-| `snow_execute_script_with_output` | Test CSM scripts        |
+| `snow_execute_script` | Test CSM scripts        |
 | `snow_deploy`                     | Deploy CSM widgets      |
 
 ### Example Workflow
@@ -388,7 +388,7 @@ await snow_query_table({
 })
 
 // 2. Check entitlements
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = checkEntitlement('account_sys_id', 'premium_support');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/data-policies/SKILL.md
+++ b/packages/opencode/src/bundled-skills/data-policies/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_discover_table_fields
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Data Policies & Dictionary for ServiceNow
@@ -377,7 +377,7 @@ function fieldExists(tableName, fieldName) {
 | --------------------------------- | ----------------------- |
 | `snow_query_table`                | Query dictionary        |
 | `snow_discover_table_fields`      | Get field definitions   |
-| `snow_execute_script_with_output` | Test dictionary scripts |
+| `snow_execute_script` | Test dictionary scripts |
 | `snow_find_artifact`              | Find data policies      |
 
 ### Example Workflow

--- a/packages/opencode/src/bundled-skills/discovery-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/discovery-patterns/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_discovery_schedule_create
   - snow_cmdb_search
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Discovery Patterns for ServiceNow
@@ -350,7 +350,7 @@ function getDiscoveredDevices(statusSysId) {
 | --------------------------------- | ---------------------- |
 | `snow_query_table`                | Query discovery tables |
 | `snow_find_artifact`              | Find discovery configs |
-| `snow_execute_script_with_output` | Test discovery scripts |
+| `snow_execute_script` | Test discovery scripts |
 | `snow_cmdb_search`                | Search discovered CIs  |
 
 ### Example Workflow
@@ -364,7 +364,7 @@ await snow_query_table({
 })
 
 // 2. Check recent discovery status
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var status = getDiscoveryStatus('schedule_sys_id');
         gs.info(JSON.stringify(status));

--- a/packages/opencode/src/bundled-skills/document-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/document-management/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
 ---
 
@@ -403,7 +403,7 @@ function canAccessAttachment(attachmentSysId) {
 | Tool                              | Purpose               |
 | --------------------------------- | --------------------- |
 | `snow_query_table`                | Query attachments     |
-| `snow_execute_script_with_output` | Test document scripts |
+| `snow_execute_script` | Test document scripts |
 | `snow_find_artifact`              | Find templates        |
 
 ### Example Workflow
@@ -417,7 +417,7 @@ await snow_query_table({
 })
 
 // 2. Generate document
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var html = generateDocumentFromTemplate('Incident Summary', 'inc_sys_id');
         gs.info('Generated: ' + (html ? 'success' : 'failed'));

--- a/packages/opencode/src/bundled-skills/domain-separation/SKILL.md
+++ b/packages/opencode/src/bundled-skills/domain-separation/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
 ---
 
@@ -360,7 +360,7 @@ function onboardTenant(tenantData) {
 | Tool                              | Purpose                    |
 | --------------------------------- | -------------------------- |
 | `snow_query_table`                | Query domain-aware data    |
-| `snow_execute_script_with_output` | Test domain scripts        |
+| `snow_execute_script` | Test domain scripts        |
 | `snow_find_artifact`              | Find domain configurations |
 
 ### Example Workflow

--- a/packages/opencode/src/bundled-skills/email-notifications/SKILL.md
+++ b/packages/opencode/src/bundled-skills/email-notifications/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_configure_email
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Email Notifications for ServiceNow

--- a/packages/opencode/src/bundled-skills/es5-compliance/SKILL.md
+++ b/packages/opencode/src/bundled-skills/es5-compliance/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_convert_es6_to_es5
 ---
 

--- a/packages/opencode/src/bundled-skills/event-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/event-management/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_create_event
 ---
 
@@ -406,7 +406,7 @@ function getThresholdName(severity) {
 | --------------------------------- | ----------------------- |
 | `snow_query_table`                | Query events and alerts |
 | `snow_find_artifact`              | Find event rules        |
-| `snow_execute_script_with_output` | Test event scripts      |
+| `snow_execute_script` | Test event scripts      |
 | `snow_create_event`               | Trigger system events   |
 
 ### Example Workflow
@@ -427,7 +427,7 @@ await snow_query_table({
 })
 
 // 3. Create test event
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var event = new GlideRecord('em_event');
         event.initialize();

--- a/packages/opencode/src/bundled-skills/field-service/SKILL.md
+++ b/packages/opencode/src/bundled-skills/field-service/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
 ---
 
@@ -374,7 +374,7 @@ function recordTimeEntry(workOrderSysId, timeData) {
 | Tool                              | Purpose             |
 | --------------------------------- | ------------------- |
 | `snow_query_table`                | Query FSM tables    |
-| `snow_execute_script_with_output` | Test FSM scripts    |
+| `snow_execute_script` | Test FSM scripts    |
 | `snow_find_artifact`              | Find configurations |
 
 ### Example Workflow
@@ -388,7 +388,7 @@ await snow_query_table({
 })
 
 // 2. Find available technicians
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var available = getAvailableTechnicians(
             new GlideDateTime(),

--- a/packages/opencode/src/bundled-skills/flow-designer/SKILL.md
+++ b/packages/opencode/src/bundled-skills/flow-designer/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Flow Designer Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/gliderecord-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/gliderecord-patterns/SKILL.md
@@ -4,7 +4,7 @@ description: This skill should be used when the user asks to "query records", "G
 version: 1.0.0
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_discover_table_fields
 ---
 

--- a/packages/opencode/src/bundled-skills/grc-compliance/SKILL.md
+++ b/packages/opencode/src/bundled-skills/grc-compliance/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_audit_compliance
   - snow_assess_risk
 ---
@@ -412,7 +412,7 @@ function getComplianceSummary() {
 | Tool                              | Purpose               |
 | --------------------------------- | --------------------- |
 | `snow_query_table`                | Query GRC tables      |
-| `snow_execute_script_with_output` | Test GRC scripts      |
+| `snow_execute_script` | Test GRC scripts      |
 | `snow_audit_compliance`           | Run compliance audits |
 | `snow_assess_risk`                | Risk assessment       |
 
@@ -434,7 +434,7 @@ await snow_query_table({
 })
 
 // 3. Get compliance summary
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var summary = getComplianceSummary();
         gs.info(JSON.stringify(summary));

--- a/packages/opencode/src/bundled-skills/hr-service-delivery/SKILL.md
+++ b/packages/opencode/src/bundled-skills/hr-service-delivery/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_hr_case_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # HR Service Delivery for ServiceNow
@@ -374,7 +374,7 @@ function processTemplate(template, data) {
 | --------------------------------- | ----------------------------- |
 | `snow_query_table`                | Query HR cases and activities |
 | `snow_find_artifact`              | Find HR configurations        |
-| `snow_execute_script_with_output` | Test HR scripts               |
+| `snow_execute_script` | Test HR scripts               |
 | `snow_deploy`                     | Deploy HR widgets             |
 
 ### Example Workflow
@@ -395,7 +395,7 @@ await snow_query_table({
 })
 
 // 3. Create HR case
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var hrCase = new GlideRecord('sn_hr_core_case');
         hrCase.initialize();

--- a/packages/opencode/src/bundled-skills/import-export/SKILL.md
+++ b/packages/opencode/src/bundled-skills/import-export/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_create_import_set
   - snow_create_transform_map
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_query_table
 ---
 
@@ -443,7 +443,7 @@ function bulkDelete(tableName, encodedQuery, maxRecords) {
 | --------------------------------- | ------------------ |
 | `snow_create_import_set`          | Create import sets |
 | `snow_create_transform_map`       | Create transforms  |
-| `snow_execute_script_with_output` | Test import/export |
+| `snow_execute_script` | Test import/export |
 | `snow_query_table`                | Query data         |
 
 ### Example Workflow
@@ -457,7 +457,7 @@ await snow_query_table({
 })
 
 // 2. Export data
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var csv = exportToCSV('incident', 'active=true', 'number,short_description,state');
         gs.info('Exported ' + csv.split('\\n').length + ' rows');

--- a/packages/opencode/src/bundled-skills/incident-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/incident-management/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_query_incidents
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Incident Management for ServiceNow
@@ -437,7 +437,7 @@ function calculateMTTR(startDate, endDate, filters) {
 | --------------------------------- | -------------------------- |
 | `snow_query_incidents`            | Query incident records     |
 | `snow_query_table`                | Advanced incident queries  |
-| `snow_execute_script_with_output` | Test incident scripts      |
+| `snow_execute_script` | Test incident scripts      |
 | `snow_create_business_rule`       | Create incident automation |
 
 ### Example Workflow
@@ -450,7 +450,7 @@ await snow_query_incidents({
 })
 
 // 2. Check incident metrics
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var stats = calculateMTTR(gs.beginningOfThisMonth(), gs.endOfThisMonth(), {});
         gs.info('MTTR: ' + stats.mttr_hours + ' hours');

--- a/packages/opencode/src/bundled-skills/instance-security/SKILL.md
+++ b/packages/opencode/src/bundled-skills/instance-security/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_property_get
   - snow_property_set
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_review_access_control
   - snow_query_table
 ---
@@ -391,7 +391,7 @@ function securityHealthCheck() {
 | Tool                              | Purpose                   |
 | --------------------------------- | ------------------------- |
 | `snow_property_get`               | Check security properties |
-| `snow_execute_script_with_output` | Test security scripts     |
+| `snow_execute_script` | Test security scripts     |
 | `snow_review_access_control`      | Review ACLs               |
 
 ### Example Workflow
@@ -403,7 +403,7 @@ await snow_property_get({
 })
 
 // 2. Run security health check
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var health = securityHealthCheck();
         gs.info(JSON.stringify(health));

--- a/packages/opencode/src/bundled-skills/integration-hub/SKILL.md
+++ b/packages/opencode/src/bundled-skills/integration-hub/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_query_table
   - snow_find_artifact
   - snow_test_rest_connection
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # IntegrationHub for ServiceNow
@@ -364,7 +364,7 @@ function executeWithRetry(fn, maxRetries, delayMs) {
 | `snow_query_table`                | Query spokes and actions |
 | `snow_find_artifact`              | Find integration configs |
 | `snow_test_rest_connection`       | Test connections         |
-| `snow_execute_script_with_output` | Test action scripts      |
+| `snow_execute_script` | Test action scripts      |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/knowledge-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/knowledge-management/SKILL.md
@@ -374,7 +374,7 @@ function updateArticleRating(articleSysId) {
 | `snow_knowledge_search`           | Search knowledge base |
 | `snow_query_table`                | Query kb_knowledge    |
 | `snow_find_artifact`              | Find articles         |
-| `snow_execute_script_with_output` | Test KB scripts       |
+| `snow_execute_script` | Test KB scripts       |
 
 ### Example Workflow
 
@@ -386,7 +386,7 @@ await snow_knowledge_search({
 })
 
 // 2. Create new article
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var article = new GlideRecord('kb_knowledge');
         article.initialize();

--- a/packages/opencode/src/bundled-skills/mid-server/SKILL.md
+++ b/packages/opencode/src/bundled-skills/mid-server/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # MID Server for ServiceNow
@@ -405,7 +405,7 @@ function getMIDServerStatus() {
 | --------------------------------- | ------------------------ |
 | `snow_query_table`                | Query MID and ECC tables |
 | `snow_find_artifact`              | Find probes/sensors      |
-| `snow_execute_script_with_output` | Test MID scripts         |
+| `snow_execute_script` | Test MID scripts         |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/mobile-development/SKILL.md
+++ b/packages/opencode/src/bundled-skills/mobile-development/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
 ---
 
@@ -427,7 +427,7 @@ function findNearbyAssets(latitude, longitude, radiusMeters) {
 | Tool                              | Purpose              |
 | --------------------------------- | -------------------- |
 | `snow_query_table`                | Query mobile configs |
-| `snow_execute_script_with_output` | Test mobile scripts  |
+| `snow_execute_script` | Test mobile scripts  |
 | `snow_find_artifact`              | Find configurations  |
 
 ### Example Workflow

--- a/packages/opencode/src/bundled-skills/notification-events/SKILL.md
+++ b/packages/opencode/src/bundled-skills/notification-events/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_create_event
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Notification Events for ServiceNow
@@ -343,7 +343,7 @@ function getPendingEvents(eventName) {
 | `snow_create_event`               | Queue events              |
 | `snow_query_table`                | Query event queue         |
 | `snow_find_artifact`              | Find event configurations |
-| `snow_execute_script_with_output` | Test event scripts        |
+| `snow_execute_script` | Test event scripts        |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/predictive-intelligence/SKILL.md
+++ b/packages/opencode/src/bundled-skills/predictive-intelligence/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - ml_predict_change_risk
   - ml_detect_anomalies
 ---
@@ -372,7 +372,7 @@ function getPredictionAccuracy(solutionName, days) {
 | Tool                              | Purpose             |
 | --------------------------------- | ------------------- |
 | `snow_query_table`                | Query ML tables     |
-| `snow_execute_script_with_output` | Test predictions    |
+| `snow_execute_script` | Test predictions    |
 | `ml_predict_change_risk`          | Predict change risk |
 | `ml_detect_anomalies`             | Anomaly detection   |
 
@@ -394,7 +394,7 @@ await snow_query_table({
 })
 
 // 3. Test prediction
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = getClassificationPrediction('incident', 'inc_sys_id', 'incident_classifier');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/problem-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/problem-management/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_knowledge_article_create
 ---
 
@@ -498,7 +498,7 @@ function notifyLinkedIncidents(problemSysId, message) {
 | --------------------------------- | ------------------------------- |
 | `snow_query_table`                | Query problems and known errors |
 | `snow_find_artifact`              | Find problem records            |
-| `snow_execute_script_with_output` | Test problem scripts            |
+| `snow_execute_script` | Test problem scripts            |
 | `snow_create_business_rule`       | Create problem automation       |
 
 ### Example Workflow
@@ -519,7 +519,7 @@ await snow_query_table({
 })
 
 // 3. Find recurring incidents for proactive problems
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var patterns = identifyProactiveProblems();
         gs.info('Patterns found: ' + patterns.length);

--- a/packages/opencode/src/bundled-skills/request-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/request-management/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_create_catalog_item
 ---
 
@@ -348,7 +348,7 @@ function getRequestApprovalStatus(requestSysId) {
 | --------------------------------- | ------------------------ |
 | `snow_query_table`                | Query requests and RITMs |
 | `snow_find_artifact`              | Find catalog items       |
-| `snow_execute_script_with_output` | Test request scripts     |
+| `snow_execute_script` | Test request scripts     |
 | `snow_create_catalog_item`        | Create catalog items     |
 
 ### Example Workflow
@@ -362,7 +362,7 @@ await snow_query_table({
 })
 
 // 2. Get request details
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var vars = getRITMVariables('ritm_sys_id');
         gs.info(JSON.stringify(vars));

--- a/packages/opencode/src/bundled-skills/rest-integration/SKILL.md
+++ b/packages/opencode/src/bundled-skills/rest-integration/SKILL.md
@@ -6,7 +6,7 @@ tools:
   - snow_create_rest_message
   - snow_test_rest_connection
   - snow_test_web_service
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # REST Integration Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/scheduled-jobs/SKILL.md
+++ b/packages/opencode/src/bundled-skills/scheduled-jobs/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_schedule_job
   - snow_find_artifact
   - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Scheduled Jobs for ServiceNow
@@ -374,7 +374,7 @@ while (history.next()) {
 | --------------------------------- | ------------------------ |
 | `snow_schedule_job`               | Create scheduled job     |
 | `snow_find_artifact`              | Find existing jobs       |
-| `snow_execute_script_with_output` | Test job script          |
+| `snow_execute_script` | Test job script          |
 | `snow_get_logs`                   | Check job execution logs |
 
 ### Example Workflow
@@ -390,7 +390,7 @@ await snow_schedule_job({
 })
 
 // 2. Test the script
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: "/* test job script */",
 })
 

--- a/packages/opencode/src/bundled-skills/script-include-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/script-include-patterns/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_create_script_include
   - snow_find_artifact
   - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Script Include Patterns for ServiceNow
@@ -325,7 +325,7 @@ MyAppUtils.prototype = {
 | `snow_create_script_include`      | Create new Script Include     |
 | `snow_find_artifact`              | Find existing Script Includes |
 | `snow_edit_artifact`              | Modify Script Include code    |
-| `snow_execute_script_with_output` | Test Script Include           |
+| `snow_execute_script` | Test Script Include           |
 
 ### Example Workflow
 
@@ -339,7 +339,7 @@ await snow_create_script_include({
 })
 
 // 2. Test the Script Include
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var utils = new IncidentUtils();
         var incident = utils.getByNumber('INC0010001');

--- a/packages/opencode/src/bundled-skills/security-operations/SKILL.md
+++ b/packages/opencode/src/bundled-skills/security-operations/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_create_event
 ---
 
@@ -380,7 +380,7 @@ function disableUser(user) {
 | --------------------------------- | ----------------------- |
 | `snow_query_table`                | Query SecOps tables     |
 | `snow_find_artifact`              | Find security configs   |
-| `snow_execute_script_with_output` | Test SecOps scripts     |
+| `snow_execute_script` | Test SecOps scripts     |
 | `snow_create_event`               | Trigger security events |
 
 ### Example Workflow
@@ -401,7 +401,7 @@ await snow_query_table({
 })
 
 // 3. Check threat indicator
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = checkThreatIndicator('suspicious-domain.com', 'domain');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/sla-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/sla-management/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_sla_definition_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # SLA Management for ServiceNow
@@ -365,7 +365,7 @@ gs.info("P1 Response SLA Compliance: " + stats.compliance + "%")
 | --------------------------------- | ---------------------- |
 | `snow_find_artifact`              | Find SLA definitions   |
 | `snow_query_table`                | Query task_sla records |
-| `snow_execute_script_with_output` | Test SLA scripts       |
+| `snow_execute_script` | Test SLA scripts       |
 | `snow_create_business_rule`       | Create SLA triggers    |
 
 ### Example Workflow
@@ -385,7 +385,7 @@ await snow_query_table({
 })
 
 // 3. Check SLA compliance
-await snow_execute_script_with_output({
+await snow_execute_script({
   script:
     'var stats = getSLAComplianceRate("P1 Response", gs.beginningOfThisMonth(), gs.endOfThisMonth()); gs.info(JSON.stringify(stats));',
 })

--- a/packages/opencode/src/bundled-skills/transform-maps/SKILL.md
+++ b/packages/opencode/src/bundled-skills/transform-maps/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_create_transform_map
   - snow_create_import_set
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Transform Maps for ServiceNow

--- a/packages/opencode/src/bundled-skills/ui-builder-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/ui-builder-patterns/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_workspace_create
   - snow_query_table
   - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # UI Builder Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/vendor-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/vendor-management/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
 ---
 
@@ -377,7 +377,7 @@ function getVendorScorecard(vendorSysId) {
 | Tool                              | Purpose             |
 | --------------------------------- | ------------------- |
 | `snow_query_table`                | Query vendor tables |
-| `snow_execute_script_with_output` | Test vendor scripts |
+| `snow_execute_script` | Test vendor scripts |
 | `snow_find_artifact`              | Find configurations |
 
 ### Example Workflow
@@ -391,7 +391,7 @@ await snow_query_table({
 })
 
 // 2. Find expiring contracts
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var expiring = getExpiringContracts(60);
         gs.info(JSON.stringify(expiring));
@@ -399,7 +399,7 @@ await snow_execute_script_with_output({
 })
 
 // 3. Get vendor scorecard
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var scorecard = getVendorScorecard('vendor_sys_id');
         gs.info(JSON.stringify(scorecard));

--- a/packages/opencode/src/bundled-skills/workspace-builder/SKILL.md
+++ b/packages/opencode/src/bundled-skills/workspace-builder/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_find_artifact
   - snow_update_set_create
 ---
@@ -377,7 +377,7 @@ function prepareAppExport(appScope) {
 | Tool                              | Purpose              |
 | --------------------------------- | -------------------- |
 | `snow_query_table`                | Query app components |
-| `snow_execute_script_with_output` | Test app scripts     |
+| `snow_execute_script` | Test app scripts     |
 | `snow_find_artifact`              | Find configurations  |
 | `snow_update_set_create`          | Create update sets   |
 

--- a/packages/opencode/src/servicenow/servicenow-automation-mcp.ts
+++ b/packages/opencode/src/servicenow/servicenow-automation-mcp.ts
@@ -371,7 +371,7 @@ class ServiceNowAutomationMCP {
         {
           name: "snow_schedule_script_with_output",
           description:
-            "⚠️ DEPRECATED - Use snow_schedule_script_job instead. SCHEDULES (not executes directly) a script via scheduled job. May return executed=false. ES5 only!",
+            "⚠️ DEPRECATED - Use snow_execute_script instead. SCHEDULES (not executes directly) a script via scheduled job. May return executed=false. ES5 only!",
           inputSchema: {
             type: "object",
             properties: {
@@ -400,7 +400,7 @@ class ServiceNowAutomationMCP {
         {
           name: "snow_schedule_script_sync",
           description:
-            '⚠️ DEPRECATED - Use snow_schedule_script_job instead. SCHEDULES (not sync executes) a script via scheduled job. The "sync" name is misleading - this still uses async scheduling. ES5 only!',
+            '⚠️ DEPRECATED - Use snow_execute_script instead. SCHEDULES (not sync executes) a script via scheduled job. The "sync" name is misleading - this still uses async scheduling. ES5 only!',
           inputSchema: {
             type: "object",
             properties: {

--- a/packages/opencode/src/servicenow/servicenow-mcp-server.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-server.ts
@@ -220,9 +220,9 @@ class ServiceNowMCPServer {
             },
           },
           {
-            name: "snow_schedule_script_job",
+            name: "snow_execute_script",
             description:
-              "⚠️ SCHEDULES (not executes directly) server-side JavaScript via Scheduled Script Job. Creates sysauto_script + sys_trigger. May return executed=false if scheduler doesn't pick it up - check System Scheduler > Scheduled Jobs.",
+              "Execute server-side JavaScript on ServiceNow. Primary: synchronous execution via Scripted REST API (~1-3s). Fallback: scheduled job if endpoint unavailable. Auto-deploys the executor endpoint on first use. ES5 only (Rhino engine)!",
             inputSchema: {
               type: "object",
               properties: {
@@ -287,7 +287,7 @@ class ServiceNowMCPServer {
           case "snow_create_workflow":
             return await this.handleCreateWorkflow(args)
 
-          case "snow_schedule_script_job":
+          case "snow_execute_script":
             return await this.handleExecuteScript(args)
 
           case "snow_test_connection":

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/README.md
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/README.md
@@ -51,7 +51,7 @@ servicenow-mcp-unified/
 │   │   ├── snow_add_uib_page_element.ts
 │   │   └── index.ts
 │   ├── automation/              # Script execution, jobs
-│   │   ├── snow_schedule_script_job.ts    # Schedule script jobs (NOT direct execution!)
+│   │   ├── snow_execute_script.ts          # Execute server-side JavaScript (sync REST API)
 │   │   ├── snow_schedule_job.ts
 │   │   └── index.ts
 │   ├── advanced/                # Analytics
@@ -112,7 +112,7 @@ Tools are organized by **domain** (functional area), not by original server:
 
 **Purpose:** Script scheduling and job management
 
-- `snow_schedule_script_job` - ⚠️ SCHEDULES scripts (NOT direct execution!) via sysauto_script + sys_trigger
+- `snow_execute_script` - Execute server-side JavaScript (sync REST API, scheduler fallback)
 - `snow_confirm_script_execution` - Confirm scripts requiring approval (also uses scheduling)
 - `snow_schedule_job` - Create scheduled jobs
 - `snow_get_logs` - Access system logs

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/shared/__tests__/stakeholder-write-protection.test.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/shared/__tests__/stakeholder-write-protection.test.ts
@@ -353,15 +353,8 @@ describe("Stakeholder Write Protection - End-to-End", () => {
           inputSchema: { type: "object", properties: {} },
         },
         {
-          name: "snow_execute_script_with_output",
-          description: "Execute script with output",
-          permission: "write",
-          allowedRoles: ["developer", "admin"],
-          inputSchema: { type: "object", properties: {} },
-        },
-        {
-          name: "snow_execute_script_sync",
-          description: "Execute script synchronously",
+          name: "snow_execute_script",
+          description: "Execute server-side JavaScript on ServiceNow",
           permission: "write",
           allowedRoles: ["developer", "admin"],
           inputSchema: { type: "object", properties: {} },

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/index.ts
@@ -34,11 +34,10 @@ export {
   toolDefinition as snow_discover_schedules_def,
   execute as snow_discover_schedules_exec,
 } from "./snow_discover_schedules.js"
-// Scheduled script job tool - schedules scripts via sysauto_script + sys_trigger (does NOT execute directly!)
 export {
-  toolDefinition as snow_schedule_script_job_def,
-  execute as snow_schedule_script_job_exec,
-} from "./snow_schedule_script_job.js"
+  toolDefinition as snow_execute_script_def,
+  execute as snow_execute_script_exec,
+} from "./snow_execute_script.js"
 export { toolDefinition as snow_get_logs_def, execute as snow_get_logs_exec } from "./snow_get_logs.js"
 export {
   toolDefinition as snow_get_email_logs_def,

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_confirm_script_execution.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_confirm_script_execution.ts
@@ -2,7 +2,7 @@
  * snow_confirm_script_execution - Confirm and execute approved script
  *
  * Executes a script after user approval. Only call this after user
- * explicitly approves script execution from snow_schedule_script_job with requireConfirmation=true.
+ * explicitly approves script execution from snow_execute_script with requireConfirmation=true.
  *
  * Uses sysauto_script + sys_trigger approach for reliable execution.
  *
@@ -16,7 +16,7 @@ import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_confirm_script_execution",
   description:
-    "⚡ Confirms and schedules script after user approval (use after snow_schedule_script_job with requireConfirmation=true). Note: Uses same scheduled job approach.",
+    "⚡ Confirms and executes script after user approval (use after snow_execute_script with requireConfirmation=true).",
   // Metadata for tool discovery (not sent to LLM)
   category: "automation",
   subcategory: "script-execution",

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_execute_script.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_execute_script.ts
@@ -1,5 +1,5 @@
 /**
- * snow_schedule_script_job - Execute server-side JavaScript on ServiceNow
+ * snow_execute_script - Execute server-side JavaScript on ServiceNow
  *
  * Primary: synchronous execution via Scripted REST API (~1-3s)
  * Fallback: scheduled job if endpoint unavailable
@@ -87,7 +87,7 @@ const OPERATION_SCRIPT = `(function process(request, response) {
 })(request, response);`
 
 export const toolDefinition: MCPToolDefinition = {
-  name: "snow_schedule_script_job",
+  name: "snow_execute_script",
   description:
     "Execute server-side JavaScript on ServiceNow. Primary: synchronous execution via Scripted REST API (~1-3s). Fallback: scheduled job if endpoint unavailable. Auto-deploys the executor endpoint on first use. ES5 only (Rhino engine)!",
   category: "automation",
@@ -150,7 +150,7 @@ export const toolDefinition: MCPToolDefinition = {
 
 export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
   const script = args.script as string
-  const description = (args.description as string) || "Script scheduled via snow_schedule_script_job"
+  const description = (args.description as string) || "Script executed via snow_execute_script"
   const timeout = (args.timeout as number) || 30000
   const validate = args.validate_es5 !== false
   const confirmation = args.requireConfirmation === true

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_get_script_output.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_get_script_output.ts
@@ -46,7 +46,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
     const client = await getAuthenticatedClient(context)
 
     // Try to find the output in sys_properties
-    // snow_schedule_script_job stores output as: SNOW_FLOW_EXEC_${executionId}
+    // snow_execute_script stores output as: SNOW_FLOW_EXEC_${executionId}
     const outputMarker = `SNOW_FLOW_EXEC_${execution_id}`
 
     const outputResponse = await client.get(
@@ -62,7 +62,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
         await client.delete(`/api/now/table/sys_properties/${property.sys_id}`)
       }
 
-      // Organize output by level (matches snow_schedule_script_job format)
+      // Organize output by level (matches snow_execute_script format)
       const organizedOutput = {
         print: (scriptOutput.output || []).filter((o: any) => o.level === "print").map((o: any) => o.message),
         info: (scriptOutput.output || []).filter((o: any) => o.level === "info").map((o: any) => o.message),

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/integration/snow_rest_message_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/integration/snow_rest_message_manage.ts
@@ -27,7 +27,7 @@ export const toolDefinition: MCPToolDefinition = {
 • Message-level Headers - apply to ALL methods (list_message_headers, create_message_header, delete_message_header)
 • Method-level Headers - apply to specific method (list_method_headers, create_method_header, delete_method_header)
 • Query Parameters (list_parameters, create_parameter, delete_parameter)
-• Testing (test) - generates ES5-compatible test script for snow_schedule_script_job`,
+• Testing (test) - generates ES5-compatible test script for snow_execute_script`,
   // Metadata for tool discovery (not sent to LLM)
   category: "integration",
   subcategory: "rest",
@@ -1448,11 +1448,11 @@ ${paramLines.length > 0 ? "    " + paramLines.join("\n    ") : "    // No parame
         test_params_provided: test_params,
         test_script: testScript,
         usage: {
-          description: "Use snow_schedule_script_job to execute this test script",
-          example: `snow_schedule_script_job({ script: <test_script>, description: 'Test REST: ${restMessageName}' })`,
+          description: "Use snow_execute_script to execute this test script",
+          example: `snow_execute_script({ script: <test_script>, description: 'Test REST: ${restMessageName}' })`,
           manual_test: `In ServiceNow: System Web Services > Outbound > REST Message > ${restMessageName} > ${method.name} > Test`,
         },
-        note: "Direct REST message testing requires ServiceNow script execution. Copy the test_script and run it via snow_schedule_script_job.",
+        note: "Direct REST message testing requires ServiceNow script execution. Copy the test_script and run it via snow_execute_script.",
       },
       { operation: "test_rest_message" },
     )


### PR DESCRIPTION
## Summary
- Renames `snow_schedule_script_job` to `snow_execute_script` across the entire codebase
- The old name was misleading — the tool primarily executes scripts synchronously via Scripted REST API (~1-3s), not via the scheduler
- Also consolidates deprecated tool name references (`snow_execute_script_with_output`, `snow_schedule_script_sync`) to the new unified name

## Changes (48 files)
- **Tool definition**: Renamed file and updated tool name, description
- **MCP server**: Updated registration and case handler
- **Companion tools**: Updated references in `snow_confirm_script_execution`, `snow_get_script_output`, `snow_rest_message_manage`
- **Deprecated server**: Updated deprecation messages to point to new name
- **39 skill files**: Updated all `snow_execute_script_with_output` references to `snow_execute_script`
- **Tests**: Consolidated two deprecated test entries into one
- **README**: Updated tool listing

Closes #77