### PR TITLE
fix(opencode): skip deferred-check over HTTP transport

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/handlers/call-tool.ts
@@ -80,15 +80,26 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     // Check if tool is deferred and needs to be enabled first.
     // Pass tenantId so the ToolSessionStore scopes its lookup correctly
     // (stdio uses "stdio"; HTTP uses the tenant's customerId).
+    //
+    // HTTP callers (the portal chat) manage their own tool-enablement
+    // state on the client side — they decide which tools to expose to
+    // the LLM and trust the LLM's choice. The server-side deferred
+    // check is a token-optimization for stdio (smaller catalog = fewer
+    // tokens per request) and would otherwise require the caller to
+    // duplicate enablement state over HTTP, which they currently don't.
+    // So we skip the check on HTTP and let permission/feature gates
+    // below do the real access control.
     const tenantId = context.tenantId ?? "stdio"
-    const canExecute = await ToolSearch.canExecuteTool(sessionId, name, tenantId)
-    if (!canExecute) {
-      const toolStatus = await ToolSearch.getToolStatus(sessionId, name, tenantId)
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `Tool "${name}" is ${toolStatus} and must be enabled first. ` +
-          `Use tool_search({query: "${name.replace("snow_", "")}"}) to enable it.`,
-      )
+    if (ctx.origin !== "http") {
+      const canExecute = await ToolSearch.canExecuteTool(sessionId, name, tenantId)
+      if (!canExecute) {
+        const toolStatus = await ToolSearch.getToolStatus(sessionId, name, tenantId)
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Tool "${name}" is ${toolStatus} and must be enabled first. ` +
+            `Use tool_search({query: "${name.replace("snow_", "")}"}) to enable it.`,
+        )
+      }
     }
 
     // Phase 2: Permission validation before execution


### PR DESCRIPTION
Fixes portal chat failing with \`Tool "snow_query_table" is [DEFERRED] and must be enabled first\` right after a successful \`tool_search\`.

## Root cause

- Portal intercepts \`tool_search\` locally, enables tools in its **own** in-memory store, adds to the LLM's tools array.
- LLM then calls \`snow_query_table\` — portal forwards to mcp-http.
- mcp-http has its own \`ToolSessionStore\`, which never saw the enable call, so the deferred-check rejects.

## Fix

\`call-tool.ts\` skips the deferred-check when \`ctx.origin === "http"\`. The HTTP caller manages enablement state client-side; permission + feature gates below still run. stdio unchanged.

## Why not \"make the portal forward tool_search\"?

The portal's \`tool_search\` covers multiple providers (ServiceNow + Jira + Confluence + …), not just the snow-flow-ts catalog. Forwarding to mcp-http would only handle the SN subset and complicate the merge. Cleaner to let mcp-http trust HTTP callers and keep lazy-loading as a stdio-only token optimisation.

## Test plan

- [x] \`bun typecheck\` clean
- [x] 53/54 tests pass (the one failure is pre-existing on main, unrelated)
- [ ] Manual: portal → \`tool_search\` → \`snow_query_table\` roundtrips without the 32600 error