### PR TITLE
feat(opencode): add 5 Tier 1 unified tools (PA, source control, jobs, KMS, on-call)

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/devops/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/devops/index.ts
@@ -18,3 +18,7 @@ export {
   toolDefinition as snow_velocity_tracking_def,
   execute as snow_velocity_tracking_exec,
 } from "./snow_velocity_tracking.js"
+export {
+  toolDefinition as snow_source_control_def,
+  execute as snow_source_control_exec,
+} from "./snow_source_control.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/devops/snow_source_control.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/devops/snow_source_control.ts
@@ -1,0 +1,473 @@
+/**
+ * snow_source_control - Bridge to the ServiceNow Studio Source Control plugin
+ *
+ * Wraps the platform's git-style Source Control operations so agents can
+ * manage branches, status, commits, and stashes against a ServiceNow
+ * application's linked repository from inside an MCP session.
+ *
+ * The Source Control REST surface (`/api/sn_source_control/...`) is not
+ * uniformly documented across releases — every action below is built from
+ * the documented Studio UI semantics and marked with a TODO where the
+ * exact endpoint or response shape needs verification against a live
+ * instance with the Source Control plugin enabled.
+ *
+ * Companion to snow_artifact_manage (which writes artifacts) and the
+ * update-set tooling (which is the platform-native alternative to source
+ * control for change tracking).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_source_control",
+  description: `Unified tool for the ServiceNow Studio Source Control plugin. Bridges git-style operations against an application's linked repository (status, push, pull, branch, commit, diff, stash) through the platform's Source Control REST endpoints under /api/sn_source_control.
+
+Actions:
+- status — show working-copy status (changed/added/deleted records) for an application
+- push — push local commits to the remote tracking branch
+- pull — pull and apply remote changes onto the working copy
+- branch — list, create, switch, or delete branches on the application's repository
+- commit — commit the working copy with a message
+- diff — show the diff for a specific record or for the whole working copy
+- stash — list, create, apply, or drop stashes against the working copy
+
+Use when: the agent needs to interact with a scoped application that is linked to a git repository (Studio Source Control) and the user wants git-equivalent operations from within the platform. Prefer update sets for environments that do not use source control.
+
+Returns: action-specific result envelopes. For status/diff: per-record change rows. For push/pull/commit: operation summary. For branch/stash: the resulting branch or stash record. All paths are best-effort against published Source Control plugin docs and require live-instance verification before relying on them in production.`,
+  category: "devops",
+  subcategory: "devops",
+  use_cases: ["devops", "source-control", "git", "branching", "studio"],
+  complexity: "advanced",
+  frequency: "low",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Source-control action to perform",
+        enum: ["status", "push", "pull", "branch", "commit", "diff", "stash"],
+      },
+      app_sys_id: {
+        type: "string",
+        description: "sys_id of the scoped application (sys_app) whose repository is targeted",
+      },
+      app_scope: {
+        type: "string",
+        description: "Alternative to app_sys_id: scope name (e.g. x_company_module). The tool will resolve it to a sys_app sys_id.",
+      },
+      // BRANCH parameters
+      branch_action: {
+        type: "string",
+        description: "[branch] Sub-action",
+        enum: ["list", "create", "switch", "delete"],
+      },
+      branch_name: {
+        type: "string",
+        description: "[branch] Branch name (required for create/switch/delete)",
+      },
+      from_branch: {
+        type: "string",
+        description: "[branch action=create] Source branch to branch off (defaults to current)",
+      },
+      // COMMIT parameters
+      commit_message: {
+        type: "string",
+        description: "[commit] Commit message",
+      },
+      // PUSH / PULL parameters
+      remote_branch: {
+        type: "string",
+        description: "[push/pull] Remote branch to push to / pull from (defaults to tracking branch)",
+      },
+      // DIFF parameters
+      record_sys_id: {
+        type: "string",
+        description: "[diff] Specific record sys_id to diff (omit for working-copy-wide diff)",
+      },
+      // STASH parameters
+      stash_action: {
+        type: "string",
+        description: "[stash] Sub-action",
+        enum: ["list", "create", "apply", "drop"],
+      },
+      stash_name: {
+        type: "string",
+        description: "[stash] Stash name (required for create/apply/drop)",
+      },
+      stash_message: {
+        type: "string",
+        description: "[stash action=create] Optional stash description",
+      },
+      // Common
+      credentials_alias: {
+        type: "string",
+        description: "Alias for stored repository credentials (sys_repo_credential), if remote auth is required",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "status":
+        return await executeStatus(args, context)
+      case "push":
+        return await executePush(args, context)
+      case "pull":
+        return await executePull(args, context)
+      case "branch":
+        return await executeBranch(args, context)
+      case "commit":
+        return await executeCommit(args, context)
+      case "diff":
+        return await executeDiff(args, context)
+      case "stash":
+        return await executeStash(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: status, push, pull, branch, commit, diff, stash`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `Source control ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function resolveAppSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const app_sys_id = args.app_sys_id as string | undefined
+  if (app_sys_id) return app_sys_id
+
+  const app_scope = args.app_scope as string | undefined
+  if (!app_scope) {
+    throw new SnowFlowError(
+      ErrorType.VALIDATION_ERROR,
+      "app_sys_id or app_scope is required to identify the target application",
+    )
+  }
+
+  const response = await client.get("/api/now/table/sys_app", {
+    params: {
+      sysparm_query: `scope=${app_scope}^ORname=${app_scope}`,
+      sysparm_limit: 1,
+      sysparm_fields: "sys_id,name,scope",
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  if (results.length === 0) {
+    throw new SnowFlowError(ErrorType.NOT_FOUND, `Application with scope/name '${app_scope}' not found`)
+  }
+  return results[0].sys_id as string
+}
+
+// ==================== STATUS ====================
+
+async function executeStatus(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  // TODO: verify against live instance — best-effort from docs.
+  // The Studio UI invokes a scripted endpoint like /api/sn_source_control/status?app=<sys_id>.
+  // We try that path first; on 404 we fall back to the documented sys_repo_status table
+  // (some releases expose status as records on sys_repo_status rather than via REST).
+  let working: unknown
+  try {
+    const response = await client.get(`/api/sn_source_control/status`, {
+      params: { app: appSysId },
+    })
+    working = response.data.result ?? response.data
+  } catch (e: unknown) {
+    // TODO: verify sys_repo_status table name on a live instance
+    const fallback = await client.get("/api/now/table/sys_repo_status", {
+      params: { sysparm_query: `app=${appSysId}`, sysparm_limit: 500 },
+    })
+    working = fallback.data.result
+  }
+
+  return createSuccessResult({
+    action: "status",
+    app_sys_id: appSysId,
+    working_copy: working,
+    note: "Source Control plugin must be installed and the application must be linked to a repository.",
+  })
+}
+
+// ==================== PUSH ====================
+
+async function executePush(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const remote_branch = args.remote_branch as string | undefined
+  const credentials_alias = args.credentials_alias as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  // TODO: verify against live instance — best-effort from docs.
+  const payload: Record<string, unknown> = { app: appSysId }
+  if (remote_branch) payload.remote_branch = remote_branch
+  if (credentials_alias) payload.credentials = credentials_alias
+
+  const response = await client.post(`/api/sn_source_control/push`, payload)
+
+  return createSuccessResult({
+    action: "push",
+    app_sys_id: appSysId,
+    remote_branch: remote_branch || "(tracking branch)",
+    result: response.data.result ?? response.data,
+  })
+}
+
+// ==================== PULL ====================
+
+async function executePull(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const remote_branch = args.remote_branch as string | undefined
+  const credentials_alias = args.credentials_alias as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  // TODO: verify against live instance — best-effort from docs.
+  const payload: Record<string, unknown> = { app: appSysId }
+  if (remote_branch) payload.remote_branch = remote_branch
+  if (credentials_alias) payload.credentials = credentials_alias
+
+  const response = await client.post(`/api/sn_source_control/pull`, payload)
+
+  return createSuccessResult({
+    action: "pull",
+    app_sys_id: appSysId,
+    remote_branch: remote_branch || "(tracking branch)",
+    result: response.data.result ?? response.data,
+  })
+}
+
+// ==================== BRANCH ====================
+
+async function executeBranch(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const branch_action = (args.branch_action as string) || "list"
+  const branch_name = args.branch_name as string | undefined
+  const from_branch = args.from_branch as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  if (branch_action !== "list" && !branch_name) {
+    return createErrorResult(`branch_name is required for branch_action='${branch_action}'`)
+  }
+
+  switch (branch_action) {
+    case "list": {
+      // TODO: verify against live instance — best-effort from docs.
+      // The platform exposes branches either through a REST helper or the sys_repo_branch table.
+      try {
+        const response = await client.get(`/api/sn_source_control/branches`, { params: { app: appSysId } })
+        return createSuccessResult({
+          action: "branch",
+          branch_action,
+          app_sys_id: appSysId,
+          branches: response.data.result ?? response.data,
+        })
+      } catch {
+        // TODO: verify sys_repo_branch table name on a live instance
+        const fallback = await client.get("/api/now/table/sys_repo_branch", {
+          params: { sysparm_query: `app=${appSysId}`, sysparm_limit: 200 },
+        })
+        return createSuccessResult({
+          action: "branch",
+          branch_action,
+          app_sys_id: appSysId,
+          branches: fallback.data.result,
+        })
+      }
+    }
+    case "create": {
+      const payload: Record<string, unknown> = { app: appSysId, name: branch_name }
+      if (from_branch) payload.from = from_branch
+      const response = await client.post(`/api/sn_source_control/branch`, payload)
+      return createSuccessResult({
+        action: "branch",
+        branch_action,
+        app_sys_id: appSysId,
+        branch: response.data.result ?? response.data,
+      })
+    }
+    case "switch": {
+      const response = await client.post(`/api/sn_source_control/checkout`, {
+        app: appSysId,
+        branch: branch_name,
+      })
+      return createSuccessResult({
+        action: "branch",
+        branch_action,
+        app_sys_id: appSysId,
+        current_branch: branch_name,
+        result: response.data.result ?? response.data,
+      })
+    }
+    case "delete": {
+      const response = await client.post(`/api/sn_source_control/branch/delete`, {
+        app: appSysId,
+        branch: branch_name,
+      })
+      return createSuccessResult({
+        action: "branch",
+        branch_action,
+        app_sys_id: appSysId,
+        deleted_branch: branch_name,
+        result: response.data.result ?? response.data,
+      })
+    }
+    default:
+      return createErrorResult(`Unknown branch_action: ${branch_action}`)
+  }
+}
+
+// ==================== COMMIT ====================
+
+async function executeCommit(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const commit_message = args.commit_message as string | undefined
+
+  if (!commit_message) {
+    return createErrorResult("commit_message is required for commit action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  // TODO: verify against live instance — best-effort from docs.
+  const response = await client.post(`/api/sn_source_control/commit`, {
+    app: appSysId,
+    message: commit_message,
+  })
+
+  return createSuccessResult({
+    action: "commit",
+    app_sys_id: appSysId,
+    message: commit_message,
+    result: response.data.result ?? response.data,
+  })
+}
+
+// ==================== DIFF ====================
+
+async function executeDiff(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const record_sys_id = args.record_sys_id as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  // TODO: verify against live instance — best-effort from docs.
+  const params: Record<string, unknown> = { app: appSysId }
+  if (record_sys_id) params.record = record_sys_id
+
+  const response = await client.get(`/api/sn_source_control/diff`, { params })
+
+  return createSuccessResult({
+    action: "diff",
+    app_sys_id: appSysId,
+    record_sys_id: record_sys_id || null,
+    diff: response.data.result ?? response.data,
+  })
+}
+
+// ==================== STASH ====================
+
+async function executeStash(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const stash_action = (args.stash_action as string) || "list"
+  const stash_name = args.stash_name as string | undefined
+  const stash_message = args.stash_message as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+  const appSysId = await resolveAppSysId(client, args)
+
+  if (stash_action !== "list" && !stash_name) {
+    return createErrorResult(`stash_name is required for stash_action='${stash_action}'`)
+  }
+
+  switch (stash_action) {
+    case "list": {
+      // TODO: verify against live instance — best-effort from docs.
+      try {
+        const response = await client.get(`/api/sn_source_control/stashes`, { params: { app: appSysId } })
+        return createSuccessResult({
+          action: "stash",
+          stash_action,
+          app_sys_id: appSysId,
+          stashes: response.data.result ?? response.data,
+        })
+      } catch {
+        // TODO: verify sys_repo_stash table name on a live instance
+        const fallback = await client.get("/api/now/table/sys_repo_stash", {
+          params: { sysparm_query: `app=${appSysId}`, sysparm_limit: 200 },
+        })
+        return createSuccessResult({
+          action: "stash",
+          stash_action,
+          app_sys_id: appSysId,
+          stashes: fallback.data.result,
+        })
+      }
+    }
+    case "create": {
+      const payload: Record<string, unknown> = { app: appSysId, name: stash_name }
+      if (stash_message) payload.message = stash_message
+      const response = await client.post(`/api/sn_source_control/stash`, payload)
+      return createSuccessResult({
+        action: "stash",
+        stash_action,
+        app_sys_id: appSysId,
+        stash: response.data.result ?? response.data,
+      })
+    }
+    case "apply": {
+      const response = await client.post(`/api/sn_source_control/stash/apply`, {
+        app: appSysId,
+        name: stash_name,
+      })
+      return createSuccessResult({
+        action: "stash",
+        stash_action,
+        app_sys_id: appSysId,
+        applied_stash: stash_name,
+        result: response.data.result ?? response.data,
+      })
+    }
+    case "drop": {
+      const response = await client.post(`/api/sn_source_control/stash/drop`, {
+        app: appSysId,
+        name: stash_name,
+      })
+      return createSuccessResult({
+        action: "stash",
+        stash_action,
+        app_sys_id: appSysId,
+        dropped_stash: stash_name,
+        result: response.data.result ?? response.data,
+      })
+    }
+    default:
+      return createErrorResult(`Unknown stash_action: ${stash_action}`)
+  }
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/index.ts
@@ -15,3 +15,9 @@ export { toolDefinition as snow_pa_discover_def, execute as snow_pa_discover_exe
 
 // Merged Tools (v8.2.0 Phase 3)
 export { toolDefinition as snow_pa_operate_def, execute as snow_pa_operate_exec } from "./snow_pa_operate.js"
+
+// Tier 1 foundation tools
+export {
+  toolDefinition as snow_pa_indicator_manage_def,
+  execute as snow_pa_indicator_manage_exec,
+} from "./snow_pa_indicator_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/snow_pa_indicator_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/snow_pa_indicator_manage.ts
@@ -1,0 +1,611 @@
+/**
+ * snow_pa_indicator_manage - Unified Performance Analytics indicator management
+ *
+ * Manages the lifecycle of Performance Analytics indicator definitions
+ * (pa_indicators) and their associated breakdowns (pa_breakdowns). Indicator
+ * widgets (pa_widgets) and sampled scores (pa_scores) are referenced for read
+ * context but are not authored directly by this tool — snow_pa_create handles
+ * widget authoring, and scores are computed by the platform.
+ *
+ * Companion to snow_pa_create (which creates the broader PA artifact family)
+ * and snow_pa_operate (which collects and inspects PA data).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_pa_indicator_manage",
+  description: `Unified tool for ServiceNow Performance Analytics indicator definitions and their dimensional breakdowns. Wraps the pa_indicators, pa_breakdowns, pa_widgets, and pa_scores tables on the platform.
+
+Actions:
+- list — list indicators, optionally filtered by facts_table or active flag
+- get — retrieve a single indicator by sys_id or name (includes related widget and breakdown counts)
+- create — create a new indicator (name, facts_table, aggregate, field required)
+- update — patch indicator fields
+- delete — remove an indicator (and optionally its dependent breakdowns)
+- add_breakdown — attach a dimensional breakdown to an indicator (writes pa_breakdowns)
+- list_breakdowns — list breakdowns for a given indicator or globally
+
+Use when: the agent needs to manage KPI/indicator definitions, attach dimensional slicers (assignment_group, priority, location, etc.) to existing indicators, or audit which indicators a facts table feeds.
+
+Returns: indicator records with sys_id, name, facts_table, aggregate, field, frequency, unit, and active flag. For breakdowns, returns sys_id, name, table, field, and matrix_source. Companion tools: snow_pa_create for full PA artifact creation (widgets, thresholds, scheduled reports) and snow_pa_operate for collecting and querying PA scores.`,
+  category: "performance-analytics",
+  subcategory: "performance-analytics",
+  use_cases: ["performance-analytics", "kpi", "indicators", "breakdowns", "reporting"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "create", "update", "delete", "add_breakdown", "list_breakdowns"],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/update/delete/add_breakdown/list_breakdowns] Indicator sys_id",
+      },
+      name: {
+        type: "string",
+        description: "[get/create/update] Indicator name (used as identifier when sys_id is absent)",
+      },
+      // CREATE/UPDATE fields
+      label: {
+        type: "string",
+        description: "[create/update] Indicator display label (defaults to name on create)",
+      },
+      description: {
+        type: "string",
+        description: "[create/update] Indicator description",
+      },
+      facts_table: {
+        type: "string",
+        description: "[create/update] Source/facts table the indicator measures (e.g. incident, sc_task)",
+      },
+      aggregate: {
+        type: "string",
+        description: "[create/update] Aggregation function",
+        enum: ["COUNT", "SUM", "AVG", "MIN", "MAX", "COUNT_DISTINCT"],
+      },
+      field: {
+        type: "string",
+        description: "[create/update] Field on facts_table to aggregate (omit for COUNT)",
+      },
+      conditions: {
+        type: "string",
+        description: "[create/update] Encoded query that filters the facts_table rows",
+      },
+      unit: {
+        type: "string",
+        description: "[create/update] Unit of measurement (count, hours, percent, etc.)",
+      },
+      frequency: {
+        type: "string",
+        description: "[create/update] Collection frequency",
+        enum: ["daily", "weekly", "monthly", "quarterly", "yearly", "hourly"],
+      },
+      direction: {
+        type: "string",
+        description: "[create/update] Whether higher or lower is better",
+        enum: ["maximize", "minimize"],
+      },
+      precision: {
+        type: "number",
+        description: "[create/update] Decimal precision",
+      },
+      active: {
+        type: "boolean",
+        description: "[create/update] Whether the indicator is active",
+        default: true,
+      },
+      // BREAKDOWN fields (for add_breakdown)
+      breakdown_name: {
+        type: "string",
+        description: "[add_breakdown] Breakdown name",
+      },
+      breakdown_table: {
+        type: "string",
+        description: "[add_breakdown] Table on which the breakdown is evaluated",
+      },
+      breakdown_field: {
+        type: "string",
+        description: "[add_breakdown] Field used to group the indicator (e.g. assignment_group, priority)",
+      },
+      related_field: {
+        type: "string",
+        description: "[add_breakdown] Related field path for cross-table breakdowns",
+      },
+      matrix_source: {
+        type: "boolean",
+        description: "[add_breakdown] Whether this is a matrix breakdown",
+        default: false,
+      },
+      // DELETE
+      cascade: {
+        type: "boolean",
+        description: "[delete] Also remove dependent pa_breakdowns rows that reference this indicator",
+        default: false,
+      },
+      // LIST/LIST_BREAKDOWNS
+      active_only: {
+        type: "boolean",
+        description: "[list/list_breakdowns] Only return active records",
+        default: false,
+      },
+      limit: {
+        type: "number",
+        description: "[list/list_breakdowns] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_breakdowns] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create":
+        return await executeCreate(args, context)
+      case "update":
+        return await executeUpdate(args, context)
+      case "delete":
+        return await executeDelete(args, context)
+      case "add_breakdown":
+        return await executeAddBreakdown(args, context)
+      case "list_breakdowns":
+        return await executeListBreakdowns(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create, update, delete, add_breakdown, list_breakdowns`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `PA indicator ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findIndicator(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  name: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/pa_indicators/${sysId}`)
+    if (direct.data.result && direct.data.result.sys_id) {
+      return direct.data.result
+    }
+  }
+  if (name) {
+    const search = await client.get("/api/now/table/pa_indicators", {
+      params: {
+        sysparm_query: `name=${name}`,
+        sysparm_limit: 1,
+      },
+    })
+    const results = search.data.result || []
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const facts_table = args.facts_table as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (facts_table) queryParts.push(`facts_table=${facts_table}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get("/api/now/table/pa_indicators", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,name,label,facts_table,aggregate,field,frequency,unit,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    indicators: results.map((r) => ({
+      sys_id: r.sys_id,
+      name: r.name,
+      label: r.label,
+      facts_table: r.facts_table,
+      aggregate: r.aggregate,
+      field: r.field,
+      frequency: r.frequency,
+      unit: r.unit,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=pa_indicators.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const name = args.name as string | undefined
+
+  if (!sys_id && !name) {
+    return createErrorResult("sys_id or name is required for get action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const indicator = await findIndicator(client, sys_id, name)
+  if (!indicator) {
+    return createErrorResult(`Indicator not found: ${sys_id || name}`)
+  }
+
+  const indicatorSysId = indicator.sys_id as string
+
+  // Count related breakdowns and widgets for context (best-effort, swallow errors)
+  let breakdownCount = 0
+  let widgetCount = 0
+  try {
+    const breakdowns = await client.get("/api/now/table/pa_breakdowns_indicator", {
+      params: { sysparm_query: `indicator=${indicatorSysId}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    breakdownCount = (breakdowns.data.result || []).length
+  } catch {
+    // TODO: verify pa_breakdowns_indicator join table name on a live instance
+  }
+  try {
+    const widgets = await client.get("/api/now/table/pa_widgets", {
+      params: { sysparm_query: `indicator=${indicatorSysId}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    widgetCount = (widgets.data.result || []).length
+  } catch {
+    // pa_widgets may carry the indicator on a different column on older instances
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id: indicatorSysId,
+    name: indicator.name,
+    indicator,
+    related: {
+      breakdown_count: breakdownCount,
+      widget_count: widgetCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=pa_indicators.do?sys_id=${indicatorSysId}`,
+  })
+}
+
+// ==================== CREATE ====================
+
+async function executeCreate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  const facts_table = args.facts_table as string | undefined
+  const aggregate = args.aggregate as string | undefined
+  const field = args.field as string | undefined
+
+  if (!name) return createErrorResult("name is required for create action")
+  if (!facts_table) return createErrorResult("facts_table is required for create action")
+  if (!aggregate) return createErrorResult("aggregate is required for create action")
+  if (aggregate !== "COUNT" && !field) {
+    return createErrorResult("field is required when aggregate is not COUNT")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Reject duplicates by name
+  const existing = await client.get("/api/now/table/pa_indicators", {
+    params: { sysparm_query: `name=${name}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((existing.data.result || []).length > 0) {
+    return createErrorResult(`Indicator '${name}' already exists. Use action='update' to modify it.`)
+  }
+
+  const payload: Record<string, unknown> = {
+    name,
+    label: (args.label as string) || name,
+    description: (args.description as string) || "",
+    facts_table,
+    aggregate: aggregate.toUpperCase(),
+    active: args.active === undefined ? true : args.active,
+  }
+  if (field) payload.field = field
+  if (args.conditions) payload.conditions = args.conditions
+  if (args.unit) payload.unit = args.unit
+  if (args.frequency) payload.frequency = args.frequency
+  if (args.direction) payload.direction = args.direction
+  if (args.precision !== undefined) payload.precision = args.precision
+
+  const response = await client.post("/api/now/table/pa_indicators", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    indicator: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=pa_indicators.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== UPDATE ====================
+
+async function executeUpdate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const name = args.name as string | undefined
+
+  if (!sys_id && !name) {
+    return createErrorResult("sys_id or name is required for update action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const indicator = await findIndicator(client, sys_id, name)
+  if (!indicator) {
+    return createErrorResult(`Indicator not found: ${sys_id || name}`)
+  }
+
+  const updatableFields = [
+    "label",
+    "description",
+    "facts_table",
+    "aggregate",
+    "field",
+    "conditions",
+    "unit",
+    "frequency",
+    "direction",
+    "precision",
+    "active",
+  ]
+  const patch: Record<string, unknown> = {}
+  for (const key of updatableFields) {
+    if (args[key] !== undefined) {
+      patch[key] = key === "aggregate" ? (args[key] as string).toUpperCase() : args[key]
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return createErrorResult("No update fields provided")
+  }
+
+  const targetSysId = indicator.sys_id as string
+  const response = await client.patch(`/api/now/table/pa_indicators/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "update",
+    updated: true,
+    sys_id: targetSysId,
+    name: updated.name,
+    updated_fields: Object.keys(patch),
+    indicator: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=pa_indicators.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== DELETE ====================
+
+async function executeDelete(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const name = args.name as string | undefined
+  const cascade = args.cascade === true
+
+  if (!sys_id && !name) {
+    return createErrorResult("sys_id or name is required for delete action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const indicator = await findIndicator(client, sys_id, name)
+  if (!indicator) {
+    return createErrorResult(`Indicator not found: ${sys_id || name}`)
+  }
+
+  const targetSysId = indicator.sys_id as string
+  const removedBreakdowns: string[] = []
+
+  if (cascade) {
+    // TODO: verify pa_breakdowns_indicator join table name on a live instance
+    const breakdownLinks = await client.get("/api/now/table/pa_breakdowns_indicator", {
+      params: { sysparm_query: `indicator=${targetSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    for (const row of (breakdownLinks.data.result || []) as Array<Record<string, unknown>>) {
+      await client.delete(`/api/now/table/pa_breakdowns_indicator/${row.sys_id}`)
+      removedBreakdowns.push(row.sys_id as string)
+    }
+  }
+
+  await client.delete(`/api/now/table/pa_indicators/${targetSysId}`)
+
+  return createSuccessResult({
+    action: "delete",
+    deleted: true,
+    sys_id: targetSysId,
+    name: indicator.name,
+    cascaded_breakdown_links: removedBreakdowns,
+  })
+}
+
+// ==================== ADD_BREAKDOWN ====================
+
+async function executeAddBreakdown(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const indicatorName = args.name as string | undefined
+  const breakdown_name = args.breakdown_name as string | undefined
+  const breakdown_table = args.breakdown_table as string | undefined
+  const breakdown_field = args.breakdown_field as string | undefined
+  const related_field = args.related_field as string | undefined
+  const matrix_source = args.matrix_source === true
+
+  if (!sys_id && !indicatorName) {
+    return createErrorResult("sys_id or name is required to identify the indicator")
+  }
+  if (!breakdown_name) return createErrorResult("breakdown_name is required")
+  if (!breakdown_table) return createErrorResult("breakdown_table is required")
+  if (!breakdown_field) return createErrorResult("breakdown_field is required")
+
+  const client = await getAuthenticatedClient(context)
+  const indicator = await findIndicator(client, sys_id, indicatorName)
+  if (!indicator) {
+    return createErrorResult(`Indicator not found: ${sys_id || indicatorName}`)
+  }
+
+  // Create the breakdown definition
+  const breakdownPayload: Record<string, unknown> = {
+    name: breakdown_name,
+    table: breakdown_table,
+    field: breakdown_field,
+    matrix_source,
+  }
+  if (related_field) breakdownPayload.related_field = related_field
+
+  const breakdownResponse = await client.post("/api/now/table/pa_breakdowns", breakdownPayload)
+  const breakdown = breakdownResponse.data.result as Record<string, unknown>
+
+  // Attach the breakdown to the indicator via the join table.
+  // TODO: verify pa_breakdowns_indicator is the correct join table on a live instance.
+  let linkSysId: string | null = null
+  try {
+    const linkResponse = await client.post("/api/now/table/pa_breakdowns_indicator", {
+      indicator: indicator.sys_id,
+      breakdown: breakdown.sys_id,
+    })
+    linkSysId = linkResponse.data.result.sys_id
+  } catch (linkError: unknown) {
+    const e = linkError as Error
+    // Surface the failure so the caller knows the breakdown exists but isn't linked
+    return createSuccessResult({
+      action: "add_breakdown",
+      breakdown_created: true,
+      indicator_linked: false,
+      sys_id: breakdown.sys_id,
+      breakdown,
+      warning: `Breakdown created but could not be linked to indicator: ${e.message}`,
+    })
+  }
+
+  return createSuccessResult({
+    action: "add_breakdown",
+    breakdown_created: true,
+    indicator_linked: linkSysId !== null,
+    sys_id: breakdown.sys_id,
+    breakdown,
+    link_sys_id: linkSysId,
+    indicator: { sys_id: indicator.sys_id, name: indicator.name },
+  })
+}
+
+// ==================== LIST_BREAKDOWNS ====================
+
+async function executeListBreakdowns(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const indicatorName = args.name as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  // If an indicator is specified, return breakdowns linked to it through the join table.
+  // Otherwise return all breakdowns globally.
+  if (sys_id || indicatorName) {
+    const indicator = await findIndicator(client, sys_id, indicatorName)
+    if (!indicator) {
+      return createErrorResult(`Indicator not found: ${sys_id || indicatorName}`)
+    }
+
+    // TODO: verify pa_breakdowns_indicator join table name on a live instance
+    const linkResponse = await client.get("/api/now/table/pa_breakdowns_indicator", {
+      params: {
+        sysparm_query: `indicator=${indicator.sys_id}`,
+        sysparm_limit: limit,
+        sysparm_fields: "sys_id,breakdown",
+      },
+    })
+
+    const breakdownIds = ((linkResponse.data.result || []) as Array<Record<string, unknown>>)
+      .map((r) => {
+        const ref = r.breakdown
+        if (typeof ref === "string") return ref
+        if (ref && typeof ref === "object" && "value" in ref) return (ref as { value: string }).value
+        return null
+      })
+      .filter((v): v is string => typeof v === "string" && v.length > 0)
+
+    if (breakdownIds.length === 0) {
+      return createSuccessResult({
+        action: "list_breakdowns",
+        indicator: { sys_id: indicator.sys_id, name: indicator.name },
+        count: 0,
+        breakdowns: [],
+      })
+    }
+
+    const breakdownsResponse = await client.get("/api/now/table/pa_breakdowns", {
+      params: {
+        sysparm_query: `sys_idIN${breakdownIds.join(",")}`,
+        sysparm_limit: limit,
+        ...(fields ? { sysparm_fields: fields } : {}),
+      },
+    })
+
+    const results = (breakdownsResponse.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list_breakdowns",
+      indicator: { sys_id: indicator.sys_id, name: indicator.name },
+      count: results.length,
+      breakdowns: results,
+    })
+  }
+
+  // Global listing
+  const response = await client.get("/api/now/table/pa_breakdowns", {
+    params: {
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      ...(fields ? { sysparm_fields: fields } : {}),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "list_breakdowns",
+    count: results.length,
+    breakdowns: results,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/index.ts
@@ -6,3 +6,7 @@ export {
   toolDefinition as snow_scheduled_job_manage_def,
   execute as snow_scheduled_job_manage_exec,
 } from "./snow_scheduled_job_manage.js"
+export {
+  toolDefinition as snow_job_status_def,
+  execute as snow_job_status_exec,
+} from "./snow_job_status.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/snow_job_status.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/snow_job_status.ts
@@ -1,0 +1,373 @@
+/**
+ * snow_job_status - Unified visibility into running and recent background work
+ *
+ * Real-time and historical view across the three job/worker registries on
+ * a ServiceNow instance:
+ *   - sys_trigger          — scheduled job triggers (next_action, last_run, state)
+ *   - sys_progress_worker  — background workers (transforms, large operations)
+ *   - sys_execution_tracker — execution trackers (fix scripts, imports, async ops)
+ *
+ * Companion to snow_trigger_scheduled_job (which starts jobs) and
+ * snow_scheduled_job_manage (which defines them). This tool is read-only.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+type SourceKey = "trigger" | "worker" | "tracker"
+
+const SOURCE_TABLES: Record<SourceKey, string> = {
+  trigger: "sys_trigger",
+  worker: "sys_progress_worker",
+  tracker: "sys_execution_tracker",
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_job_status",
+  description: `Unified read-only visibility into ServiceNow background work. Spans sys_trigger (scheduled-job triggers), sys_progress_worker (background workers for transforms, imports, large operations), and sys_execution_tracker (fix-script and async-operation trackers).
+
+Actions:
+- list_active — list currently running/queued work across triggers, workers, and trackers
+- get_status — fetch the full record for a single job/worker/tracker by sys_id
+- get_history — historical runs for a specific scheduled job (sys_trigger), bounded by limit and time window
+- get_errors — surface recent failed/errored runs across the three sources
+
+Use when: the agent needs real-time situational awareness of what is running on the instance, debugging a slow transform, or auditing why a scheduled job did not fire. Companion to snow_trigger_scheduled_job for starting jobs and snow_scheduled_job_manage for defining them.
+
+Returns: per-source arrays of normalized records with sys_id, name, state, progress, started_at, completed_at, and source-specific fields. All operations are read-only Table API queries.`,
+  category: "automation",
+  subcategory: "scheduled-jobs",
+  use_cases: ["monitoring", "scheduled-jobs", "background-jobs", "debugging", "observability"],
+  complexity: "intermediate",
+  frequency: "high",
+  permission: "read",
+  allowedRoles: ["developer", "admin", "stakeholder"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Status-query action to perform",
+        enum: ["list_active", "get_status", "get_history", "get_errors"],
+      },
+      source: {
+        type: "string",
+        description:
+          "[list_active/get_status/get_errors] Which source to query. Defaults to 'all' which queries trigger, worker, and tracker in parallel.",
+        enum: ["all", "trigger", "worker", "tracker"],
+        default: "all",
+      },
+      sys_id: {
+        type: "string",
+        description: "[get_status/get_history] Record sys_id to inspect",
+      },
+      job_name: {
+        type: "string",
+        description: "[get_history] Scheduled job name (alternative to sys_id, queries sys_trigger by name)",
+      },
+      limit: {
+        type: "number",
+        description: "[list_active/get_history/get_errors] Maximum records to return per source",
+        default: 50,
+      },
+      since_hours: {
+        type: "number",
+        description: "[list_active/get_history/get_errors] Only include records updated within the last N hours",
+        default: 24,
+      },
+      fields: {
+        type: "string",
+        description: "[get_status] Comma-separated list of fields to return for the specific record",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_active":
+        return await executeListActive(args, context)
+      case "get_status":
+        return await executeGetStatus(args, context)
+      case "get_history":
+        return await executeGetHistory(args, context)
+      case "get_errors":
+        return await executeGetErrors(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_active, get_status, get_history, get_errors`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `Job status ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function buildSourceList(source: string | undefined): SourceKey[] {
+  if (!source || source === "all") return ["trigger", "worker", "tracker"]
+  return [source as SourceKey]
+}
+
+function activeQueryFor(source: SourceKey, sinceHours: number): string {
+  const sinceClause = `sys_updated_on>=javascript:gs.beginningOfLastXHours(${sinceHours})`
+  switch (source) {
+    case "trigger":
+      // sys_trigger has a 'state' field — running triggers are state=1 (ready) or state=2 (running)
+      // TODO: verify state codes against a live instance
+      return `state!=0^${sinceClause}`
+    case "worker":
+      // sys_progress_worker state: running/pending/queued
+      return `stateIN0,1,2^${sinceClause}`
+    case "tracker":
+      // sys_execution_tracker.state: running/pending — completion is usually >= 4
+      return `stateIN0,1,2^${sinceClause}`
+  }
+}
+
+function normalizeRecord(source: SourceKey, raw: Record<string, unknown>): Record<string, unknown> {
+  const common = {
+    source,
+    sys_id: raw.sys_id,
+    name: raw.name,
+    state: raw.state,
+    updated_at: raw.sys_updated_on,
+  }
+
+  switch (source) {
+    case "trigger":
+      return {
+        ...common,
+        next_action: raw.next_action,
+        trigger_type: raw.trigger_type,
+        document_key: raw.document_key,
+        document: raw.document,
+      }
+    case "worker":
+      return {
+        ...common,
+        progress: raw.progress,
+        progress_percent: raw.progress_percent,
+        started_at: raw.start_time,
+        completed_at: raw.end_time,
+        message: raw.message,
+      }
+    case "tracker":
+      return {
+        ...common,
+        progress: raw.progress,
+        started_at: raw.start_time,
+        completed_at: raw.end_time,
+        result: raw.result,
+        message: raw.message,
+      }
+  }
+}
+
+// ==================== LIST_ACTIVE ====================
+
+async function executeListActive(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const source = args.source as string | undefined
+  const limit = (args.limit as number) || 50
+  const since_hours = (args.since_hours as number) || 24
+
+  const client = await getAuthenticatedClient(context)
+  const sources = buildSourceList(source)
+
+  const results: Record<string, Array<Record<string, unknown>>> = {}
+
+  await Promise.all(
+    sources.map(async (s) => {
+      const table = SOURCE_TABLES[s]
+      const response = await client.get(`/api/now/table/${table}`, {
+        params: {
+          sysparm_query: activeQueryFor(s, since_hours),
+          sysparm_limit: limit,
+          sysparm_orderby: "sys_updated_on",
+          sysparm_order: "desc",
+        },
+      })
+      const rows = (response.data.result || []) as Array<Record<string, unknown>>
+      results[s] = rows.map((r) => normalizeRecord(s, r))
+    }),
+  )
+
+  const totalActive = Object.values(results).reduce((sum, arr) => sum + arr.length, 0)
+
+  return createSuccessResult({
+    action: "list_active",
+    since_hours,
+    total_active: totalActive,
+    sources: results,
+  })
+}
+
+// ==================== GET_STATUS ====================
+
+async function executeGetStatus(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const source = (args.source as string | undefined) || "all"
+  const fields = args.fields as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for get_status action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const sources = buildSourceList(source)
+
+  for (const s of sources) {
+    const table = SOURCE_TABLES[s]
+    try {
+      const response = await client.get(`/api/now/table/${table}/${sys_id}`, {
+        params: fields ? { sysparm_fields: fields } : {},
+      })
+      const record = response.data.result as Record<string, unknown> | undefined
+      if (record && record.sys_id) {
+        return createSuccessResult({
+          action: "get_status",
+          source: s,
+          sys_id: record.sys_id,
+          record: normalizeRecord(s, record),
+          raw: record,
+          url: `${context.instanceUrl}/nav_to.do?uri=${table}.do?sys_id=${sys_id}`,
+        })
+      }
+    } catch {
+      // Not in this source, try the next one
+    }
+  }
+
+  return createErrorResult(`Record ${sys_id} not found in any of: ${sources.join(", ")}`)
+}
+
+// ==================== GET_HISTORY ====================
+
+async function executeGetHistory(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const job_name = args.job_name as string | undefined
+  const limit = (args.limit as number) || 50
+  const since_hours = (args.since_hours as number) || 168 // default 7 days for history
+
+  if (!sys_id && !job_name) {
+    return createErrorResult("sys_id or job_name is required for get_history action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Resolve the scheduled job (sysauto_script) the trigger refers to.
+  // sys_trigger.document_key is the sys_id of the referenced sysauto/sysauto_script record.
+  let triggerQuery = ""
+  if (sys_id) {
+    triggerQuery = `document_key=${sys_id}^ORsys_id=${sys_id}`
+  } else if (job_name) {
+    triggerQuery = `nameLIKE${job_name}`
+  }
+
+  // sys_trigger doesn't carry rich per-run history on every release; the
+  // execution_tracker and progress_worker tables typically do.
+  // TODO: verify mapping between sys_trigger and execution_tracker on a live instance.
+  const triggerResponse = await client.get("/api/now/table/sys_trigger", {
+    params: {
+      sysparm_query: `${triggerQuery}^sys_updated_on>=javascript:gs.beginningOfLastXHours(${since_hours})`,
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_updated_on",
+      sysparm_order: "desc",
+    },
+  })
+
+  const trackerResponse = await client.get("/api/now/table/sys_execution_tracker", {
+    params: {
+      sysparm_query: `nameLIKE${job_name || ""}^sys_updated_on>=javascript:gs.beginningOfLastXHours(${since_hours})`,
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_order: "desc",
+    },
+  })
+
+  const triggers = ((triggerResponse.data.result || []) as Array<Record<string, unknown>>).map((r) =>
+    normalizeRecord("trigger", r),
+  )
+  const trackers = ((trackerResponse.data.result || []) as Array<Record<string, unknown>>).map((r) =>
+    normalizeRecord("tracker", r),
+  )
+
+  return createSuccessResult({
+    action: "get_history",
+    since_hours,
+    job_identifier: sys_id || job_name,
+    trigger_runs: triggers,
+    execution_trackers: trackers,
+  })
+}
+
+// ==================== GET_ERRORS ====================
+
+async function executeGetErrors(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const source = args.source as string | undefined
+  const limit = (args.limit as number) || 50
+  const since_hours = (args.since_hours as number) || 24
+
+  const client = await getAuthenticatedClient(context)
+  const sources = buildSourceList(source)
+
+  const results: Record<string, Array<Record<string, unknown>>> = {}
+
+  await Promise.all(
+    sources.map(async (s) => {
+      const table = SOURCE_TABLES[s]
+      // Error state codes vary per table. The common pattern across ServiceNow:
+      //   sys_progress_worker.state = 4 (cancelled), 5 (error)
+      //   sys_execution_tracker.state = 5 (error), 6 (cancelled)
+      //   sys_trigger has no canonical error state — surface those whose last_action recorded a failure.
+      // TODO: verify state codes against a live instance.
+      let query: string
+      const sinceClause = `sys_updated_on>=javascript:gs.beginningOfLastXHours(${since_hours})`
+      if (s === "worker") {
+        query = `stateIN4,5^${sinceClause}`
+      } else if (s === "tracker") {
+        query = `stateIN5,6^${sinceClause}`
+      } else {
+        // trigger: best-effort — look at next_action set in the past with last_action containing an error message
+        query = `last_action_messageLIKEerror^${sinceClause}`
+      }
+
+      const response = await client.get(`/api/now/table/${table}`, {
+        params: {
+          sysparm_query: query,
+          sysparm_limit: limit,
+          sysparm_orderby: "sys_updated_on",
+          sysparm_order: "desc",
+        },
+      })
+
+      const rows = (response.data.result || []) as Array<Record<string, unknown>>
+      results[s] = rows.map((r) => normalizeRecord(s, r))
+    }),
+  )
+
+  const totalErrors = Object.values(results).reduce((sum, arr) => sum + arr.length, 0)
+
+  return createSuccessResult({
+    action: "get_errors",
+    since_hours,
+    total_errors: totalErrors,
+    sources: results,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/index.ts
@@ -6,3 +6,7 @@ export {
   toolDefinition as snow_add_schedule_entry_def,
   execute as snow_add_schedule_entry_exec,
 } from "./snow_add_schedule_entry.js"
+export {
+  toolDefinition as snow_oncall_manage_def,
+  execute as snow_oncall_manage_exec,
+} from "./snow_oncall_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/snow_oncall_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/snow_oncall_manage.ts
@@ -1,0 +1,420 @@
+/**
+ * snow_oncall_manage - Unified On-Call Scheduling operations
+ *
+ * Manages ServiceNow On-Call Scheduling (OCS) artifacts: rotations
+ * (cmn_rota), rotation members (cmn_rota_member), and roster assignments
+ * (cmn_rota_roster). Used by ITSM teams to define who is responsible for
+ * which group at which time, and to answer "who is on call right now".
+ *
+ * Companion to snow_create_schedule and snow_add_schedule_entry (which
+ * manage the underlying cmn_schedule structures that rotations reference).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_oncall_manage",
+  description: `Unified tool for ServiceNow On-Call Scheduling. Operates over cmn_rota (rotations), cmn_rota_member (members in a rotation), and cmn_rota_roster (shift assignments) to manage who covers which group at which time.
+
+Actions:
+- list_rotations — list rotations, optionally filtered by assignment group
+- get_current_oncall — resolve who is on call right now for a given rotation (queries cmn_rota_roster against the current GlideDateTime via a server-side helper)
+- list_shifts — list upcoming shifts/rosters for a rotation within a time window
+- swap_shift — reassign a roster entry from one rotation member to another
+
+Use when: ITSM teams need visibility into on-call coverage, the agent must page the correct person, or a user requests a one-time shift swap. Companion to snow_create_schedule for the underlying schedule definitions.
+
+Returns: action-specific structures. list_rotations returns rotation records with assignment_group and schedule references. get_current_oncall returns the active rotation member (sys_user link) plus the roster row that grants coverage. list_shifts returns roster rows ordered by start time. swap_shift returns the updated roster record.`,
+  category: "schedules",
+  subcategory: "schedules",
+  use_cases: ["on-call", "scheduling", "itsm", "rosters", "rotation"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "On-call action to perform",
+        enum: ["list_rotations", "get_current_oncall", "list_shifts", "swap_shift"],
+      },
+      // Rotation identifiers
+      rotation_sys_id: {
+        type: "string",
+        description: "[get_current_oncall/list_shifts/swap_shift] sys_id of the cmn_rota rotation",
+      },
+      rotation_name: {
+        type: "string",
+        description: "[get_current_oncall/list_shifts] Rotation name (alternative to rotation_sys_id)",
+      },
+      assignment_group: {
+        type: "string",
+        description: "[list_rotations] Filter rotations by assignment group sys_id or name",
+      },
+      active_only: {
+        type: "boolean",
+        description: "[list_rotations] Only return active rotations",
+        default: true,
+      },
+      // Time window
+      start_time: {
+        type: "string",
+        description: "[list_shifts] Window start in ServiceNow datetime format (YYYY-MM-DD HH:MM:SS, UTC). Defaults to now.",
+      },
+      end_time: {
+        type: "string",
+        description: "[list_shifts] Window end in ServiceNow datetime format. Defaults to start_time + 7 days.",
+      },
+      // SWAP_SHIFT parameters
+      roster_sys_id: {
+        type: "string",
+        description: "[swap_shift] sys_id of the cmn_rota_roster row to reassign",
+      },
+      from_member_sys_id: {
+        type: "string",
+        description: "[swap_shift] sys_id of the cmn_rota_member currently assigned (used as a guard)",
+      },
+      to_member_sys_id: {
+        type: "string",
+        description: "[swap_shift] sys_id of the cmn_rota_member taking the shift",
+      },
+      reason: {
+        type: "string",
+        description: "[swap_shift] Optional reason recorded on the roster row",
+      },
+      // Common
+      limit: {
+        type: "number",
+        description: "[list_rotations/list_shifts] Maximum records to return",
+        default: 50,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_rotations":
+        return await executeListRotations(args, context)
+      case "get_current_oncall":
+        return await executeGetCurrentOncall(args, context)
+      case "list_shifts":
+        return await executeListShifts(args, context)
+      case "swap_shift":
+        return await executeSwapShift(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_rotations, get_current_oncall, list_shifts, swap_shift`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `On-call ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function resolveAssignmentGroupSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  group: string,
+): Promise<string | null> {
+  // Accept either a sys_id directly or a group name.
+  if (/^[0-9a-f]{32}$/i.test(group)) return group
+  const response = await client.get("/api/now/table/sys_user_group", {
+    params: { sysparm_query: `name=${group}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  const rows = (response.data.result || []) as Array<Record<string, unknown>>
+  return rows.length > 0 ? (rows[0].sys_id as string) : null
+}
+
+async function findRotation(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  name: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/cmn_rota/${sysId}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  }
+  if (name) {
+    const search = await client.get("/api/now/table/cmn_rota", {
+      params: { sysparm_query: `name=${name}`, sysparm_limit: 1 },
+    })
+    const rows = (search.data.result || []) as Array<Record<string, unknown>>
+    if (rows.length > 0) return rows[0]
+  }
+  return null
+}
+
+// ==================== LIST_ROTATIONS ====================
+
+async function executeListRotations(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const assignment_group = args.assignment_group as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+
+  if (assignment_group) {
+    const groupSysId = await resolveAssignmentGroupSysId(client, assignment_group)
+    if (!groupSysId) {
+      return createErrorResult(`Assignment group '${assignment_group}' not found`)
+    }
+    queryParts.push(`group=${groupSysId}`)
+  }
+
+  const response = await client.get("/api/now/table/cmn_rota", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: "sys_id,name,group,schedule,active,time_zone,start_date,end_date,sys_updated_on",
+    },
+  })
+
+  const rotations = ((response.data.result || []) as Array<Record<string, unknown>>).map((r) => ({
+    sys_id: r.sys_id,
+    name: r.name,
+    group: r.group,
+    schedule: r.schedule,
+    time_zone: r.time_zone,
+    active: r.active,
+    start_date: r.start_date,
+    end_date: r.end_date,
+    updated_at: r.sys_updated_on,
+    url: `${context.instanceUrl}/nav_to.do?uri=cmn_rota.do?sys_id=${r.sys_id}`,
+  }))
+
+  return createSuccessResult({
+    action: "list_rotations",
+    count: rotations.length,
+    rotations,
+  })
+}
+
+// ==================== GET_CURRENT_ONCALL ====================
+
+async function executeGetCurrentOncall(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const rotation_sys_id = args.rotation_sys_id as string | undefined
+  const rotation_name = args.rotation_name as string | undefined
+
+  if (!rotation_sys_id && !rotation_name) {
+    return createErrorResult("rotation_sys_id or rotation_name is required for get_current_oncall action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const rotation = await findRotation(client, rotation_sys_id, rotation_name)
+  if (!rotation) {
+    return createErrorResult(`Rotation not found: ${rotation_sys_id || rotation_name}`)
+  }
+
+  const rotationSysId = rotation.sys_id as string
+
+  // Find the roster row whose window covers "now" and that points at an active member.
+  // Use an encoded query that combines start_date_time <= now and end_date_time >= now.
+  // The platform's exact column names on cmn_rota_roster vary slightly across releases;
+  // we use the documented start_date_time / end_date_time pair.
+  // TODO: verify column names against a live instance.
+  const rosterResponse = await client.get("/api/now/table/cmn_rota_roster", {
+    params: {
+      sysparm_query: `rota=${rotationSysId}^start_date_time<=javascript:gs.nowDateTime()^end_date_time>=javascript:gs.nowDateTime()`,
+      sysparm_limit: 5,
+      sysparm_orderby: "start_date_time",
+    },
+  })
+
+  const rosterRows = (rosterResponse.data.result || []) as Array<Record<string, unknown>>
+  if (rosterRows.length === 0) {
+    return createSuccessResult({
+      action: "get_current_oncall",
+      rotation: { sys_id: rotationSysId, name: rotation.name },
+      on_call: null,
+      message: "No active roster entry covers the current time for this rotation.",
+    })
+  }
+
+  // The roster row references a cmn_rota_member; the member references a sys_user.
+  // Resolve them in turn for a useful payload.
+  const primary = rosterRows[0]
+  const memberRef = primary.member
+  const memberSysId =
+    typeof memberRef === "string"
+      ? memberRef
+      : memberRef && typeof memberRef === "object" && "value" in memberRef
+        ? (memberRef as { value: string }).value
+        : null
+
+  let member: Record<string, unknown> | null = null
+  let user: Record<string, unknown> | null = null
+  if (memberSysId) {
+    const memberResponse = await client.get(`/api/now/table/cmn_rota_member/${memberSysId}`)
+    member = (memberResponse.data.result as Record<string, unknown>) ?? null
+
+    const userRef = member?.user
+    const userSysId =
+      typeof userRef === "string"
+        ? userRef
+        : userRef && typeof userRef === "object" && "value" in userRef
+          ? (userRef as { value: string }).value
+          : null
+    if (userSysId) {
+      const userResponse = await client.get(`/api/now/table/sys_user/${userSysId}`, {
+        params: { sysparm_fields: "sys_id,user_name,name,email,phone,active" },
+      })
+      user = (userResponse.data.result as Record<string, unknown>) ?? null
+    }
+  }
+
+  return createSuccessResult({
+    action: "get_current_oncall",
+    rotation: { sys_id: rotationSysId, name: rotation.name },
+    on_call: {
+      roster_sys_id: primary.sys_id,
+      member: member
+        ? { sys_id: member.sys_id, order: member.order, escalation_step: member.escalation_step }
+        : null,
+      user,
+      window: {
+        start: primary.start_date_time,
+        end: primary.end_date_time,
+      },
+    },
+    additional_rosters: rosterRows.slice(1).map((r) => ({
+      roster_sys_id: r.sys_id,
+      start: r.start_date_time,
+      end: r.end_date_time,
+    })),
+  })
+}
+
+// ==================== LIST_SHIFTS ====================
+
+async function executeListShifts(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const rotation_sys_id = args.rotation_sys_id as string | undefined
+  const rotation_name = args.rotation_name as string | undefined
+  const start_time = args.start_time as string | undefined
+  const end_time = args.end_time as string | undefined
+  const limit = (args.limit as number) || 50
+
+  const client = await getAuthenticatedClient(context)
+  const rotation = await findRotation(client, rotation_sys_id, rotation_name)
+  if (!rotation) {
+    return createErrorResult(`Rotation not found: ${rotation_sys_id || rotation_name}`)
+  }
+
+  const rotationSysId = rotation.sys_id as string
+
+  // Default window: from now to now+7d, expressed as javascript: clauses so the
+  // server evaluates them in the instance's timezone.
+  const startClause = start_time ? `start_date_time>=${start_time}` : `start_date_time>=javascript:gs.nowDateTime()`
+  const endClause = end_time
+    ? `end_date_time<=${end_time}`
+    : `end_date_time<=javascript:gs.daysAgoEnd(-7)`
+
+  const response = await client.get("/api/now/table/cmn_rota_roster", {
+    params: {
+      sysparm_query: `rota=${rotationSysId}^${startClause}^${endClause}`,
+      sysparm_limit: limit,
+      sysparm_orderby: "start_date_time",
+      sysparm_fields: "sys_id,member,start_date_time,end_date_time,override,override_reason",
+    },
+  })
+
+  const shifts = ((response.data.result || []) as Array<Record<string, unknown>>).map((r) => ({
+    sys_id: r.sys_id,
+    member: r.member,
+    start_date_time: r.start_date_time,
+    end_date_time: r.end_date_time,
+    override: r.override,
+    override_reason: r.override_reason,
+  }))
+
+  return createSuccessResult({
+    action: "list_shifts",
+    rotation: { sys_id: rotationSysId, name: rotation.name },
+    window: {
+      start: start_time || "now",
+      end: end_time || "now + 7 days",
+    },
+    count: shifts.length,
+    shifts,
+  })
+}
+
+// ==================== SWAP_SHIFT ====================
+
+async function executeSwapShift(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const roster_sys_id = args.roster_sys_id as string | undefined
+  const from_member_sys_id = args.from_member_sys_id as string | undefined
+  const to_member_sys_id = args.to_member_sys_id as string | undefined
+  const reason = args.reason as string | undefined
+
+  if (!roster_sys_id) return createErrorResult("roster_sys_id is required for swap_shift action")
+  if (!to_member_sys_id) return createErrorResult("to_member_sys_id is required for swap_shift action")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Optional safety check: confirm the current member matches from_member_sys_id when provided.
+  const currentResponse = await client.get(`/api/now/table/cmn_rota_roster/${roster_sys_id}`)
+  const current = currentResponse.data.result as Record<string, unknown> | undefined
+  if (!current || !current.sys_id) {
+    return createErrorResult(`Roster row ${roster_sys_id} not found`)
+  }
+
+  if (from_member_sys_id) {
+    const currentMember = current.member
+    const currentMemberId =
+      typeof currentMember === "string"
+        ? currentMember
+        : currentMember && typeof currentMember === "object" && "value" in currentMember
+          ? (currentMember as { value: string }).value
+          : null
+    if (currentMemberId !== from_member_sys_id) {
+      return createErrorResult(
+        `Current roster member (${currentMemberId}) does not match expected from_member_sys_id (${from_member_sys_id})`,
+      )
+    }
+  }
+
+  // Apply the swap. We mark the roster row as an override and record the reason.
+  // TODO: verify override/override_reason field names against a live instance.
+  const patchPayload: Record<string, unknown> = {
+    member: to_member_sys_id,
+    override: true,
+  }
+  if (reason) patchPayload.override_reason = reason
+
+  const updateResponse = await client.patch(`/api/now/table/cmn_rota_roster/${roster_sys_id}`, patchPayload)
+  const updated = updateResponse.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "swap_shift",
+    swapped: true,
+    roster_sys_id,
+    previous_member: from_member_sys_id || current.member,
+    new_member: to_member_sys_id,
+    roster: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=cmn_rota_roster.do?sys_id=${roster_sys_id}`,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
@@ -48,6 +48,12 @@ export {
   execute as snow_security_risk_assessment_exec,
 } from "./snow_security_risk_assessment.js"
 
+// Key Management Framework
+export {
+  toolDefinition as snow_kms_manage_def,
+  execute as snow_kms_manage_exec,
+} from "./snow_kms_manage.js"
+
 // SecOps Tools
 export {
   toolDefinition as snow_analyze_threat_intelligence_def,

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_kms_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_kms_manage.ts
@@ -1,0 +1,467 @@
+/**
+ * snow_kms_manage - Unified Key Management Framework (KMF) operations
+ *
+ * Wraps ServiceNow's Key Management Framework: KMF modules (sys_kmf_module),
+ * cryptographic modules (sys_kmf_crypto_module), keys (sys_kmf_key), and key
+ * ring assignments. Used to bootstrap and rotate the keys that drive PII/PCI
+ * encryption flows (column encryption, edge encryption, encrypted text fields).
+ *
+ * Encryption and decryption are not standard Table API operations — they are
+ * exposed by ServiceNow as scripted REST endpoints or via the GlideEncrypter
+ * API inside Script Includes. This tool calls the platform's KMF helper
+ * Script Include via the documented scripted REST surface; if the endpoint
+ * is unavailable, it falls back to invoking GlideEncrypter directly through
+ * the shared script-execution path.
+ *
+ * Companion to snow_create_security_policy and snow_audit_trail_analysis.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_kms_manage",
+  description: `Unified tool for the ServiceNow Key Management Framework. Covers KMF modules (sys_kmf_module), cryptographic modules (sys_kmf_crypto_module), and keys (sys_kmf_key) for use in PII/PCI encryption flows and Edge Encryption.
+
+Actions:
+- list_modules — list KMF modules (sys_kmf_module) and their crypto modules
+- create_key — create a new key under a KMF module (writes sys_kmf_key)
+- encrypt — encrypt a plaintext payload using the named key
+- decrypt — decrypt a ciphertext payload using the named key
+- list_keys — list keys, optionally filtered by module
+- rotate_key — generate a new active version of a key and deactivate the previous one
+
+Use when: managing KMF modules and keys for sensitive data, rotating keys on schedule, or wrapping/unwrapping payloads through the platform. Encrypt and decrypt invoke a server-side helper Script Include rather than the Table API; falls back to a scripted-execution path if the dedicated endpoint is absent.
+
+Returns: action-specific data. List operations return arrays of KMF records (sys_id, name, module, type, active, key_format). Create/rotate return the new key record. Encrypt/decrypt return the wrapped/unwrapped payload as a string. Plaintext and ciphertext are never logged in error metadata.`,
+  category: "security",
+  subcategory: "security",
+  use_cases: ["security", "encryption", "kms", "key-management", "pii", "compliance"],
+  complexity: "advanced",
+  frequency: "low",
+  permission: "write",
+  allowedRoles: ["admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "KMS action to perform",
+        enum: ["list_modules", "create_key", "encrypt", "decrypt", "list_keys", "rotate_key"],
+      },
+      // Identifiers
+      module_sys_id: {
+        type: "string",
+        description: "[create_key/list_keys/rotate_key] sys_id of the KMF module (sys_kmf_module)",
+      },
+      key_sys_id: {
+        type: "string",
+        description: "[rotate_key/encrypt/decrypt] sys_id of the key (sys_kmf_key)",
+      },
+      key_name: {
+        type: "string",
+        description: "[create_key/encrypt/decrypt/rotate_key] Logical name of the key (alternative to key_sys_id)",
+      },
+      // CREATE_KEY parameters
+      algorithm: {
+        type: "string",
+        description: "[create_key] Symmetric algorithm",
+        enum: ["AES-128", "AES-256", "RSA-2048", "RSA-4096", "HMAC-SHA-256"],
+      },
+      key_purpose: {
+        type: "string",
+        description: "[create_key] Intended purpose",
+        enum: ["encryption", "signing", "wrapping"],
+      },
+      label: {
+        type: "string",
+        description: "[create_key] Display label",
+      },
+      // ENCRYPT / DECRYPT parameters
+      plaintext: {
+        type: "string",
+        description: "[encrypt] Plaintext payload to encrypt (never logged in error output)",
+      },
+      ciphertext: {
+        type: "string",
+        description: "[decrypt] Base64-encoded ciphertext payload to decrypt (never logged in error output)",
+      },
+      // LIST parameters
+      active_only: {
+        type: "boolean",
+        description: "[list_modules/list_keys] Only return active records",
+        default: true,
+      },
+      limit: {
+        type: "number",
+        description: "[list_modules/list_keys] Maximum records to return",
+        default: 50,
+      },
+      // ROTATE parameters
+      retire_previous: {
+        type: "boolean",
+        description: "[rotate_key] Mark the previous active key as inactive after creating the new version",
+        default: true,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_modules":
+        return await executeListModules(args, context)
+      case "create_key":
+        return await executeCreateKey(args, context)
+      case "encrypt":
+        return await executeEncrypt(args, context)
+      case "decrypt":
+        return await executeDecrypt(args, context)
+      case "list_keys":
+        return await executeListKeys(args, context)
+      case "rotate_key":
+        return await executeRotateKey(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_modules, create_key, encrypt, decrypt, list_keys, rotate_key`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    // Redact any plaintext/ciphertext payload from the error message — be paranoid.
+    const redactedMessage = redactSensitive(err.message)
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `KMS ${action} failed: ${redactedMessage}`, {
+            originalError: new Error(redactedMessage),
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function redactSensitive(message: string): string {
+  // Strip anything that looks like a long base64 blob, in case the platform echoes payload back.
+  return message.replace(/[A-Za-z0-9+/]{40,}={0,2}/g, "[redacted]")
+}
+
+async function findKey(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  name: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/sys_kmf_key/${sysId}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  }
+  if (name) {
+    const search = await client.get("/api/now/table/sys_kmf_key", {
+      params: {
+        sysparm_query: `name=${name}^active=true`,
+        sysparm_limit: 1,
+      },
+    })
+    const results = search.data.result || []
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+// ==================== LIST_MODULES ====================
+
+async function executeListModules(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+
+  const client = await getAuthenticatedClient(context)
+
+  const moduleResponse = await client.get("/api/now/table/sys_kmf_module", {
+    params: {
+      sysparm_query: active_only ? "active=true" : "",
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+    },
+  })
+  const modules = ((moduleResponse.data.result || []) as Array<Record<string, unknown>>).map((m) => ({
+    sys_id: m.sys_id,
+    name: m.name,
+    label: m.label,
+    type: m.type,
+    active: m.active,
+    url: `${context.instanceUrl}/nav_to.do?uri=sys_kmf_module.do?sys_id=${m.sys_id}`,
+  }))
+
+  // Also list crypto modules — they pair with KMF modules in the framework.
+  // TODO: verify sys_kmf_crypto_module structure against a live instance.
+  let cryptoModules: Array<Record<string, unknown>> = []
+  try {
+    const cryptoResponse = await client.get("/api/now/table/sys_kmf_crypto_module", {
+      params: { sysparm_limit: limit, sysparm_orderby: "name" },
+    })
+    cryptoModules = ((cryptoResponse.data.result || []) as Array<Record<string, unknown>>).map((c) => ({
+      sys_id: c.sys_id,
+      name: c.name,
+      provider: c.provider,
+      type: c.type,
+      active: c.active,
+    }))
+  } catch {
+    // Crypto module table may not be present on every release
+  }
+
+  return createSuccessResult({
+    action: "list_modules",
+    modules,
+    crypto_modules: cryptoModules,
+    counts: { modules: modules.length, crypto_modules: cryptoModules.length },
+  })
+}
+
+// ==================== CREATE_KEY ====================
+
+async function executeCreateKey(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const module_sys_id = args.module_sys_id as string | undefined
+  const key_name = args.key_name as string | undefined
+  const algorithm = args.algorithm as string | undefined
+  const key_purpose = args.key_purpose as string | undefined
+  const label = args.label as string | undefined
+
+  if (!module_sys_id) return createErrorResult("module_sys_id is required for create_key action")
+  if (!key_name) return createErrorResult("key_name is required for create_key action")
+  if (!algorithm) return createErrorResult("algorithm is required for create_key action")
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = {
+    module: module_sys_id,
+    name: key_name,
+    label: label || key_name,
+    algorithm,
+    active: true,
+  }
+  if (key_purpose) payload.purpose = key_purpose
+
+  // TODO: verify sys_kmf_key field set against a live instance.
+  const response = await client.post("/api/now/table/sys_kmf_key", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_key",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    key: {
+      sys_id: created.sys_id,
+      name: created.name,
+      label: created.label,
+      algorithm: created.algorithm,
+      module: created.module,
+      active: created.active,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=sys_kmf_key.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== ENCRYPT / DECRYPT ====================
+
+async function executeEncrypt(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const plaintext = args.plaintext as string | undefined
+  if (!plaintext) return createErrorResult("plaintext is required for encrypt action")
+  const keyRef = resolveKeyRef(args)
+  if (!keyRef) return createErrorResult("key_sys_id or key_name is required for encrypt action")
+
+  return await callKmfHelper(context, "encrypt", { key: keyRef, payload: plaintext })
+}
+
+async function executeDecrypt(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const ciphertext = args.ciphertext as string | undefined
+  if (!ciphertext) return createErrorResult("ciphertext is required for decrypt action")
+  const keyRef = resolveKeyRef(args)
+  if (!keyRef) return createErrorResult("key_sys_id or key_name is required for decrypt action")
+
+  return await callKmfHelper(context, "decrypt", { key: keyRef, payload: ciphertext })
+}
+
+function resolveKeyRef(args: Record<string, unknown>): string | null {
+  const key_sys_id = args.key_sys_id as string | undefined
+  const key_name = args.key_name as string | undefined
+  return key_sys_id || key_name || null
+}
+
+async function callKmfHelper(
+  context: ServiceNowContext,
+  op: "encrypt" | "decrypt",
+  body: { key: string; payload: string },
+): Promise<ToolResult> {
+  const client = await getAuthenticatedClient(context)
+
+  // Preferred path: scripted REST endpoint exposed by the KMF helper.
+  // TODO: verify against live instance — best-effort from docs.
+  try {
+    const response = await client.post(`/api/sn_kmf/${op}`, body)
+    const data = response.data.result ?? response.data
+    return createSuccessResult({
+      action: op,
+      key: body.key,
+      result: data,
+    })
+  } catch (firstErr: unknown) {
+    // Fallback: invoke GlideEncrypter via the platform's scripted-exec.
+    // We import lazily to avoid a hard dependency cycle if scripted-exec
+    // changes its signature. ES5 syntax only inside the executed script.
+    const scripted = await import("../../shared/scripted-exec.js")
+
+    // ES5 script string — no const/let/arrow/template literal inside.
+    var script: string
+    if (op === "encrypt") {
+      script =
+        "var enc = new GlideEncrypter();\n" +
+        "var keyRef = " + JSON.stringify(body.key) + ";\n" +
+        "var payload = " + JSON.stringify(body.payload) + ";\n" +
+        "var out = enc.encrypt(keyRef, payload);\n" +
+        "gs.print(out);"
+    } else {
+      script =
+        "var enc = new GlideEncrypter();\n" +
+        "var keyRef = " + JSON.stringify(body.key) + ";\n" +
+        "var payload = " + JSON.stringify(body.payload) + ";\n" +
+        "var out = enc.decrypt(keyRef, payload);\n" +
+        "gs.print(out);"
+    }
+
+    const execResult = await scripted.executeServerScript(context, script, {
+      description: `KMS ${op} via GlideEncrypter fallback`,
+      timeout: 30000,
+    })
+
+    if (!execResult.success) {
+      const firstMessage = (firstErr as Error).message
+      throw new SnowFlowError(
+        ErrorType.SERVICENOW_API_ERROR,
+        "KMF helper endpoint unavailable and GlideEncrypter fallback failed: " + redactSensitive(execResult.error || firstMessage),
+      )
+    }
+
+    const printed = (execResult.output || [])
+      .filter((o) => o.level === "print")
+      .map((o) => o.message)
+      .join("")
+
+    return createSuccessResult({
+      action: op,
+      key: body.key,
+      method: "scripted_exec_fallback",
+      result: printed,
+    })
+  }
+}
+
+// ==================== LIST_KEYS ====================
+
+async function executeListKeys(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const module_sys_id = args.module_sys_id as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (module_sys_id) queryParts.push(`module=${module_sys_id}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get("/api/now/table/sys_kmf_key", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: "sys_id,name,label,algorithm,purpose,module,active,sys_created_on,sys_updated_on",
+    },
+  })
+
+  const keys = ((response.data.result || []) as Array<Record<string, unknown>>).map((k) => ({
+    sys_id: k.sys_id,
+    name: k.name,
+    label: k.label,
+    algorithm: k.algorithm,
+    purpose: k.purpose,
+    module: k.module,
+    active: k.active,
+    created_at: k.sys_created_on,
+    updated_at: k.sys_updated_on,
+    url: `${context.instanceUrl}/nav_to.do?uri=sys_kmf_key.do?sys_id=${k.sys_id}`,
+  }))
+
+  return createSuccessResult({
+    action: "list_keys",
+    count: keys.length,
+    keys,
+  })
+}
+
+// ==================== ROTATE_KEY ====================
+
+async function executeRotateKey(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const key_sys_id = args.key_sys_id as string | undefined
+  const key_name = args.key_name as string | undefined
+  const retire_previous = args.retire_previous !== false
+
+  if (!key_sys_id && !key_name) {
+    return createErrorResult("key_sys_id or key_name is required for rotate_key action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const previous = await findKey(client, key_sys_id, key_name)
+  if (!previous) {
+    return createErrorResult(`Key not found: ${key_sys_id || key_name}`)
+  }
+
+  const previousSysId = previous.sys_id as string
+
+  // Create a new active key with the same name/algorithm/module but a versioned label.
+  // The platform's recommended pattern is "name + _vN"; if a version column exists, increment it.
+  // TODO: verify the canonical rotation API/columns against a live instance.
+  const newKeyPayload: Record<string, unknown> = {
+    module: previous.module,
+    name: previous.name,
+    label: `${previous.label || previous.name} (rotated)`,
+    algorithm: previous.algorithm,
+    purpose: previous.purpose,
+    active: true,
+  }
+  if (previous.version !== undefined) {
+    const versionAsNumber = Number(previous.version)
+    newKeyPayload.version = Number.isFinite(versionAsNumber) ? versionAsNumber + 1 : previous.version
+  }
+
+  const newResponse = await client.post("/api/now/table/sys_kmf_key", newKeyPayload)
+  const newKey = newResponse.data.result as Record<string, unknown>
+
+  if (retire_previous) {
+    await client.patch(`/api/now/table/sys_kmf_key/${previousSysId}`, { active: false })
+  }
+
+  return createSuccessResult({
+    action: "rotate_key",
+    rotated: true,
+    previous_sys_id: previousSysId,
+    previous_active: !retire_previous,
+    new_sys_id: newKey.sys_id,
+    new_key: {
+      sys_id: newKey.sys_id,
+      name: newKey.name,
+      label: newKey.label,
+      algorithm: newKey.algorithm,
+      active: newKey.active,
+    },
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"


### PR DESCRIPTION
## Summary

Adds five Tier 1 mega-tools to the unified MCP server. Each follows the
`snow_artifact_manage` pattern (single tool, action switch, per-action
helpers, `version` + `author` exports).

| Tool | Domain | Tables / Endpoints | Actions |
| --- | --- | --- | --- |
| `snow_pa_indicator_manage` | `performance-analytics/` | `pa_indicators`, `pa_breakdowns`, `pa_breakdowns_indicator` (join) | `list`, `get`, `create`, `update`, `delete`, `add_breakdown`, `list_breakdowns` |
| `snow_source_control` | `devops/` | `/api/sn_source_control/...`, `sys_repo_branch`, `sys_repo_stash`, `sys_repo_status` (fallbacks) | `status`, `push`, `pull`, `branch`, `commit`, `diff`, `stash` |
| `snow_job_status` | `scheduled-jobs/` | `sys_trigger`, `sys_progress_worker`, `sys_execution_tracker` | `list_active`, `get_status`, `get_history`, `get_errors` |
| `snow_kms_manage` | `security/` | `sys_kmf_module`, `sys_kmf_crypto_module`, `sys_kmf_key`, `/api/sn_kmf/{encrypt,decrypt}` (with `GlideEncrypter` fallback) | `list_modules`, `create_key`, `encrypt`, `decrypt`, `list_keys`, `rotate_key` |
| `snow_oncall_manage` | `schedules/` | `cmn_rota`, `cmn_rota_member`, `cmn_rota_roster`, `sys_user_group`, `sys_user` | `list_rotations`, `get_current_oncall`, `list_shifts`, `swap_shift` |

Each tool reuses `getAuthenticatedClient`, `createSuccessResult`,
`createErrorResult`, and `SnowFlowError` from `shared/`. No new
dependencies. All inline `GlideEncrypter` script strings inside
`snow_kms_manage` are ES5 (var, function, string concat).

Local `bun packages/opencode/script/generate-tools-json.ts` reported 401
tools (was 396), 0 failures. `tools.json` is left for the workflow to
regenerate.

## Verification status

Every action was built from documented ServiceNow surface area. None of
the five tools were exercised against a live instance. The following
paths are marked with `// TODO: verify against live instance` and need
empirical confirmation before merge:

- `pa_breakdowns_indicator` join table name (used in `get`, `delete`
  cascade, `add_breakdown`, `list_breakdowns`)
- `/api/sn_source_control/...` endpoint paths and request shapes for all
  seven Source Control actions
- `sys_repo_*` fallback table names (status, branches, stashes)
- `sys_kmf_key` field set (algorithm, purpose, version) and the
  `/api/sn_kmf/{encrypt,decrypt}` endpoint
- `sys_trigger` state codes and the `last_action_message` column used to
  surface errors
- `cmn_rota_roster.start_date_time` / `end_date_time` column names and
  `override` / `override_reason` columns

Plaintext and ciphertext payloads in `snow_kms_manage` are redacted from
error metadata before being returned to the agent.

## Test plan

- [ ] Run `bun packages/opencode/script/generate-tools-json.ts` and confirm count
- [ ] Smoke-boot the MCP server (`bun dev serve`) and call each tool's `list`/`status` action
- [ ] Against a live instance with PA enabled: create an indicator, attach a breakdown, retrieve it
- [ ] Against a live instance with the Source Control plugin: run `status` and `branch action=list` for a linked app
- [ ] Against a live instance: call `list_active` and confirm rows from each of the three job sources
- [ ] Against a live instance with KMF: create a key, encrypt+decrypt a short payload, rotate the key
- [ ] Against a live instance with OCS: list rotations, resolve current on-call for a known rotation

Fixes #113.