### PR TITLE
fix(opencode): read MCP HTTP headers from extra.requestInfo

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/call-tool.ts
@@ -17,7 +17,7 @@ import { mcpDebug } from "../../shared/mcp-debug.js"
 import { formatArgsForLogging, isRetryableOperation } from "../shared/handler-helpers.js"
 import { HandlerDeps } from "./types.js"
 
-export const callTool = (deps: HandlerDeps) => async (request: any) => {
+export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any) => {
   const { name, arguments: args } = request.params
 
   // Enhanced logging: show tool name AND key parameters
@@ -27,7 +27,7 @@ export const callTool = (deps: HandlerDeps) => async (request: any) => {
     mcpDebug(`[Server]   Parameters: ${logArgs}`)
   }
 
-  const ctx = await deps.resolveContext(request)
+  const ctx = await deps.resolveContext(request, extra)
   // Fail fast if an HTTP resolver forgets to set tenantId — see list-tools.ts.
   if (ctx.origin === "http" && !ctx.serviceNow.tenantId) {
     throw new Error(

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/list-tools.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/list-tools.ts
@@ -15,8 +15,8 @@ import { mcpDebug } from "../../shared/mcp-debug.js"
 import { MCPToolDefinition } from "../shared/types.js"
 import { HandlerDeps } from "./types.js"
 
-export const listTools = (deps: HandlerDeps) => async (request: any) => {
-  const ctx = await deps.resolveContext(request)
+export const listTools = (deps: HandlerDeps) => async (request: any, extra?: any) => {
+  const ctx = await deps.resolveContext(request, extra)
   // Fail fast if an HTTP resolver forgets to set tenantId — falling back
   // to the "stdio" sentinel under HTTP traffic would silently share
   // ToolSessionStore state across tenants.

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/types.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/types.ts
@@ -11,11 +11,16 @@ import { RequestContext } from "../shared/types.js"
  * - Stdio transport returns a closure that produces a context with static
  *   ServiceNow credentials (loaded once at startup) plus per-request session
  *   ID derived from env vars / ToolSearch session file / JWT header.
- * - HTTP transport parses the JWT from `Authorization`, looks up the tenant
- *   instance in the portal DB, decrypts credentials via KMS, and returns a
- *   fully-populated context with `origin: "http"`.
+ * - HTTP transport reads the inbound `Authorization` header from
+ *   `extra.requestInfo.headers` (populated by the MCP SDK's web-standard
+ *   streamable HTTP transport) and forwards it to a resolver endpoint that
+ *   verifies the JWT, looks up the tenant, and decrypts credentials.
+ *
+ * `extra` is the `RequestHandlerExtra` from the MCP SDK; its `requestInfo`
+ * field is the only reliable place the HTTP headers live. The JSON-RPC
+ * `request` param never carries them. stdio transports pass `undefined`.
  */
-export type ContextResolver = (request: any) => Promise<RequestContext>
+export type ContextResolver = (request: any, extra?: any) => Promise<RequestContext>
 
 /**
  * Dependencies passed to every MCP request handler.

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/__tests__/http-resolver.test.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/__tests__/http-resolver.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `createHttpResolver` — contract with the MCP SDK.
+ *
+ * The SDK's web-standard streamable HTTP transport copies HTTP headers onto
+ * `extra.requestInfo.headers`, not onto the JSON-RPC `request` object. The
+ * resolver used to read from `request.headers` and ended up forwarding an
+ * empty `authorization` to the upstream endpoint — portal then returned 400
+ * "missing authorization in body" and the client silently fell back to the
+ * direct catalog, so the HTTP transport looked "up" while actually being
+ * bypassed entirely. These tests guard against that regression.
+ *
+ * We spin up a real HTTP echo server (Bun or Node) instead of mocking `fetch`
+ * so we exercise the actual network path end-to-end.
+ */
+
+import { describe, test, expect } from "@jest/globals"
+import * as http from "http"
+import { AddressInfo } from "net"
+import { createHttpResolver } from "../http-resolver.js"
+
+type EchoedBody = { authorization: string }
+
+const startEchoServer = async (): Promise<{
+  url: string
+  calls: EchoedBody[]
+  internalAuthHeaders: string[]
+  stop: () => Promise<void>
+}> => {
+  const calls: EchoedBody[] = []
+  const internalAuthHeaders: string[] = []
+  const server = http.createServer((req, res) => {
+    internalAuthHeaders.push(String(req.headers["x-internal-auth"] ?? ""))
+    const chunks: Buffer[] = []
+    req.on("data", (c) => chunks.push(Buffer.from(c)))
+    req.on("end", () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf-8"))
+      calls.push(body)
+      // Echo the authorization back wrapped as a minimal RequestContext so the
+      // resolver's downstream assertion (json parsing) doesn't break.
+      res.setHeader("content-type", "application/json")
+      res.end(
+        JSON.stringify({
+          origin: "http",
+          sessionId: "test",
+          jwtPayload: null,
+          serviceNow: { tenantId: "c:1", instanceUrl: "https://x", clientId: "", clientSecret: "" },
+          echoed: body.authorization,
+        }),
+      )
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    url: `http://127.0.0.1:${port}/resolve`,
+    calls,
+    internalAuthHeaders,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      }),
+  }
+}
+
+describe("createHttpResolver", () => {
+  test("forwards authorization from extra.requestInfo.headers", async () => {
+    const srv = await startEchoServer()
+    try {
+      const resolve = createHttpResolver({ url: srv.url, internalToken: "shh" })
+      const result = await resolve(
+        {},
+        { requestInfo: { headers: { authorization: "Bearer abc.def.ghi" } } },
+      )
+
+      expect(srv.calls).toHaveLength(1)
+      expect(srv.calls[0]!.authorization).toBe("Bearer abc.def.ghi")
+      expect(srv.internalAuthHeaders[0]).toBe("shh")
+      expect((result as any).echoed).toBe("Bearer abc.def.ghi")
+    } finally {
+      await srv.stop()
+    }
+  })
+
+  test("falls back to request.headers for legacy callers", async () => {
+    const srv = await startEchoServer()
+    try {
+      const resolve = createHttpResolver({ url: srv.url, internalToken: "shh" })
+      await resolve({ headers: { authorization: "Bearer legacy" } })
+
+      expect(srv.calls).toHaveLength(1)
+      expect(srv.calls[0]!.authorization).toBe("Bearer legacy")
+    } finally {
+      await srv.stop()
+    }
+  })
+
+  test("forwards empty string when neither source has authorization", async () => {
+    const srv = await startEchoServer()
+    try {
+      const resolve = createHttpResolver({ url: srv.url, internalToken: "shh" })
+      // The resolver forwards the empty token; it's the downstream endpoint
+      // (the portal's /api/internal/mcp-resolve) that returns 400. We only
+      // care here that we do not crash and do not silently synthesize a token.
+      await resolve({}, { requestInfo: { headers: {} } })
+      expect(srv.calls[0]!.authorization).toBe("")
+    } finally {
+      await srv.stop()
+    }
+  })
+
+  test("tolerates Authorization header with uppercase A", async () => {
+    const srv = await startEchoServer()
+    try {
+      const resolve = createHttpResolver({ url: srv.url, internalToken: "shh" })
+      // The MCP SDK lowercases, but hand-built callers (tests, alternative
+      // harnesses) may still pass the canonical-case form.
+      await resolve({}, { requestInfo: { headers: { Authorization: "Bearer upper" } } })
+      expect(srv.calls[0]!.authorization).toBe("Bearer upper")
+    } finally {
+      await srv.stop()
+    }
+  })
+
+  test("throws when endpoint returns non-2xx", async () => {
+    // A server that always responds 400 — we expect the resolver to surface it.
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 400
+      res.end("missing authorization in body")
+    })
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const port = (server.address() as AddressInfo).port
+
+    try {
+      const resolve = createHttpResolver({
+        url: `http://127.0.0.1:${port}/resolve`,
+        internalToken: "shh",
+      })
+      await expect(
+        resolve({}, { requestInfo: { headers: { authorization: "Bearer x" } } }),
+      ).rejects.toThrow(/mcp-resolver endpoint returned 400/)
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+})

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/http-resolver.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/http-resolver.ts
@@ -49,12 +49,22 @@ export interface HttpResolverOptions {
  * Build a `ContextResolver` that forwards each inbound request to
  * `opts.url`. The returned function is the exact type `createHttpApp`
  * expects for its `resolveContext` dependency.
+ *
+ * HTTP headers live on `extra.requestInfo.headers` — the MCP SDK's
+ * web-standard streamable HTTP transport copies them off the Fetch API
+ * Request there before invoking the handler. The JSON-RPC `request`
+ * param carries only the protocol message body and never HTTP metadata,
+ * so we have to consult `extra` (and only fall back to `request.headers`
+ * to stay compatible with older call sites that pass headers inline).
  */
 export const createHttpResolver = (opts: HttpResolverOptions): ContextResolver => {
   const timeoutMs = opts.timeoutMs ?? 5000
 
-  return async (request: any) => {
-    const headers = (request as any)?.headers ?? {}
+  return async (request: any, extra?: any) => {
+    // Headers are always lowercased by the SDK (Fetch API Headers iterator),
+    // but keep the Authorization/AUTHORIZATION fallbacks to tolerate callers
+    // that build `extra` by hand in tests.
+    const headers = extra?.requestInfo?.headers ?? (request as any)?.headers ?? {}
     // Forward the caller's Bearer token verbatim — the resolver endpoint
     // is the thing that knows how to verify it.
     const authorization =

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/stdio.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/transports/stdio.ts
@@ -48,7 +48,10 @@ export const startStdio = async (): Promise<StdioHandle> => {
   // after the server is already created.
   let context: ServiceNowContext = loadContext()
 
-  const resolveContext = async (request: any): Promise<RequestContext> => {
+  const resolveContext = async (request: any, _extra?: any): Promise<RequestContext> => {
+    // stdio has no HTTP headers; `request.headers` is undefined here. We keep
+    // the lookup for symmetry with the HTTP resolver and because some test
+    // harnesses pass a hand-crafted request with inline headers.
     const headers = (request as any)?.headers
     const jwtPayload = extractJWTPayload(headers)
     const sessionId =


### PR DESCRIPTION
Fixes groeimetai/snow-flow-enterprise#35.

## Summary

- `createHttpResolver` now reads the inbound `Authorization` header from `extra.requestInfo.headers` (where the MCP SDK actually puts HTTP headers) instead of `request.headers` (which is always undefined on the JSON-RPC request).
- Handler signatures for `listTools` and `callTool` now propagate the SDK's `extra` argument to `resolveContext`.
- New integration tests under `transports/__tests__/http-resolver.test.ts` spin up a real local HTTP server to verify the header plumbing end-to-end.

## Why

With `USE_HTTP_MCP=true` enabled on Hetzner, the mcp-http container's callout to the portal resolver was sending `{ "authorization": "" }` — portal responded 400 "missing authorization in body" and the client silently fell back to the direct catalog. HTTP MCP transport looked healthy while actually being bypassed.

## Test plan

- [x] `bun test src/servicenow/servicenow-mcp-unified/transports/__tests__/http-resolver.test.ts` — 5/5 pass
- [x] `bun typecheck` — clean
- [x] Existing unified MCP tests still pass (one pre-existing unrelated failure in `stakeholder-write-protection.test.ts` is on main already)
- [ ] Verified on Hetzner once the new mcp-http image is deployed (follow-up)