### PR TITLE
feat(opencode): add 3 Tier 2 unified tools (catalog, approvals, SP theming)

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/index.ts
@@ -10,3 +10,7 @@ export {
   toolDefinition as snow_get_pending_approvals_def,
   execute as snow_get_pending_approvals_exec,
 } from "./snow_get_pending_approvals.js"
+export {
+  toolDefinition as snow_approval_chain_manage_def,
+  execute as snow_approval_chain_manage_exec,
+} from "./snow_approval_chain_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/snow_approval_chain_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/snow_approval_chain_manage.ts
@@ -1,0 +1,504 @@
+/**
+ * snow_approval_chain_manage - Unified Approval Chain management
+ *
+ * Manages multi-step approval workflows over the ServiceNow approval engine
+ * tables: sysapproval_approver (per-approver request rows), sysapproval_group
+ * (group-based approval requests), and sysapproval_action (the verb history
+ * applied to an approval). Where snow_request_approval inserts a single
+ * ad-hoc approver, this tool defines an ordered chain, lets the caller
+ * preview the chain before firing it, lists currently pending approvals on
+ * a record, and cancels an in-flight chain.
+ *
+ * Companion to snow_request_approval (single ad-hoc approval),
+ * snow_approve_reject (acts on a single sysapproval_approver), and
+ * snow_get_pending_approvals (per-user inbox view).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+interface ChainStep {
+  approver?: string
+  group?: string
+  order?: number
+  comments?: string
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_approval_chain_manage",
+  description: `Unified tool for ServiceNow approval chains across the sysapproval_approver, sysapproval_group, and sysapproval_action tables. Use this when a record needs an ordered, multi-step approval flow rather than a single ad-hoc approver.
+
+Actions:
+- define_chain — write an ordered chain of approval steps for a source record. Each step may target a user (sysapproval_approver) or a group (sysapproval_group). Steps after the first start in 'not_yet_requested' state and are activated as earlier steps complete.
+- preview_chain — resolve who would be asked at each step (expanding group memberships) without inserting any rows. Useful for showing the caller the chain before firing it.
+- get_approvals — list all pending and historical approval rows for a given source record across both sysapproval_approver and sysapproval_group, plus the recent sysapproval_action verbs applied.
+- cancel — end an active chain. Marks every still-open approver/group row as 'cancelled' and records a sysapproval_action 'cancelled' verb on each.
+
+Use when: an agent needs to wire up a multi-step approval (e.g. peer → manager → director), preview the chain before committing, audit pending approvals on a record, or stop an in-flight chain. For a single ad-hoc approval use snow_request_approval; to act on an individual approval use snow_approve_reject.
+
+Returns: define_chain returns the inserted approval rows in order. preview_chain returns the resolved approver list per step without writing. get_approvals returns pending and complete rows plus the recent action verbs. cancel returns the rows it closed.`,
+  category: "itsm",
+  subcategory: "approvals",
+  use_cases: ["approvals", "workflow", "chain", "multi-step"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Approval chain action to perform",
+        enum: ["define_chain", "preview_chain", "get_approvals", "cancel"],
+      },
+      // Source record (target of the approval chain)
+      source_table: {
+        type: "string",
+        description: "[define_chain/preview_chain/get_approvals/cancel] Source table (e.g. change_request, sc_request, problem)",
+      },
+      source_sys_id: {
+        type: "string",
+        description: "[define_chain/preview_chain/get_approvals/cancel] Source record sys_id the chain attaches to",
+      },
+      // CHAIN definition
+      steps: {
+        type: "array",
+        description: "[define_chain/preview_chain] Ordered chain steps. Each step has approver (user sys_id) OR group (sys_user_group sys_id), optional order (defaults to array index * 100), and optional comments.",
+        items: {
+          type: "object",
+          properties: {
+            approver: { type: "string", description: "User sys_id (use for individual approver step)" },
+            group: { type: "string", description: "Group sys_id (use for group approval step)" },
+            order: { type: "number", description: "Explicit order/sequence; defaults to (index + 1) * 100" },
+            comments: { type: "string", description: "Optional comments stored on the approval row" },
+          },
+        },
+      },
+      activate_first: {
+        type: "boolean",
+        description: "[define_chain] Whether the first step is created in state 'requested' (active) or 'not_yet_requested' (queued). Defaults to true.",
+        default: true,
+      },
+      // CANCEL
+      cancel_comment: {
+        type: "string",
+        description: "[cancel] Comment recorded on each closed approval row and on the matching sysapproval_action verb",
+      },
+      // GET_APPROVALS filters
+      include_complete: {
+        type: "boolean",
+        description: "[get_approvals] Include approver/group rows that are already approved/rejected/cancelled",
+        default: false,
+      },
+      include_actions: {
+        type: "boolean",
+        description: "[get_approvals] Include recent sysapproval_action verb history for the source record",
+        default: true,
+      },
+      limit: {
+        type: "number",
+        description: "[get_approvals] Maximum rows to return per table",
+        default: 50,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "define_chain":
+        return await executeDefineChain(args, context)
+      case "preview_chain":
+        return await executePreviewChain(args, context)
+      case "get_approvals":
+        return await executeGetApprovals(args, context)
+      case "cancel":
+        return await executeCancel(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: define_chain, preview_chain, get_approvals, cancel`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `Approval chain ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function readSteps(args: Record<string, unknown>): ChainStep[] | null {
+  const raw = args.steps
+  if (!Array.isArray(raw) || raw.length === 0) return null
+  return raw as ChainStep[]
+}
+
+function validateSteps(steps: ChainStep[]): string | null {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    if (!step || typeof step !== "object") return `Step ${i + 1} is malformed`
+    if (!step.approver && !step.group) {
+      return `Step ${i + 1} requires either approver (user sys_id) or group (sys_user_group sys_id)`
+    }
+    if (step.approver && step.group) {
+      return `Step ${i + 1} cannot specify both approver and group — pick one`
+    }
+  }
+  return null
+}
+
+// ==================== DEFINE_CHAIN ====================
+
+async function executeDefineChain(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const source_table = args.source_table as string | undefined
+  const source_sys_id = args.source_sys_id as string | undefined
+  const steps = readSteps(args)
+  const activateFirst = args.activate_first === undefined ? true : args.activate_first === true
+
+  if (!source_table) return createErrorResult("source_table is required for define_chain")
+  if (!source_sys_id) return createErrorResult("source_sys_id is required for define_chain")
+  if (!steps) return createErrorResult("steps is required for define_chain (non-empty array)")
+
+  const stepError = validateSteps(steps)
+  if (stepError) return createErrorResult(stepError)
+
+  const client = await getAuthenticatedClient(context)
+
+  const insertedApprovers: Array<Record<string, unknown>> = []
+  const insertedGroups: Array<Record<string, unknown>> = []
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    const order = typeof step.order === "number" ? step.order : (i + 1) * 100
+    const isFirst = i === 0
+    const stepState = isFirst && activateFirst ? "requested" : "not_yet_requested"
+
+    if (step.approver) {
+      const payload: Record<string, unknown> = {
+        source_table,
+        sysapproval: source_sys_id,
+        approver: step.approver,
+        state: stepState,
+        order,
+      }
+      if (step.comments) payload.comments = step.comments
+      const resp = await client.post("/api/now/table/sysapproval_approver", payload)
+      insertedApprovers.push(resp.data.result)
+    } else if (step.group) {
+      // TODO: verify against live instance — older versions use the column
+      // `group` while newer ones expose `approval_group`. We try `group` first
+      // since it matches the OOB sysapproval_group table.
+      const payload: Record<string, unknown> = {
+        source_table,
+        document_id: source_sys_id,
+        group: step.group,
+        state: stepState,
+        order,
+      }
+      if (step.comments) payload.comments = step.comments
+      const resp = await client.post("/api/now/table/sysapproval_group", payload)
+      insertedGroups.push(resp.data.result)
+    }
+  }
+
+  return createSuccessResult({
+    action: "define_chain",
+    created: true,
+    source_table,
+    source_sys_id,
+    step_count: insertedApprovers.length + insertedGroups.length,
+    approver_rows: insertedApprovers.map((r) => ({
+      sys_id: r.sys_id,
+      approver: r.approver,
+      state: r.state,
+      order: r.order,
+    })),
+    group_rows: insertedGroups.map((r) => ({
+      sys_id: r.sys_id,
+      group: (r as Record<string, unknown>).group ?? (r as Record<string, unknown>).approval_group,
+      state: r.state,
+      order: r.order,
+    })),
+  })
+}
+
+// ==================== PREVIEW_CHAIN ====================
+
+async function executePreviewChain(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const steps = readSteps(args)
+  if (!steps) return createErrorResult("steps is required for preview_chain (non-empty array)")
+  const stepError = validateSteps(steps)
+  if (stepError) return createErrorResult(stepError)
+
+  const client = await getAuthenticatedClient(context)
+
+  const resolved: Array<Record<string, unknown>> = []
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    const order = typeof step.order === "number" ? step.order : (i + 1) * 100
+
+    if (step.approver) {
+      let userName = step.approver
+      try {
+        const userResp = await client.get(`/api/now/table/sys_user/${step.approver}`, {
+          params: { sysparm_fields: "sys_id,name,email,active" },
+        })
+        const u = userResp.data.result as Record<string, unknown> | undefined
+        if (u && u.name) userName = u.name as string
+        resolved.push({
+          step: i + 1,
+          order,
+          type: "user",
+          approver_sys_id: step.approver,
+          name: userName,
+          email: u?.email ?? null,
+          active: u?.active ?? null,
+          comments: step.comments ?? null,
+        })
+      } catch {
+        resolved.push({
+          step: i + 1,
+          order,
+          type: "user",
+          approver_sys_id: step.approver,
+          name: null,
+          warning: "User not found on this instance",
+          comments: step.comments ?? null,
+        })
+      }
+    } else if (step.group) {
+      // Expand group membership to show who would actually be asked.
+      const members: Array<Record<string, unknown>> = []
+      try {
+        // TODO: verify against live instance — sys_user_grmember is the OOB
+        // membership join; some installs add an active filter at the join.
+        const memResp = await client.get("/api/now/table/sys_user_grmember", {
+          params: {
+            sysparm_query: `group=${step.group}`,
+            sysparm_fields: "user.sys_id,user.name,user.email,user.active",
+            sysparm_limit: 50,
+          },
+        })
+        const rows = (memResp.data.result || []) as Array<Record<string, unknown>>
+        for (const row of rows) {
+          members.push({
+            sys_id: row["user.sys_id"],
+            name: row["user.name"],
+            email: row["user.email"],
+            active: row["user.active"],
+          })
+        }
+      } catch {
+        // Membership lookup is best-effort
+      }
+      let groupName: string | null = null
+      try {
+        const gResp = await client.get(`/api/now/table/sys_user_group/${step.group}`, {
+          params: { sysparm_fields: "sys_id,name,active" },
+        })
+        const g = gResp.data.result as Record<string, unknown> | undefined
+        groupName = (g?.name as string) ?? null
+      } catch {
+        // Best-effort
+      }
+      resolved.push({
+        step: i + 1,
+        order,
+        type: "group",
+        group_sys_id: step.group,
+        name: groupName,
+        member_count: members.length,
+        members,
+        comments: step.comments ?? null,
+      })
+    }
+  }
+
+  return createSuccessResult({
+    action: "preview_chain",
+    step_count: resolved.length,
+    chain: resolved,
+  })
+}
+
+// ==================== GET_APPROVALS ====================
+
+async function executeGetApprovals(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const source_table = args.source_table as string | undefined
+  const source_sys_id = args.source_sys_id as string | undefined
+  const include_complete = args.include_complete === true
+  const include_actions = args.include_actions === undefined ? true : args.include_actions === true
+  const limit = (args.limit as number) || 50
+
+  if (!source_sys_id) return createErrorResult("source_sys_id is required for get_approvals")
+
+  const client = await getAuthenticatedClient(context)
+
+  const stateFilter = include_complete ? "" : "^stateIN requested,not_yet_requested"
+
+  // Per-user approver rows
+  const approverQueryParts = [`sysapproval=${source_sys_id}`]
+  if (source_table) approverQueryParts.push(`source_table=${source_table}`)
+  const approverQuery = approverQueryParts.join("^") + stateFilter
+
+  const approverResp = await client.get("/api/now/table/sysapproval_approver", {
+    params: {
+      sysparm_query: approverQuery,
+      sysparm_limit: limit,
+      sysparm_orderby: "order",
+      sysparm_display_value: "true",
+    },
+  })
+  const approverRows = (approverResp.data.result || []) as Array<Record<string, unknown>>
+
+  // Group approval rows
+  // TODO: verify against live instance — the column linking sysapproval_group
+  // to a record varies (document_id vs sysapproval) between releases.
+  const groupQueryParts = [`document_id=${source_sys_id}`]
+  if (source_table) groupQueryParts.push(`source_table=${source_table}`)
+  const groupQuery = groupQueryParts.join("^") + stateFilter
+
+  let groupRows: Array<Record<string, unknown>> = []
+  try {
+    const groupResp = await client.get("/api/now/table/sysapproval_group", {
+      params: {
+        sysparm_query: groupQuery,
+        sysparm_limit: limit,
+        sysparm_orderby: "order",
+        sysparm_display_value: "true",
+      },
+    })
+    groupRows = (groupResp.data.result || []) as Array<Record<string, unknown>>
+  } catch {
+    // sysapproval_group not present or query column differs; skip silently
+  }
+
+  // Recent action verbs
+  let actions: Array<Record<string, unknown>> = []
+  if (include_actions) {
+    try {
+      // TODO: verify against live instance — sysapproval_action is the audit
+      // table for approval verbs; the link column may be `sysapproval` or
+      // `document_id` depending on platform version.
+      const actionsResp = await client.get("/api/now/table/sysapproval_action", {
+        params: {
+          sysparm_query: `document_id=${source_sys_id}^ORsysapproval=${source_sys_id}`,
+          sysparm_limit: limit,
+          sysparm_orderby: "sys_created_on",
+          sysparm_order: "desc",
+          sysparm_display_value: "true",
+        },
+      })
+      actions = (actionsResp.data.result || []) as Array<Record<string, unknown>>
+    } catch {
+      // Best-effort
+    }
+  }
+
+  return createSuccessResult({
+    action: "get_approvals",
+    source_table,
+    source_sys_id,
+    approver_count: approverRows.length,
+    group_count: groupRows.length,
+    action_count: actions.length,
+    approvers: approverRows,
+    groups: groupRows,
+    actions,
+  })
+}
+
+// ==================== CANCEL ====================
+
+async function executeCancel(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const source_table = args.source_table as string | undefined
+  const source_sys_id = args.source_sys_id as string | undefined
+  const comment = args.cancel_comment as string | undefined
+
+  if (!source_sys_id) return createErrorResult("source_sys_id is required for cancel")
+
+  const client = await getAuthenticatedClient(context)
+
+  const cancelledApprovers: Array<Record<string, unknown>> = []
+  const cancelledGroups: Array<Record<string, unknown>> = []
+
+  // Cancel per-user rows that are still open
+  const approverQueryParts = [`sysapproval=${source_sys_id}`, "stateIN requested,not_yet_requested"]
+  if (source_table) approverQueryParts.push(`source_table=${source_table}`)
+  const approverResp = await client.get("/api/now/table/sysapproval_approver", {
+    params: {
+      sysparm_query: approverQueryParts.join("^"),
+      sysparm_limit: 500,
+      sysparm_fields: "sys_id,approver,state,order",
+    },
+  })
+  for (const row of (approverResp.data.result || []) as Array<Record<string, unknown>>) {
+    const patch: Record<string, unknown> = { state: "cancelled" }
+    if (comment) patch.comments = comment
+    const upd = await client.patch(`/api/now/table/sysapproval_approver/${row.sys_id}`, patch)
+    cancelledApprovers.push({ sys_id: row.sys_id, state: upd.data.result.state })
+  }
+
+  // Cancel group rows that are still open
+  try {
+    const groupQueryParts = [`document_id=${source_sys_id}`, "stateIN requested,not_yet_requested"]
+    if (source_table) groupQueryParts.push(`source_table=${source_table}`)
+    const groupResp = await client.get("/api/now/table/sysapproval_group", {
+      params: {
+        sysparm_query: groupQueryParts.join("^"),
+        sysparm_limit: 500,
+        sysparm_fields: "sys_id,state,order",
+      },
+    })
+    for (const row of (groupResp.data.result || []) as Array<Record<string, unknown>>) {
+      const patch: Record<string, unknown> = { state: "cancelled" }
+      if (comment) patch.comments = comment
+      const upd = await client.patch(`/api/now/table/sysapproval_group/${row.sys_id}`, patch)
+      cancelledGroups.push({ sys_id: row.sys_id, state: upd.data.result.state })
+    }
+  } catch {
+    // sysapproval_group may be absent on this instance
+  }
+
+  // Record a cancellation verb in the audit table (best-effort)
+  let actionRow: Record<string, unknown> | null = null
+  try {
+    const actionPayload: Record<string, unknown> = {
+      document_id: source_sys_id,
+      action: "cancelled",
+    }
+    if (source_table) actionPayload.source_table = source_table
+    if (comment) actionPayload.comments = comment
+    const actionResp = await client.post("/api/now/table/sysapproval_action", actionPayload)
+    actionRow = actionResp.data.result
+  } catch {
+    // sysapproval_action insert is best-effort; the per-row cancel above is the source of truth
+  }
+
+  return createSuccessResult({
+    action: "cancel",
+    cancelled: true,
+    source_table,
+    source_sys_id,
+    cancelled_approvers: cancelledApprovers,
+    cancelled_groups: cancelledGroups,
+    action_logged: actionRow !== null,
+    action_row: actionRow,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/index.ts
@@ -29,3 +29,7 @@ export {
   toolDefinition as snow_search_catalog_def,
   execute as snow_search_catalog_exec,
 } from "./snow_search_catalog.js"
+export {
+  toolDefinition as snow_catalog_manage_def,
+  execute as snow_catalog_manage_exec,
+} from "./snow_catalog_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/snow_catalog_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/snow_catalog_manage.ts
@@ -1,0 +1,504 @@
+/**
+ * snow_catalog_manage - Unified Service Catalog structure management
+ *
+ * Manages the catalog patterns that snow_create_catalog_item does not cover:
+ * order guides (sc_cat_item_guide), record producers (sc_cat_item_producer),
+ * catalog categories (sc_category), and the item-to-category junction
+ * (sc_cat_item_category). These are the structural pieces that group and
+ * route catalog items — the items themselves are still authored by
+ * snow_create_catalog_item.
+ *
+ * Companion to snow_create_catalog_item (sc_cat_item authoring),
+ * snow_discover_catalogs (catalog topology discovery), and
+ * snow_create_catalog_ui_policy / snow_create_catalog_client_script
+ * (per-item variable behavior).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_catalog_manage",
+  description: `Unified tool for ServiceNow Service Catalog structure: order guides, record producers, categories, and the item-to-category junction. Wraps the sc_cat_item_guide, sc_cat_item_producer, sc_category, and sc_cat_item_category tables.
+
+Actions:
+- create_order_guide — create a new order guide (sc_cat_item_guide) that bundles related catalog items into a single guided flow
+- list_order_guides — list order guides, optionally filtered by catalog
+- create_record_producer — create a record producer (sc_cat_item_producer) that surfaces as a catalog item but writes to a non-request target table (incident, change_request, etc.)
+- list_record_producers — list record producers, optionally filtered by target table
+- list_categories — list catalog categories (sc_category), optionally filtered by catalog or parent
+- create_category — create a catalog category to organize items into a navigable tree
+- link_item_to_category — attach a catalog item to a category through the sc_cat_item_category junction (items can live in multiple categories)
+
+Use when: the agent needs to organize catalog items into guides or categories, or expose a record-creation form (record producer) outside the standard requested-item flow. For the catalog items themselves use snow_create_catalog_item; for ordering an existing item use snow_order_catalog_item.
+
+Returns: created or queried records with sys_id, name, and the relevant references (sc_catalogs, category, table_name). Junction inserts return the sc_cat_item_category link sys_id so it can be removed later.`,
+  category: "itsm",
+  subcategory: "service-catalog",
+  use_cases: ["service-catalog", "order-guides", "record-producers", "categories"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Catalog structure action to perform",
+        enum: [
+          "create_order_guide",
+          "list_order_guides",
+          "create_record_producer",
+          "list_record_producers",
+          "list_categories",
+          "create_category",
+          "link_item_to_category",
+        ],
+      },
+      // ORDER GUIDE / RECORD PRODUCER / CATEGORY common fields
+      name: {
+        type: "string",
+        description: "[create_order_guide/create_record_producer/create_category] Display name",
+      },
+      short_description: {
+        type: "string",
+        description: "[create_order_guide/create_record_producer/create_category] Short description shown on the catalog tile",
+      },
+      description: {
+        type: "string",
+        description: "[create_order_guide/create_record_producer/create_category] Long description / overview",
+      },
+      sc_catalogs: {
+        type: "string",
+        description: "[create_order_guide/create_record_producer/create_category/list_*] Catalog sys_id (sc_catalog) to attach to or filter by",
+      },
+      category: {
+        type: "string",
+        description: "[create_order_guide/create_record_producer] Initial sc_category sys_id (use link_item_to_category to add more later)",
+      },
+      active: {
+        type: "boolean",
+        description: "[create_order_guide/create_record_producer/create_category] Whether the record is active",
+        default: true,
+      },
+      // ORDER GUIDE specific
+      include_items: {
+        type: "boolean",
+        description: "[create_order_guide] Whether items are pre-selected for the requester (sc_cat_item_guide.include_items)",
+        default: true,
+      },
+      // RECORD PRODUCER specific
+      table_name: {
+        type: "string",
+        description: "[create_record_producer/list_record_producers] Target table the producer writes to (e.g. incident, change_request, problem)",
+      },
+      script: {
+        type: "string",
+        description: "[create_record_producer] Server-side script that maps producer variables to the target record. ES5 only — use var, function(), and string concatenation; no const/let/arrow/template literals",
+      },
+      // CATEGORY specific
+      parent: {
+        type: "string",
+        description: "[create_category/list_categories] Parent sc_category sys_id (for nested categories) or filter",
+      },
+      title: {
+        type: "string",
+        description: "[create_category] Category display title (defaults to name)",
+      },
+      // LINK_ITEM_TO_CATEGORY
+      cat_item: {
+        type: "string",
+        description: "[link_item_to_category] Catalog item sys_id (sc_cat_item) to link",
+      },
+      category_sys_id: {
+        type: "string",
+        description: "[link_item_to_category] Category sys_id (sc_category) to link the item to",
+      },
+      // LIST common
+      active_only: {
+        type: "boolean",
+        description: "[list_*] Only return active records",
+        default: false,
+      },
+      limit: {
+        type: "number",
+        description: "[list_*] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_*] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "create_order_guide":
+        return await executeCreateOrderGuide(args, context)
+      case "list_order_guides":
+        return await executeListOrderGuides(args, context)
+      case "create_record_producer":
+        return await executeCreateRecordProducer(args, context)
+      case "list_record_producers":
+        return await executeListRecordProducers(args, context)
+      case "list_categories":
+        return await executeListCategories(args, context)
+      case "create_category":
+        return await executeCreateCategory(args, context)
+      case "link_item_to_category":
+        return await executeLinkItemToCategory(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: create_order_guide, list_order_guides, create_record_producer, list_record_producers, list_categories, create_category, link_item_to_category`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `Catalog ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== CREATE_ORDER_GUIDE ====================
+
+async function executeCreateOrderGuide(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  if (!name) return createErrorResult("name is required for create_order_guide")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Reject duplicate by name within the same catalog (if a catalog is specified)
+  const dedupeQuery = args.sc_catalogs
+    ? `name=${name}^sc_catalogsLIKE${args.sc_catalogs}`
+    : `name=${name}`
+  const existing = await client.get("/api/now/table/sc_cat_item_guide", {
+    params: { sysparm_query: dedupeQuery, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((existing.data.result || []).length > 0) {
+    return createErrorResult(`Order guide '${name}' already exists in this catalog`)
+  }
+
+  const payload: Record<string, unknown> = {
+    name,
+    short_description: (args.short_description as string) || "",
+    description: (args.description as string) || "",
+    active: args.active === undefined ? true : args.active,
+    include_items: args.include_items === undefined ? true : args.include_items,
+  }
+  if (args.sc_catalogs) payload.sc_catalogs = args.sc_catalogs
+  if (args.category) payload.category = args.category
+
+  const response = await client.post("/api/now/table/sc_cat_item_guide", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_order_guide",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    order_guide: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=sc_cat_item_guide.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LIST_ORDER_GUIDES ====================
+
+async function executeListOrderGuides(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sc_catalogs = args.sc_catalogs as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (sc_catalogs) queryParts.push(`sc_catalogsLIKE${sc_catalogs}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get("/api/now/table/sc_cat_item_guide", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,name,short_description,sc_catalogs,category,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_order_guides",
+    count: results.length,
+    order_guides: results.map((r) => ({
+      sys_id: r.sys_id,
+      name: r.name,
+      short_description: r.short_description,
+      sc_catalogs: r.sc_catalogs,
+      category: r.category,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=sc_cat_item_guide.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== CREATE_RECORD_PRODUCER ====================
+
+async function executeCreateRecordProducer(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  const table_name = args.table_name as string | undefined
+
+  if (!name) return createErrorResult("name is required for create_record_producer")
+  if (!table_name) {
+    return createErrorResult("table_name is required for create_record_producer (target table the producer writes to)")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Reject duplicate by name (record producer names are commonly unique per catalog)
+  const existing = await client.get("/api/now/table/sc_cat_item_producer", {
+    params: { sysparm_query: `name=${name}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((existing.data.result || []).length > 0) {
+    return createErrorResult(`Record producer '${name}' already exists. Use snow_artifact_manage to update it.`)
+  }
+
+  const payload: Record<string, unknown> = {
+    name,
+    short_description: (args.short_description as string) || "",
+    description: (args.description as string) || "",
+    table_name,
+    active: args.active === undefined ? true : args.active,
+  }
+  if (args.script) payload.script = args.script
+  if (args.sc_catalogs) payload.sc_catalogs = args.sc_catalogs
+  if (args.category) payload.category = args.category
+
+  // TODO: verify against live instance — some platforms also require `type` or
+  // `sys_class_name` to differentiate the producer from a generic sc_cat_item.
+  const response = await client.post("/api/now/table/sc_cat_item_producer", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_record_producer",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    table_name: created.table_name,
+    record_producer: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=sc_cat_item_producer.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LIST_RECORD_PRODUCERS ====================
+
+async function executeListRecordProducers(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const table_name = args.table_name as string | undefined
+  const sc_catalogs = args.sc_catalogs as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (table_name) queryParts.push(`table_name=${table_name}`)
+  if (sc_catalogs) queryParts.push(`sc_catalogsLIKE${sc_catalogs}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get("/api/now/table/sc_cat_item_producer", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,name,short_description,table_name,sc_catalogs,category,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_record_producers",
+    count: results.length,
+    record_producers: results.map((r) => ({
+      sys_id: r.sys_id,
+      name: r.name,
+      short_description: r.short_description,
+      table_name: r.table_name,
+      sc_catalogs: r.sc_catalogs,
+      category: r.category,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=sc_cat_item_producer.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== LIST_CATEGORIES ====================
+
+async function executeListCategories(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sc_catalogs = args.sc_catalogs as string | undefined
+  const parent = args.parent as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (sc_catalogs) queryParts.push(`sc_catalog=${sc_catalogs}`)
+  if (parent) queryParts.push(`parent=${parent}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get("/api/now/table/sc_category", {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "title",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,title,description,sc_catalog,parent,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_categories",
+    count: results.length,
+    categories: results.map((r) => ({
+      sys_id: r.sys_id,
+      title: r.title,
+      description: r.description,
+      sc_catalog: r.sc_catalog,
+      parent: r.parent,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=sc_category.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== CREATE_CATEGORY ====================
+
+async function executeCreateCategory(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  const title = (args.title as string | undefined) || name
+  if (!name) return createErrorResult("name is required for create_category")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Reject duplicates within the same catalog when one is specified
+  const dedupeQuery = args.sc_catalogs
+    ? `title=${title}^sc_catalog=${args.sc_catalogs}`
+    : `title=${title}`
+  const existing = await client.get("/api/now/table/sc_category", {
+    params: { sysparm_query: dedupeQuery, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((existing.data.result || []).length > 0) {
+    return createErrorResult(`Category '${title}' already exists in this catalog`)
+  }
+
+  const payload: Record<string, unknown> = {
+    title,
+    description: (args.description as string) || (args.short_description as string) || "",
+    active: args.active === undefined ? true : args.active,
+  }
+  if (args.sc_catalogs) payload.sc_catalog = args.sc_catalogs
+  if (args.parent) payload.parent = args.parent
+
+  const response = await client.post("/api/now/table/sc_category", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_category",
+    created: true,
+    sys_id: created.sys_id,
+    title: created.title,
+    category: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=sc_category.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LINK_ITEM_TO_CATEGORY ====================
+
+async function executeLinkItemToCategory(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const cat_item = args.cat_item as string | undefined
+  const category_sys_id = args.category_sys_id as string | undefined
+
+  if (!cat_item) return createErrorResult("cat_item is required (sc_cat_item sys_id)")
+  if (!category_sys_id) return createErrorResult("category_sys_id is required (sc_category sys_id)")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Avoid duplicate junction rows
+  const existing = await client.get("/api/now/table/sc_cat_item_category", {
+    params: {
+      sysparm_query: `sc_cat_item=${cat_item}^sc_category=${category_sys_id}`,
+      sysparm_limit: 1,
+      sysparm_fields: "sys_id",
+    },
+  })
+  const dup = (existing.data.result || []) as Array<Record<string, unknown>>
+  if (dup.length > 0) {
+    return createSuccessResult({
+      action: "link_item_to_category",
+      created: false,
+      already_linked: true,
+      link_sys_id: dup[0].sys_id,
+      cat_item,
+      category_sys_id,
+    })
+  }
+
+  // TODO: verify against live instance — on some platforms the junction
+  // columns are named `sc_cat_item` and `sc_category`, on others `cat_item`
+  // and `category`. We use the more common short-name pair and surface any
+  // server-side error verbatim.
+  const response = await client.post("/api/now/table/sc_cat_item_category", {
+    sc_cat_item: cat_item,
+    sc_category: category_sys_id,
+  })
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "link_item_to_category",
+    created: true,
+    link_sys_id: created.sys_id,
+    cat_item,
+    category_sys_id,
+    junction: created,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/index.ts
@@ -6,3 +6,7 @@ export {
   toolDefinition as snow_create_sp_page_def,
   execute as snow_create_sp_page_exec,
 } from "./snow_create_sp_page.js"
+export {
+  toolDefinition as snow_sp_theme_manage_def,
+  execute as snow_sp_theme_manage_exec,
+} from "./snow_sp_theme_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_theme_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_theme_manage.ts
@@ -1,0 +1,451 @@
+/**
+ * snow_sp_theme_manage - Unified Service Portal theme management
+ *
+ * Manages the visual identity of ServiceNow Service Portals across the
+ * sp_theme (theme definitions), sp_brand (per-portal branding records),
+ * sp_css (theme stylesheets), and sp_portal (portal records that reference
+ * a theme) tables. Designed for white-labeling and multi-tenant scenarios
+ * where the same portal codebase needs to render differently per customer.
+ *
+ * Companion to snow_create_sp_widget and snow_create_sp_page (which author
+ * the per-portal content) — this tool covers the look-and-feel layer.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_sp_theme_manage",
+  description: `Unified tool for ServiceNow Service Portal theming. Operates over sp_theme (theme definitions), sp_brand (per-portal branding records such as logo and favicon), sp_css (theme-scoped stylesheets), and sp_portal (the portal records that reference a theme).
+
+Actions:
+- list_themes — list all sp_theme records with their name, header, footer, and CSS variable bundle
+- create_theme — create a new sp_theme with name, css_variables, header, and footer
+- update_branding — upsert an sp_brand row (logo, favicon, color tokens) for a given portal; existing brand rows are patched in place, otherwise a new row is inserted
+- clone_theme — duplicate an existing sp_theme (and its sp_css children) under a new name so a per-tenant variant can be edited independently of the source
+- apply_theme_to_portal — set sp_portal.theme to a given theme sys_id so the portal renders with the new look on the next page load
+
+Use when: rolling out white-labeled portals per tenant, building a base theme + per-customer overlays, or migrating an existing portal onto a redesigned theme without rewriting the underlying widgets. Companion tools: snow_create_sp_widget for content, snow_create_sp_page for page composition.
+
+Returns: action-specific structures. list_themes returns theme rows with related CSS counts. create_theme and clone_theme return the new sys_id plus the copied sp_css rows. update_branding indicates whether the row was inserted or patched. apply_theme_to_portal returns the updated sp_portal record.`,
+  category: "ui-frameworks",
+  subcategory: "service-portal",
+  use_cases: ["service-portal", "theming", "branding", "white-label", "multi-tenant"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Theme management action to perform",
+        enum: [
+          "list_themes",
+          "create_theme",
+          "update_branding",
+          "clone_theme",
+          "apply_theme_to_portal",
+        ],
+      },
+      // THEME identification
+      theme_sys_id: {
+        type: "string",
+        description: "[clone_theme/apply_theme_to_portal] sys_id of the source or target sp_theme",
+      },
+      theme_name: {
+        type: "string",
+        description: "[clone_theme/apply_theme_to_portal] Theme name (used when theme_sys_id is not provided)",
+      },
+      // CREATE_THEME / CLONE_THEME
+      name: {
+        type: "string",
+        description: "[create_theme/clone_theme] Name for the new theme",
+      },
+      css_variables: {
+        type: "string",
+        description: "[create_theme] CSS variables block (e.g. --brand-primary: #ff6600;) compiled into the theme",
+      },
+      header: {
+        type: "string",
+        description: "[create_theme] Header widget id or HTML reference (defaults to OOB stock-header)",
+      },
+      footer: {
+        type: "string",
+        description: "[create_theme] Footer widget id or HTML reference (defaults to OOB stock-footer)",
+      },
+      copy_css: {
+        type: "boolean",
+        description: "[clone_theme] Also copy the source theme's sp_css children",
+        default: true,
+      },
+      // UPDATE_BRANDING
+      portal: {
+        type: "string",
+        description: "[update_branding/apply_theme_to_portal] sp_portal sys_id (or unique URL suffix) to brand or to apply the theme to",
+      },
+      logo: {
+        type: "string",
+        description: "[update_branding] Logo image URL or sys_attachment sys_id",
+      },
+      favicon: {
+        type: "string",
+        description: "[update_branding] Favicon URL or sys_attachment sys_id",
+      },
+      primary_color: {
+        type: "string",
+        description: "[update_branding] Primary brand color (hex, e.g. #1f6feb)",
+      },
+      secondary_color: {
+        type: "string",
+        description: "[update_branding] Secondary brand color (hex)",
+      },
+      brand_name: {
+        type: "string",
+        description: "[update_branding] Display brand name shown in headers and tab titles",
+      },
+      // LIST
+      limit: {
+        type: "number",
+        description: "[list_themes] Maximum themes to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_themes] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_themes":
+        return await executeListThemes(args, context)
+      case "create_theme":
+        return await executeCreateTheme(args, context)
+      case "update_branding":
+        return await executeUpdateBranding(args, context)
+      case "clone_theme":
+        return await executeCloneTheme(args, context)
+      case "apply_theme_to_portal":
+        return await executeApplyThemeToPortal(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_themes, create_theme, update_branding, clone_theme, apply_theme_to_portal`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `SP theme ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findTheme(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  name: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    try {
+      const direct = await client.get(`/api/now/table/sp_theme/${sysId}`)
+      if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+    } catch {
+      // fall through to name lookup
+    }
+  }
+  if (name) {
+    const search = await client.get("/api/now/table/sp_theme", {
+      params: { sysparm_query: `name=${name}`, sysparm_limit: 1 },
+    })
+    const rows = (search.data.result || []) as Array<Record<string, unknown>>
+    if (rows.length > 0) return rows[0]
+  }
+  return null
+}
+
+async function findPortal(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  portal: string,
+): Promise<Record<string, unknown> | null> {
+  // Try by sys_id first, then by URL suffix
+  try {
+    const direct = await client.get(`/api/now/table/sp_portal/${portal}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  } catch {
+    // fall through
+  }
+  const search = await client.get("/api/now/table/sp_portal", {
+    params: { sysparm_query: `url_suffix=${portal}^ORtitle=${portal}`, sysparm_limit: 1 },
+  })
+  const rows = (search.data.result || []) as Array<Record<string, unknown>>
+  return rows.length > 0 ? rows[0] : null
+}
+
+// ==================== LIST_THEMES ====================
+
+async function executeListThemes(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const response = await client.get("/api/now/table/sp_theme", {
+    params: {
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,name,header,footer,css_variables,sys_updated_on" }),
+    },
+  })
+
+  const themes = (response.data.result || []) as Array<Record<string, unknown>>
+
+  // Annotate each theme with its sp_css child count (best-effort)
+  const enriched: Array<Record<string, unknown>> = []
+  for (const theme of themes) {
+    let cssCount = 0
+    try {
+      const cssResp = await client.get("/api/now/table/sp_css", {
+        params: { sysparm_query: `theme=${theme.sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 100 },
+      })
+      cssCount = (cssResp.data.result || []).length
+    } catch {
+      // best-effort
+    }
+    enriched.push({
+      sys_id: theme.sys_id,
+      name: theme.name,
+      header: theme.header,
+      footer: theme.footer,
+      css_variables: theme.css_variables,
+      sp_css_count: cssCount,
+      updated_at: theme.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=sp_theme.do?sys_id=${theme.sys_id}`,
+    })
+  }
+
+  return createSuccessResult({
+    action: "list_themes",
+    count: enriched.length,
+    themes: enriched,
+  })
+}
+
+// ==================== CREATE_THEME ====================
+
+async function executeCreateTheme(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  if (!name) return createErrorResult("name is required for create_theme")
+
+  const client = await getAuthenticatedClient(context)
+
+  const existing = await client.get("/api/now/table/sp_theme", {
+    params: { sysparm_query: `name=${name}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((existing.data.result || []).length > 0) {
+    return createErrorResult(`Theme '${name}' already exists. Use clone_theme for a variant.`)
+  }
+
+  const payload: Record<string, unknown> = { name }
+  if (args.css_variables) payload.css_variables = args.css_variables
+  if (args.header) payload.header = args.header
+  if (args.footer) payload.footer = args.footer
+
+  const response = await client.post("/api/now/table/sp_theme", payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_theme",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    theme: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=sp_theme.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== UPDATE_BRANDING ====================
+
+async function executeUpdateBranding(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const portalRef = args.portal as string | undefined
+  if (!portalRef) return createErrorResult("portal is required for update_branding (sp_portal sys_id or url_suffix)")
+
+  const client = await getAuthenticatedClient(context)
+
+  const portal = await findPortal(client, portalRef)
+  if (!portal) return createErrorResult(`Portal not found: ${portalRef}`)
+
+  const portalSysId = portal.sys_id as string
+
+  // TODO: verify against live instance — sp_brand carries portal-specific
+  // branding overrides. The link column is commonly `portal`; on some
+  // releases it is `sp_portal`. We attempt to read the existing row and
+  // patch it; otherwise we insert.
+  const brandPayload: Record<string, unknown> = { portal: portalSysId }
+  if (args.logo !== undefined) brandPayload.logo = args.logo
+  if (args.favicon !== undefined) brandPayload.favicon = args.favicon
+  if (args.primary_color !== undefined) brandPayload.primary_color = args.primary_color
+  if (args.secondary_color !== undefined) brandPayload.secondary_color = args.secondary_color
+  if (args.brand_name !== undefined) brandPayload.name = args.brand_name
+
+  const existingBrand = await client.get("/api/now/table/sp_brand", {
+    params: { sysparm_query: `portal=${portalSysId}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  const existingRows = (existingBrand.data.result || []) as Array<Record<string, unknown>>
+
+  let brand: Record<string, unknown>
+  let mode: "inserted" | "patched"
+
+  if (existingRows.length > 0) {
+    mode = "patched"
+    const brandSysId = existingRows[0].sys_id as string
+    const updResp = await client.patch(`/api/now/table/sp_brand/${brandSysId}`, brandPayload)
+    brand = updResp.data.result
+  } else {
+    mode = "inserted"
+    const insResp = await client.post("/api/now/table/sp_brand", brandPayload)
+    brand = insResp.data.result
+  }
+
+  return createSuccessResult({
+    action: "update_branding",
+    mode,
+    portal: { sys_id: portalSysId, title: portal.title, url_suffix: portal.url_suffix },
+    sys_id: brand.sys_id,
+    brand,
+    url: `${context.instanceUrl}/nav_to.do?uri=sp_brand.do?sys_id=${brand.sys_id}`,
+  })
+}
+
+// ==================== CLONE_THEME ====================
+
+async function executeCloneTheme(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sourceSysId = args.theme_sys_id as string | undefined
+  const sourceName = args.theme_name as string | undefined
+  const newName = args.name as string | undefined
+  const copyCss = args.copy_css === undefined ? true : args.copy_css === true
+
+  if (!newName) return createErrorResult("name is required for clone_theme (target theme name)")
+  if (!sourceSysId && !sourceName) {
+    return createErrorResult("theme_sys_id or theme_name is required for clone_theme")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const source = await findTheme(client, sourceSysId, sourceName)
+  if (!source) return createErrorResult(`Source theme not found: ${sourceSysId || sourceName}`)
+
+  // Reject if target name is taken
+  const dup = await client.get("/api/now/table/sp_theme", {
+    params: { sysparm_query: `name=${newName}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+  })
+  if ((dup.data.result || []).length > 0) {
+    return createErrorResult(`Theme '${newName}' already exists`)
+  }
+
+  // Copy theme fields except sys_*, name
+  const themePayload: Record<string, unknown> = { name: newName }
+  for (const [key, value] of Object.entries(source)) {
+    if (key.startsWith("sys_")) continue
+    if (key === "name") continue
+    if (value === null || value === undefined) continue
+    themePayload[key] = value
+  }
+
+  const newThemeResp = await client.post("/api/now/table/sp_theme", themePayload)
+  const newTheme = newThemeResp.data.result as Record<string, unknown>
+
+  // Copy sp_css children if requested
+  const copiedCss: Array<Record<string, unknown>> = []
+  if (copyCss) {
+    try {
+      const cssResp = await client.get("/api/now/table/sp_css", {
+        params: { sysparm_query: `theme=${source.sys_id}`, sysparm_limit: 200 },
+      })
+      const rows = (cssResp.data.result || []) as Array<Record<string, unknown>>
+      for (const row of rows) {
+        const payload: Record<string, unknown> = {}
+        for (const [key, value] of Object.entries(row)) {
+          if (key.startsWith("sys_")) continue
+          if (value === null || value === undefined) continue
+          payload[key] = value
+        }
+        payload.theme = newTheme.sys_id
+        const inserted = await client.post("/api/now/table/sp_css", payload)
+        copiedCss.push({ sys_id: inserted.data.result.sys_id, name: inserted.data.result.name })
+      }
+    } catch {
+      // sp_css copy is best-effort; the new theme still exists even if children fail
+    }
+  }
+
+  return createSuccessResult({
+    action: "clone_theme",
+    created: true,
+    sys_id: newTheme.sys_id,
+    name: newTheme.name,
+    source: { sys_id: source.sys_id, name: source.name },
+    theme: newTheme,
+    cloned_css_count: copiedCss.length,
+    cloned_css: copiedCss,
+    url: `${context.instanceUrl}/nav_to.do?uri=sp_theme.do?sys_id=${newTheme.sys_id}`,
+  })
+}
+
+// ==================== APPLY_THEME_TO_PORTAL ====================
+
+async function executeApplyThemeToPortal(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const portalRef = args.portal as string | undefined
+  const themeSysId = args.theme_sys_id as string | undefined
+  const themeName = args.theme_name as string | undefined
+
+  if (!portalRef) return createErrorResult("portal is required for apply_theme_to_portal")
+  if (!themeSysId && !themeName) {
+    return createErrorResult("theme_sys_id or theme_name is required for apply_theme_to_portal")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const portal = await findPortal(client, portalRef)
+  if (!portal) return createErrorResult(`Portal not found: ${portalRef}`)
+
+  const theme = await findTheme(client, themeSysId, themeName)
+  if (!theme) return createErrorResult(`Theme not found: ${themeSysId || themeName}`)
+
+  const portalSysId = portal.sys_id as string
+
+  // sp_portal.theme is the canonical reference; some OOB releases also use
+  // a denormalized theme_name column which is regenerated on save.
+  const updResp = await client.patch(`/api/now/table/sp_portal/${portalSysId}`, { theme: theme.sys_id })
+  const updated = updResp.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "apply_theme_to_portal",
+    updated: true,
+    portal: { sys_id: portalSysId, title: updated.title, url_suffix: updated.url_suffix, theme: updated.theme },
+    theme: { sys_id: theme.sys_id, name: theme.name },
+    url: `${context.instanceUrl}/nav_to.do?uri=sp_portal.do?sys_id=${portalSysId}`,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"


### PR DESCRIPTION
## Summary

Three Tier 2 mega-tools added to the unified MCP server, each following the
`snow_pa_indicator_manage` / `snow_artifact_manage` multi-action pattern from
the Tier 1 PR (#116).

- **`snow_catalog_manage`** (`tools/catalog/`) — `create_order_guide`,
  `list_order_guides`, `create_record_producer`, `list_record_producers`,
  `list_categories`, `create_category`, `link_item_to_category` over
  `sc_cat_item_guide`, `sc_cat_item_producer`, `sc_category`,
  `sc_cat_item_category`. Covers the catalog structure patterns that
  `snow_create_catalog_item` does not (order guides, record producers,
  category trees, item-to-category junction).
- **`snow_approval_chain_manage`** (`tools/approvals/`) — `define_chain`,
  `preview_chain`, `get_approvals`, `cancel` over `sysapproval_approver`,
  `sysapproval_group`, `sysapproval_action`. Multi-step ordered approval
  flows with group expansion on preview. Companion to the existing single-row
  `snow_request_approval` / `snow_approve_reject` /
  `snow_get_pending_approvals`.
- **`snow_sp_theme_manage`** (`tools/service-portal/`) — `list_themes`,
  `create_theme`, `update_branding`, `clone_theme`, `apply_theme_to_portal`
  over `sp_theme`, `sp_brand`, `sp_css`, `sp_portal`. White-labeling and
  multi-tenant theming — `clone_theme` copies `sp_css` children,
  `update_branding` upserts the `sp_brand` row, `apply_theme_to_portal`
  flips `sp_portal.theme`.

## Verification

- `bun packages/opencode/script/generate-tools-json.ts` — 399 tools across 127
  subcategories, 0 import failures, 3 new tool names registered.
- `tools.json` itself is not committed (auto-generated; regenerated by the
  upstream workflow on merge to `main`).

## Risks / needs maintainer attention

Each tool has a small set of `// TODO: verify against live instance`
comments where `docs.servicenow.com` is sparse on the underlying column
layout:

- `sc_cat_item_producer` may need an extra `type`/`sys_class_name` value on
  some platform versions to differentiate the producer from a generic
  `sc_cat_item`.
- `sysapproval_group` — the link column to the source record is `document_id`
  on most releases but reported as `sysapproval` on older platforms; both are
  attempted on `get_approvals`.
- `sysapproval_action` — same `document_id` vs `sysapproval` uncertainty for
  the audit-verb table.
- `sc_cat_item_category` — junction column naming (`sc_cat_item`+`sc_category`
  vs `cat_item`+`category`); the more common short-name pair is used.
- `sp_brand.portal` link column — assumed `portal`; some releases use
  `sp_portal`.

None of the three tools have been exercised against a running ServiceNow
instance. Fixes #114.