### PR TITLE
fix(servicenow): resolve current user via gs.getUserID() in flow lock

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -556,16 +556,50 @@ async function verifyFlowState(
  */
 async function getCurrentUserSysId(client: any): Promise<string> {
   if (client._cachedUserSysId) return client._cachedUserSysId
+  // Encoded `javascript:` queries are evaluated server-side against the
+  // current session, so this returns the *authenticated* caller's sys_id.
+  // The previous "limit 1, no filter" lookup grabbed whatever happened to
+  // be the first row in `sys_user` — usually a demo data user on dev
+  // instances — which is what broke the Flow Designer safe-edit lock
+  // chain in issue #101 (the lock was created for the wrong user, and
+  // every subsequent GraphQL trigger/action call was rejected). Same
+  // pattern as snow_session_context and snow_impersonate_user.
   try {
     var resp = await client.get("/api/now/table/sys_user", {
-      params: { sysparm_limit: 1, sysparm_fields: "sys_id" },
+      params: {
+        sysparm_query: "sys_id=javascript:gs.getUserID()",
+        sysparm_limit: 1,
+        sysparm_fields: "sys_id",
+      },
     })
     var id = resp.data?.result?.[0]?.sys_id || ""
-    if (id) client._cachedUserSysId = id
-    return id
+    if (id) {
+      client._cachedUserSysId = id
+      return id
+    }
+  } catch (_) {
+    // Fall through to the user_name fallback.
+  }
+  // Fallback for hardened instances that strip `sys_id=javascript:` from
+  // queries: the username variant tends to be left intact because it's
+  // the workhorse for permission filters across the platform.
+  try {
+    var resp = await client.get("/api/now/table/sys_user", {
+      params: {
+        sysparm_query: "user_name=javascript:gs.getUserName()",
+        sysparm_limit: 1,
+        sysparm_fields: "sys_id",
+      },
+    })
+    var id = resp.data?.result?.[0]?.sys_id || ""
+    if (id) {
+      client._cachedUserSysId = id
+      return id
+    }
   } catch (_) {
     return ""
   }
+  return ""
 }
 
 /**


### PR DESCRIPTION
Fixes #101.

`getCurrentUserSysId` in `snow_manage_flow.ts` was doing `GET /api/now/table/sys_user?sysparm_limit=1` — which returns whichever row happens to come first, not the authenticated caller. On instances with demo data that's an unrelated user, so the patch step in `acquireFlowEditingLock` set the safe-edit lock owner to that demo user, and every follow-up GraphQL `add_trigger` / `add_action` call was rejected.

Switched to `sys_id=javascript:gs.getUserID()` — the same pattern `snow_session_context` and `snow_impersonate_user` already use elsewhere in this codebase. Added a `user_name=javascript:gs.getUserName()` fallback for hardened instances that strip the first form. Cached-result behaviour is unchanged.

## Test plan

- [ ] On a dev instance with demo data, OAuth as a non-default service account
- [ ] Call `snow_manage_flow` with `action: create`
- [ ] Verify `diagnostics.processflow_lock.debug.user_sys_id` matches the OAuth user, not a demo user
- [ ] Add a trigger via `add_trigger` and confirm no "does not have safe edit record" error