### PR TITLE
feat(opencode): add 3 FSM tools (work order, dispatch, parts)

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Field Service Management (FSM) tools
+ *
+ * Wraps the tables installed by the ServiceNow Field Service Management
+ * plugin (com.snc.work_management). Greenfield: first FSM coverage in
+ * the repo — tables, fields and state catalogs are best-effort against
+ * the documented FSM data model and should be verified against a live
+ * instance before relying on the write paths.
+ */
+
+export {
+  toolDefinition as snow_fsm_work_order_manage_def,
+  execute as snow_fsm_work_order_manage_exec,
+} from "./snow_fsm_work_order_manage.js"
+
+export {
+  toolDefinition as snow_fsm_dispatch_manage_def,
+  execute as snow_fsm_dispatch_manage_exec,
+} from "./snow_fsm_dispatch_manage.js"
+
+export {
+  toolDefinition as snow_fsm_parts_manage_def,
+  execute as snow_fsm_parts_manage_exec,
+} from "./snow_fsm_parts_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_dispatch_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_dispatch_manage.ts
@@ -1,0 +1,593 @@
+/**
+ * snow_fsm_dispatch_manage - Unified Field Service Management dispatch
+ * workflow tool.
+ *
+ * Wraps the wm_agent (field technician), wm_dispatch_group, wm_skill
+ * and wm_qualification tables installed by the Field Service Management
+ * plugin (com.snc.work_management). Used by the dispatch workflow to
+ * find the right technician for a work order based on skill, group and
+ * availability.
+ *
+ * Notes:
+ * - `suggest_agent` is a read-only smart query: it filters wm_agent by
+ *   a required skill (via wm_qualification) and an availability window.
+ *   It deliberately does NOT call FSM's AI dispatch / scheduling
+ *   engines — those are separate plugins. The caller should treat the
+ *   result as a candidate list, not a binding assignment.
+ *
+ * Greenfield: this is the first FSM coverage in the repo. Column names
+ * are best-effort against the documented FSM data model — verify
+ * against a live instance with com.snc.work_management activated
+ * before relying on the smart-query output.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const AGENT_TABLE = "wm_agent"
+const DISPATCH_GROUP_TABLE = "wm_dispatch_group"
+const SKILL_TABLE = "wm_skill"
+const QUALIFICATION_TABLE = "wm_qualification"
+const WORK_ORDER_TABLE = "wm_order"
+const FSM_PLUGIN = "com.snc.work_management"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_fsm_dispatch_manage",
+  description: `Unified tool for ServiceNow Field Service Management dispatch operations. Wraps the wm_agent, wm_dispatch_group, wm_skill and wm_qualification tables installed by the Field Service Management plugin (com.snc.work_management).
+
+Actions:
+- list_agents — list wm_agent rows (field technicians), optionally filtered by dispatch_group, skill, location or active flag
+- list_groups — list wm_dispatch_group rows
+- assign_agent — set a work order's assigned_to (and optionally assignment_group). Convenience wrapper for the same operation in snow_fsm_work_order_manage, scoped to dispatch workflows
+- suggest_agent — read-only smart query that returns candidate agents filtered by required skill, dispatch group, and an availability window. Does NOT call FSM's AI dispatch engine
+- check_availability — list agents whose schedule has no overlapping work orders during the given window
+
+Use when: the agent needs to discover technicians for a work order, audit dispatch group membership, or pre-filter candidates before opening the Dispatcher Workspace. Requires the Field Service Management plugin (com.snc.work_management) — every action surfaces a clear PLUGIN_MISSING error if wm_agent is absent.
+
+Returns: agent records with sys_id, name, user (sys_user reference), dispatch_group, location, active. Group records include sys_id, name, location and parent group. Suggestions include the matching skill, group membership flag, and a "reasons" array describing why the candidate matched.`,
+  category: "itsm",
+  subcategory: "field-service",
+  use_cases: ["field-service", "dispatch", "scheduling", "technician", "fsm"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list_agents", "list_groups", "assign_agent", "suggest_agent", "check_availability"],
+      },
+      // Filters / identifiers
+      dispatch_group: {
+        type: "string",
+        description: "[list_agents/suggest_agent/check_availability] Filter agents by wm_dispatch_group (sys_id or name)",
+      },
+      skill: {
+        type: "string",
+        description: "[list_agents/suggest_agent] Filter agents by required skill (wm_skill sys_id or name) — joined through wm_qualification",
+      },
+      location: {
+        type: "string",
+        description: "[list_agents/suggest_agent] Filter agents by location (cmn_location sys_id or name)",
+      },
+      active_only: {
+        type: "boolean",
+        description: "[list_agents/list_groups/suggest_agent/check_availability] Only return active rows",
+        default: true,
+      },
+      // ASSIGN_AGENT fields
+      work_order_sys_id: {
+        type: "string",
+        description: "[assign_agent] sys_id of the wm_order to assign",
+      },
+      work_order_number: {
+        type: "string",
+        description: "[assign_agent] number of the wm_order (used when work_order_sys_id is absent)",
+      },
+      agent: {
+        type: "string",
+        description: "[assign_agent] wm_agent sys_id or referenced sys_user sys_id/user_name to assign as assigned_to on the work order",
+      },
+      assignment_group: {
+        type: "string",
+        description: "[assign_agent] Optional sys_user_group sys_id or name to set on the work order",
+      },
+      // AVAILABILITY / SUGGEST window
+      window_start: {
+        type: "string",
+        description: "[suggest_agent/check_availability] Window start datetime (YYYY-MM-DD HH:MM:SS in instance TZ)",
+      },
+      window_end: {
+        type: "string",
+        description: "[suggest_agent/check_availability] Window end datetime (YYYY-MM-DD HH:MM:SS in instance TZ)",
+      },
+      limit: {
+        type: "number",
+        description: "[list_agents/list_groups/suggest_agent/check_availability] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_agents/list_groups] Comma-separated list of fields to return (defaults to a curated set)",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_agents":
+        return await executeListAgents(args, context)
+      case "list_groups":
+        return await executeListGroups(args, context)
+      case "assign_agent":
+        return await executeAssignAgent(args, context)
+      case "suggest_agent":
+        return await executeSuggestAgent(args, context)
+      case "check_availability":
+        return await executeCheckAvailability(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_agents, list_groups, assign_agent, suggest_agent, check_availability`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    const wrapped = wrapFsmError(err, action)
+    return createErrorResult(wrapped)
+  }
+}
+
+// ==================== HELPERS ====================
+
+function wrapFsmError(err: Error, action: string): SnowFlowError {
+  const msg = err.message || ""
+  if (msg.indexOf("Invalid table") !== -1 || msg.indexOf("404") !== -1) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Field Service Management tables are not available on this instance. Activate the Field Service Management plugin (${FSM_PLUGIN}) and retry.`,
+      { details: { plugin: FSM_PLUGIN, originalMessage: msg } },
+    )
+  }
+  if (err instanceof SnowFlowError) return err
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `FSM dispatch ${action} failed: ${msg}`, {
+    originalError: err,
+  })
+}
+
+async function resolveDispatchGroupSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  ref: string,
+): Promise<string | null> {
+  // Accept either a sys_id (32-char hex) or a name lookup.
+  if (/^[0-9a-f]{32}$/i.test(ref)) return ref
+  const response = await client.get(`/api/now/table/${DISPATCH_GROUP_TABLE}`, {
+    params: { sysparm_query: `name=${ref}`, sysparm_fields: "sys_id", sysparm_limit: 1 },
+  })
+  const rows = (response.data.result || []) as Array<Record<string, unknown>>
+  if (rows.length > 0 && typeof rows[0].sys_id === "string") return rows[0].sys_id as string
+  return null
+}
+
+async function resolveSkillSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  ref: string,
+): Promise<string | null> {
+  if (/^[0-9a-f]{32}$/i.test(ref)) return ref
+  const response = await client.get(`/api/now/table/${SKILL_TABLE}`, {
+    params: { sysparm_query: `name=${ref}`, sysparm_fields: "sys_id", sysparm_limit: 1 },
+  })
+  const rows = (response.data.result || []) as Array<Record<string, unknown>>
+  if (rows.length > 0 && typeof rows[0].sys_id === "string") return rows[0].sys_id as string
+  return null
+}
+
+// ==================== LIST_AGENTS ====================
+
+async function executeListAgents(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const dispatch_group = args.dispatch_group as string | undefined
+  const skill = args.skill as string | undefined
+  const location = args.location as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  // TODO: verify wm_agent column names on a live instance — some
+  // variants expose `user` as the sys_user reference, others use
+  // `agent` or rely on extending sys_user directly.
+  const fields =
+    (args.fields as string) || "sys_id,name,user,dispatch_group,location,active,sys_updated_on"
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+  if (dispatch_group) {
+    const groupSysId = await resolveDispatchGroupSysId(client, dispatch_group)
+    if (groupSysId) queryParts.push(`dispatch_group=${groupSysId}`)
+  }
+  if (location) queryParts.push(`location=${location}`)
+
+  // If a skill was requested, resolve agents that hold the matching
+  // qualification first, then scope the wm_agent query to those sys_ids.
+  if (skill) {
+    const skillSysId = await resolveSkillSysId(client, skill)
+    if (!skillSysId) {
+      return createSuccessResult({ action: "list_agents", count: 0, agents: [], note: `Skill not found: ${skill}` })
+    }
+    const qualifications = await client.get(`/api/now/table/${QUALIFICATION_TABLE}`, {
+      params: {
+        sysparm_query: `skill=${skillSysId}`,
+        sysparm_fields: "agent",
+        sysparm_limit: 500,
+      },
+    })
+    const agentRefs = ((qualifications.data.result || []) as Array<Record<string, unknown>>)
+      .map((row) => {
+        const ref = row.agent
+        if (typeof ref === "string") return ref
+        if (ref && typeof ref === "object" && "value" in ref) return (ref as { value: string }).value
+        return null
+      })
+      .filter((v): v is string => typeof v === "string" && v.length > 0)
+    if (agentRefs.length === 0) {
+      return createSuccessResult({ action: "list_agents", count: 0, agents: [], note: "No agents hold this skill" })
+    }
+    queryParts.push(`sys_idIN${agentRefs.join(",")}`)
+  }
+
+  const response = await client.get(`/api/now/table/${AGENT_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: fields,
+    },
+  })
+
+  const agents = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_agents",
+    count: agents.length,
+    agents: agents.map((a) => ({
+      sys_id: a.sys_id,
+      name: a.name,
+      user: a.user,
+      dispatch_group: a.dispatch_group,
+      location: a.location,
+      active: a.active,
+      updated_at: a.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${AGENT_TABLE}.do?sys_id=${a.sys_id}`,
+    })),
+  })
+}
+
+// ==================== LIST_GROUPS ====================
+
+async function executeListGroups(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  // TODO: verify wm_dispatch_group columns — some variants expose
+  // `parent` and `location`, others only carry a name + active flag.
+  const fields = (args.fields as string) || "sys_id,name,parent,location,active,sys_updated_on"
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${DISPATCH_GROUP_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: fields,
+    },
+  })
+
+  const groups = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_groups",
+    count: groups.length,
+    groups: groups.map((g) => ({
+      sys_id: g.sys_id,
+      name: g.name,
+      parent: g.parent,
+      location: g.location,
+      active: g.active,
+      updated_at: g.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${DISPATCH_GROUP_TABLE}.do?sys_id=${g.sys_id}`,
+    })),
+  })
+}
+
+// ==================== ASSIGN_AGENT ====================
+
+async function executeAssignAgent(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const work_order_sys_id = args.work_order_sys_id as string | undefined
+  const work_order_number = args.work_order_number as string | undefined
+  const agent = args.agent as string | undefined
+  const assignment_group = args.assignment_group as string | undefined
+
+  if (!work_order_sys_id && !work_order_number) {
+    return createErrorResult("work_order_sys_id or work_order_number is required for assign_agent action")
+  }
+  if (!agent) {
+    return createErrorResult("agent is required for assign_agent action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Resolve work order
+  let targetSysId = work_order_sys_id
+  if (!targetSysId && work_order_number) {
+    const response = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+      params: { sysparm_query: `number=${work_order_number}`, sysparm_fields: "sys_id", sysparm_limit: 1 },
+    })
+    const rows = (response.data.result || []) as Array<Record<string, unknown>>
+    if (rows.length === 0) {
+      return createErrorResult(`Work order not found: ${work_order_number}`)
+    }
+    targetSysId = rows[0].sys_id as string
+  }
+
+  // The `agent` parameter can be a wm_agent sys_id, a sys_user sys_id,
+  // or a sys_user username. The wm_order.assigned_to column refers to
+  // sys_user, so when a wm_agent sys_id is supplied we dereference it
+  // first.
+  let assignedToUserSysId = agent
+  // Heuristic: if it looks like a sys_id, see if a wm_agent row exists
+  // and use its `user` reference; otherwise treat the value as-is and
+  // let the ServiceNow reference qualifier resolve it.
+  if (/^[0-9a-f]{32}$/i.test(agent)) {
+    try {
+      const agentResponse = await client.get(`/api/now/table/${AGENT_TABLE}/${agent}`)
+      const row = agentResponse.data.result as Record<string, unknown> | undefined
+      if (row && row.user) {
+        const userRef = row.user
+        if (typeof userRef === "string") assignedToUserSysId = userRef
+        else if (userRef && typeof userRef === "object" && "value" in userRef) {
+          assignedToUserSysId = (userRef as { value: string }).value
+        }
+      }
+    } catch {
+      // The sys_id may belong to sys_user directly. Fall through.
+    }
+  }
+
+  const patch: Record<string, unknown> = { assigned_to: assignedToUserSysId }
+  if (assignment_group) patch.assignment_group = assignment_group
+
+  const response = await client.patch(`/api/now/table/${WORK_ORDER_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "assign_agent",
+    assigned: true,
+    sys_id: targetSysId,
+    number: updated.number,
+    assigned_to: updated.assigned_to,
+    assignment_group: updated.assignment_group,
+    work_order: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== SUGGEST_AGENT ====================
+
+async function executeSuggestAgent(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const skill = args.skill as string | undefined
+  const dispatch_group = args.dispatch_group as string | undefined
+  const location = args.location as string | undefined
+  const window_start = args.window_start as string | undefined
+  const window_end = args.window_end as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+
+  const client = await getAuthenticatedClient(context)
+
+  // Resolve required skill (when supplied) into the set of qualified agents.
+  let qualifiedAgentSysIds: string[] | null = null
+  let resolvedSkillSysId: string | null = null
+  if (skill) {
+    resolvedSkillSysId = await resolveSkillSysId(client, skill)
+    if (!resolvedSkillSysId) {
+      return createSuccessResult({
+        action: "suggest_agent",
+        count: 0,
+        candidates: [],
+        note: `Skill not found: ${skill}`,
+      })
+    }
+    const qualifications = await client.get(`/api/now/table/${QUALIFICATION_TABLE}`, {
+      params: { sysparm_query: `skill=${resolvedSkillSysId}`, sysparm_fields: "agent", sysparm_limit: 500 },
+    })
+    qualifiedAgentSysIds = ((qualifications.data.result || []) as Array<Record<string, unknown>>)
+      .map((row) => {
+        const ref = row.agent
+        if (typeof ref === "string") return ref
+        if (ref && typeof ref === "object" && "value" in ref) return (ref as { value: string }).value
+        return null
+      })
+      .filter((v): v is string => typeof v === "string" && v.length > 0)
+    if (qualifiedAgentSysIds.length === 0) {
+      return createSuccessResult({
+        action: "suggest_agent",
+        count: 0,
+        candidates: [],
+        note: "No agents hold the requested skill",
+      })
+    }
+  }
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+  if (qualifiedAgentSysIds && qualifiedAgentSysIds.length > 0) {
+    queryParts.push(`sys_idIN${qualifiedAgentSysIds.join(",")}`)
+  }
+  if (dispatch_group) {
+    const groupSysId = await resolveDispatchGroupSysId(client, dispatch_group)
+    if (groupSysId) queryParts.push(`dispatch_group=${groupSysId}`)
+  }
+  if (location) queryParts.push(`location=${location}`)
+
+  const agentResponse = await client.get(`/api/now/table/${AGENT_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: "sys_id,name,user,dispatch_group,location,active",
+    },
+  })
+  const candidates = (agentResponse.data.result || []) as Array<Record<string, unknown>>
+
+  // For each candidate, check whether they have any overlapping wm_order
+  // rows in the supplied window. We treat absence of overlap as a positive
+  // signal but do NOT filter out candidates that have overlap — the caller
+  // decides whether to honor it.
+  const enriched: Array<Record<string, unknown>> = []
+  for (const candidate of candidates) {
+    const userRef = candidate.user
+    const userSysId =
+      typeof userRef === "string"
+        ? userRef
+        : userRef && typeof userRef === "object" && "value" in userRef
+          ? (userRef as { value: string }).value
+          : null
+
+    const reasons: string[] = []
+    if (resolvedSkillSysId) reasons.push("matches required skill")
+    if (dispatch_group) reasons.push("belongs to requested dispatch group")
+    if (location) reasons.push("located in requested area")
+
+    let overlappingWorkOrders = 0
+    if (userSysId && window_start && window_end) {
+      try {
+        const overlap = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+          params: {
+            sysparm_query: `assigned_to=${userSysId}^work_start<${window_end}^work_end>${window_start}`,
+            sysparm_fields: "sys_id",
+            sysparm_limit: 5,
+          },
+        })
+        overlappingWorkOrders = ((overlap.data.result || []) as Array<unknown>).length
+        if (overlappingWorkOrders === 0) reasons.push("no scheduling conflict in window")
+      } catch {
+        // Window check is best-effort. A failure here should not block the suggestion.
+      }
+    }
+
+    enriched.push({
+      sys_id: candidate.sys_id,
+      name: candidate.name,
+      user: candidate.user,
+      dispatch_group: candidate.dispatch_group,
+      location: candidate.location,
+      overlapping_work_orders: overlappingWorkOrders,
+      reasons,
+    })
+  }
+
+  return createSuccessResult({
+    action: "suggest_agent",
+    count: enriched.length,
+    window: window_start && window_end ? { start: window_start, end: window_end } : null,
+    skill: resolvedSkillSysId ? { sys_id: resolvedSkillSysId, label: skill } : null,
+    candidates: enriched,
+    note: "Read-only candidate list — does not call FSM AI dispatch/scheduling engines.",
+  })
+}
+
+// ==================== CHECK_AVAILABILITY ====================
+
+async function executeCheckAvailability(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const dispatch_group = args.dispatch_group as string | undefined
+  const window_start = args.window_start as string | undefined
+  const window_end = args.window_end as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+
+  if (!window_start || !window_end) {
+    return createErrorResult("window_start and window_end are required for check_availability action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+  if (dispatch_group) {
+    const groupSysId = await resolveDispatchGroupSysId(client, dispatch_group)
+    if (groupSysId) queryParts.push(`dispatch_group=${groupSysId}`)
+  }
+
+  const agentResponse = await client.get(`/api/now/table/${AGENT_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: "sys_id,name,user,dispatch_group,location,active",
+    },
+  })
+  const agents = (agentResponse.data.result || []) as Array<Record<string, unknown>>
+
+  const availability: Array<Record<string, unknown>> = []
+  for (const agent of agents) {
+    const userRef = agent.user
+    const userSysId =
+      typeof userRef === "string"
+        ? userRef
+        : userRef && typeof userRef === "object" && "value" in userRef
+          ? (userRef as { value: string }).value
+          : null
+
+    let overlappingCount = 0
+    let overlappingOrders: Array<Record<string, unknown>> = []
+    if (userSysId) {
+      try {
+        const overlap = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+          params: {
+            sysparm_query: `assigned_to=${userSysId}^work_start<${window_end}^work_end>${window_start}`,
+            sysparm_fields: "sys_id,number,short_description,work_start,work_end",
+            sysparm_limit: 5,
+          },
+        })
+        overlappingOrders = (overlap.data.result || []) as Array<Record<string, unknown>>
+        overlappingCount = overlappingOrders.length
+      } catch {
+        // Swallow — agent stays in the list with "unknown" overlap.
+      }
+    }
+
+    availability.push({
+      sys_id: agent.sys_id,
+      name: agent.name,
+      user: agent.user,
+      dispatch_group: agent.dispatch_group,
+      location: agent.location,
+      available: overlappingCount === 0,
+      overlapping_work_orders: overlappingOrders,
+    })
+  }
+
+  return createSuccessResult({
+    action: "check_availability",
+    count: availability.length,
+    available_count: availability.filter((a) => a.available === true).length,
+    window: { start: window_start, end: window_end },
+    agents: availability,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_parts_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_parts_manage.ts
@@ -1,0 +1,432 @@
+/**
+ * snow_fsm_parts_manage - Unified Field Service Management parts
+ * management tool.
+ *
+ * Wraps the pc_part (Parts Catalog), wm_part_requirement (parts
+ * required for a work order), pc_part_request (parts ordering) and
+ * pc_stock_level tables. Used to look up parts, attach required parts
+ * to a work order, request parts from a stockroom, and check stock
+ * level availability.
+ *
+ * Greenfield: this is the first FSM coverage in the repo. Column
+ * names are best-effort against the documented FSM data model — they
+ * should be verified against a live instance with the Field Service
+ * Management plugin (com.snc.work_management) activated before this
+ * tool is trusted for write operations.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const PART_TABLE = "pc_part"
+const PART_REQUIREMENT_TABLE = "wm_part_requirement"
+const PART_REQUEST_TABLE = "pc_part_request"
+const STOCK_LEVEL_TABLE = "pc_stock_level"
+const WORK_ORDER_TABLE = "wm_order"
+const FSM_PLUGIN = "com.snc.work_management"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_fsm_parts_manage",
+  description: `Unified tool for ServiceNow Field Service Management parts operations. Wraps the pc_part (Parts Catalog), wm_part_requirement (parts required for a work order), pc_part_request (parts ordering) and pc_stock_level tables.
+
+Actions:
+- list_parts — list pc_part rows from the catalog, optionally filtered by model, category or name
+- request_part — create a wm_part_requirement row that attaches a required part to a work order
+- list_requirements — list wm_part_requirement rows for a work order
+- fulfill_request — create a pc_part_request (purchase / transfer request) to source the part for a wm_part_requirement
+- check_stock — list pc_stock_level rows for a part, optionally filtered by stockroom, to see what is available
+
+Use when: the agent needs to plan parts for a work order, attach required parts, raise a purchase / stock-transfer request, or look up what stockroom has a part in stock. Requires the Field Service Management plugin (com.snc.work_management) — every action surfaces a clear PLUGIN_MISSING error if the primary tables are absent.
+
+Returns: catalog rows with sys_id, name, model, manufacturer. Requirements include sys_id, work_order, part, quantity, state. Requests include sys_id, part, quantity, stockroom, state. Stock levels include sys_id, part, stockroom, quantity.`,
+  category: "itsm",
+  subcategory: "field-service",
+  use_cases: ["field-service", "parts", "inventory", "stockroom", "fsm"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list_parts", "request_part", "list_requirements", "fulfill_request", "check_stock"],
+      },
+      // LIST_PARTS filters
+      name: {
+        type: "string",
+        description: "[list_parts] Filter parts by name (LIKE match)",
+      },
+      model: {
+        type: "string",
+        description: "[list_parts] Filter parts by model (cmdb_model sys_id or name)",
+      },
+      manufacturer: {
+        type: "string",
+        description: "[list_parts] Filter parts by manufacturer (core_company sys_id or name)",
+      },
+      category: {
+        type: "string",
+        description: "[list_parts] Filter parts by category",
+      },
+      // Common references
+      part: {
+        type: "string",
+        description: "[request_part/fulfill_request/check_stock] pc_part sys_id of the part",
+      },
+      work_order_sys_id: {
+        type: "string",
+        description: "[request_part/list_requirements] sys_id of the wm_order this requirement is attached to",
+      },
+      work_order_number: {
+        type: "string",
+        description: "[request_part/list_requirements] number of the wm_order (used when work_order_sys_id is absent)",
+      },
+      requirement_sys_id: {
+        type: "string",
+        description: "[fulfill_request] sys_id of the wm_part_requirement to fulfill",
+      },
+      quantity: {
+        type: "number",
+        description: "[request_part/fulfill_request] Quantity of the part required / requested",
+      },
+      stockroom: {
+        type: "string",
+        description: "[fulfill_request/check_stock] sys_id or name of the source stockroom (alm_stockroom)",
+      },
+      requested_for: {
+        type: "string",
+        description: "[fulfill_request] sys_user sys_id of the requester (defaults to the assigned technician)",
+      },
+      // LIST limits / fields
+      active_only: {
+        type: "boolean",
+        description: "[list_parts/list_requirements/check_stock] Only return active rows",
+        default: true,
+      },
+      limit: {
+        type: "number",
+        description: "[list_parts/list_requirements/check_stock] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_parts/list_requirements/check_stock] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_parts":
+        return await executeListParts(args, context)
+      case "request_part":
+        return await executeRequestPart(args, context)
+      case "list_requirements":
+        return await executeListRequirements(args, context)
+      case "fulfill_request":
+        return await executeFulfillRequest(args, context)
+      case "check_stock":
+        return await executeCheckStock(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_parts, request_part, list_requirements, fulfill_request, check_stock`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    const wrapped = wrapFsmError(err, action)
+    return createErrorResult(wrapped)
+  }
+}
+
+// ==================== HELPERS ====================
+
+function wrapFsmError(err: Error, action: string): SnowFlowError {
+  const msg = err.message || ""
+  if (msg.indexOf("Invalid table") !== -1 || msg.indexOf("404") !== -1) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Field Service Management parts tables are not available on this instance. Activate the Field Service Management plugin (${FSM_PLUGIN}) and retry.`,
+      { details: { plugin: FSM_PLUGIN, originalMessage: msg } },
+    )
+  }
+  if (err instanceof SnowFlowError) return err
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `FSM parts ${action} failed: ${msg}`, {
+    originalError: err,
+  })
+}
+
+async function resolveWorkOrderSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  number: string | undefined,
+): Promise<string | null> {
+  if (sysId) return sysId
+  if (!number) return null
+  const response = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+    params: { sysparm_query: `number=${number}`, sysparm_fields: "sys_id", sysparm_limit: 1 },
+  })
+  const rows = (response.data.result || []) as Array<Record<string, unknown>>
+  if (rows.length === 0) return null
+  return (rows[0].sys_id as string) || null
+}
+
+// ==================== LIST_PARTS ====================
+
+async function executeListParts(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  const model = args.model as string | undefined
+  const manufacturer = args.manufacturer as string | undefined
+  const category = args.category as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  // TODO: verify pc_part column names — common variants include
+  // `name`, `model`, `manufacturer`, `category`, `unit_cost`, `active`.
+  const fields = (args.fields as string) || "sys_id,name,model,manufacturer,category,unit_cost,active,sys_updated_on"
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (active_only) queryParts.push("active=true")
+  if (name) queryParts.push(`nameLIKE${name}`)
+  if (model) queryParts.push(`model=${model}`)
+  if (manufacturer) queryParts.push(`manufacturer=${manufacturer}`)
+  if (category) queryParts.push(`category=${category}`)
+
+  const response = await client.get(`/api/now/table/${PART_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_fields: fields,
+    },
+  })
+
+  const parts = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_parts",
+    count: parts.length,
+    parts: parts.map((p) => ({
+      sys_id: p.sys_id,
+      name: p.name,
+      model: p.model,
+      manufacturer: p.manufacturer,
+      category: p.category,
+      unit_cost: p.unit_cost,
+      active: p.active,
+      updated_at: p.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${PART_TABLE}.do?sys_id=${p.sys_id}`,
+    })),
+  })
+}
+
+// ==================== REQUEST_PART ====================
+
+async function executeRequestPart(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const part = args.part as string | undefined
+  const quantity = args.quantity as number | undefined
+  const work_order_sys_id = args.work_order_sys_id as string | undefined
+  const work_order_number = args.work_order_number as string | undefined
+
+  if (!part) return createErrorResult("part is required for request_part action")
+  if (quantity === undefined || quantity === null) {
+    return createErrorResult("quantity is required for request_part action")
+  }
+  if (!work_order_sys_id && !work_order_number) {
+    return createErrorResult("work_order_sys_id or work_order_number is required for request_part action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrderSysId = await resolveWorkOrderSysId(client, work_order_sys_id, work_order_number)
+  if (!workOrderSysId) {
+    return createErrorResult(`Work order not found: ${work_order_sys_id || work_order_number}`)
+  }
+
+  // TODO: verify wm_part_requirement column names on a live instance.
+  // The most common shape is { work_order, part, quantity, state }.
+  const payload: Record<string, unknown> = {
+    work_order: workOrderSysId,
+    part,
+    quantity,
+  }
+
+  const response = await client.post(`/api/now/table/${PART_REQUIREMENT_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "request_part",
+    created: true,
+    sys_id: created.sys_id,
+    requirement: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${PART_REQUIREMENT_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LIST_REQUIREMENTS ====================
+
+async function executeListRequirements(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const work_order_sys_id = args.work_order_sys_id as string | undefined
+  const work_order_number = args.work_order_number as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields =
+    (args.fields as string) || "sys_id,work_order,part,quantity,state,sys_updated_on"
+
+  if (!work_order_sys_id && !work_order_number) {
+    return createErrorResult("work_order_sys_id or work_order_number is required for list_requirements action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrderSysId = await resolveWorkOrderSysId(client, work_order_sys_id, work_order_number)
+  if (!workOrderSysId) {
+    return createErrorResult(`Work order not found: ${work_order_sys_id || work_order_number}`)
+  }
+
+  const response = await client.get(`/api/now/table/${PART_REQUIREMENT_TABLE}`, {
+    params: {
+      sysparm_query: `work_order=${workOrderSysId}`,
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_fields: fields,
+    },
+  })
+
+  const requirements = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_requirements",
+    work_order_sys_id: workOrderSysId,
+    count: requirements.length,
+    requirements: requirements.map((r) => ({
+      sys_id: r.sys_id,
+      work_order: r.work_order,
+      part: r.part,
+      quantity: r.quantity,
+      state: r.state,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${PART_REQUIREMENT_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== FULFILL_REQUEST ====================
+
+async function executeFulfillRequest(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const requirement_sys_id = args.requirement_sys_id as string | undefined
+  let part = args.part as string | undefined
+  let quantity = args.quantity as number | undefined
+  const stockroom = args.stockroom as string | undefined
+  const requested_for = args.requested_for as string | undefined
+
+  if (!requirement_sys_id && (!part || quantity === undefined || quantity === null)) {
+    return createErrorResult(
+      "Provide either requirement_sys_id (to source from an existing wm_part_requirement) or both part and quantity for fulfill_request action",
+    )
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // If a requirement is supplied, hydrate the part and quantity from it
+  // so the caller doesn't have to re-supply them.
+  let sourceRequirement: Record<string, unknown> | null = null
+  if (requirement_sys_id) {
+    const response = await client.get(`/api/now/table/${PART_REQUIREMENT_TABLE}/${requirement_sys_id}`)
+    sourceRequirement = (response.data.result as Record<string, unknown>) || null
+    if (!sourceRequirement) {
+      return createErrorResult(`Part requirement not found: ${requirement_sys_id}`)
+    }
+    if (!part) {
+      const ref = sourceRequirement.part
+      if (typeof ref === "string") part = ref
+      else if (ref && typeof ref === "object" && "value" in ref) part = (ref as { value: string }).value
+    }
+    if (quantity === undefined || quantity === null) {
+      const q = sourceRequirement.quantity
+      quantity = typeof q === "number" ? q : Number(q)
+    }
+  }
+
+  // TODO: verify pc_part_request column names — common shape is
+  // { part, quantity, stockroom, requested_for, requirement, state }.
+  const payload: Record<string, unknown> = {
+    part,
+    quantity,
+  }
+  if (stockroom) payload.stockroom = stockroom
+  if (requested_for) payload.requested_for = requested_for
+  if (requirement_sys_id) payload.requirement = requirement_sys_id
+
+  const response = await client.post(`/api/now/table/${PART_REQUEST_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "fulfill_request",
+    created: true,
+    sys_id: created.sys_id,
+    request: created,
+    source_requirement: sourceRequirement ? { sys_id: sourceRequirement.sys_id } : null,
+    url: `${context.instanceUrl}/nav_to.do?uri=${PART_REQUEST_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== CHECK_STOCK ====================
+
+async function executeCheckStock(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const part = args.part as string | undefined
+  const stockroom = args.stockroom as string | undefined
+  const limit = (args.limit as number) || 50
+  // TODO: verify pc_stock_level column names — common shape is
+  // { part, stockroom, quantity, available_quantity, sys_updated_on }.
+  const fields =
+    (args.fields as string) || "sys_id,part,stockroom,quantity,available_quantity,sys_updated_on"
+
+  if (!part && !stockroom) {
+    return createErrorResult("At least one of part or stockroom is required for check_stock action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (part) queryParts.push(`part=${part}`)
+  if (stockroom) queryParts.push(`stockroom=${stockroom}`)
+
+  const response = await client.get(`/api/now/table/${STOCK_LEVEL_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "stockroom",
+      sysparm_fields: fields,
+    },
+  })
+
+  const levels = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "check_stock",
+    count: levels.length,
+    stock_levels: levels.map((l) => ({
+      sys_id: l.sys_id,
+      part: l.part,
+      stockroom: l.stockroom,
+      quantity: l.quantity,
+      available_quantity: l.available_quantity,
+      updated_at: l.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${STOCK_LEVEL_TABLE}.do?sys_id=${l.sys_id}`,
+    })),
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_work_order_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_work_order_manage.ts
@@ -1,0 +1,589 @@
+/**
+ * snow_fsm_work_order_manage - Unified Field Service Management work order
+ * lifecycle tool.
+ *
+ * Wraps the wm_order (Work Order), wm_task (Work Task), and
+ * wm_order_history tables that the Field Service Management plugin
+ * (com.snc.work_management) installs. Covers the lifecycle from
+ * creation through assignment, scheduling and status updates, plus
+ * read-only access to the dependent work tasks.
+ *
+ * Greenfield: this is the first FSM coverage in the repo. Every
+ * column referenced below is best-effort against the documented FSM
+ * data model — fields and state names should be verified against a
+ * live instance with the plugin activated before this tool is
+ * trusted for write operations.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const WORK_ORDER_TABLE = "wm_order"
+const WORK_TASK_TABLE = "wm_task"
+const WORK_ORDER_HISTORY_TABLE = "wm_order_history"
+const FSM_PLUGIN = "com.snc.work_management"
+
+// Work Order state names as used in FSM. ServiceNow stores these as
+// numeric state codes whose meaning is configured per instance, so we
+// accept the human-readable name and resolve via sys_choice at runtime.
+// TODO: verify exact state catalog (Draft, Scheduled, Dispatched, En Route,
+// Onsite, Work in Progress, Closed Complete, Closed Incomplete, Cancelled,
+// Pending Dispatch) against a live instance — greenfield FSM tool, no
+// in-repo reference.
+const WORK_ORDER_STATES = [
+  "Draft",
+  "Pending Dispatch",
+  "Scheduled",
+  "Dispatched",
+  "En Route",
+  "Onsite",
+  "Work in Progress",
+  "Closed Complete",
+  "Closed Incomplete",
+  "Cancelled",
+] as const
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_fsm_work_order_manage",
+  description: `Unified tool for ServiceNow Field Service Management work orders. Wraps the wm_order, wm_task and wm_order_history tables installed by the Field Service Management plugin (com.snc.work_management).
+
+Actions:
+- list — list work orders, optionally filtered by state, assignment_group, assigned_to, or location
+- get — retrieve a single work order by sys_id or number (includes related task and history counts)
+- create — create a new work order with short_description, location, contact, priority, and optional scheduling window
+- assign — assign the work order to a technician (assigned_to) and/or dispatch group (assignment_group)
+- schedule — set the scheduled work_start and work_end on the work order
+- update_status — transition the state field by human-readable state name (Draft, Scheduled, En Route, Onsite, Closed Complete, ...)
+- list_tasks — list the wm_task rows linked to a parent work order
+
+Use when: the agent needs to create, dispatch, schedule, or report on field-service work orders. Requires the Field Service Management plugin (com.snc.work_management) on the target instance — every action surfaces a clear PLUGIN_MISSING error if wm_order is absent.
+
+Returns: work order records with sys_id, number, short_description, state, priority, assignment_group, assigned_to, location, contact, work_start, work_end. For list_tasks returns wm_task rows with sys_id, number, short_description and state.`,
+  category: "itsm",
+  subcategory: "field-service",
+  use_cases: ["field-service", "work-order", "dispatch", "scheduling", "fsm"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "create", "assign", "schedule", "update_status", "list_tasks"],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/assign/schedule/update_status/list_tasks] Work order sys_id",
+      },
+      number: {
+        type: "string",
+        description: "[get/assign/schedule/update_status/list_tasks] Work order number (e.g. WO0001234) — used when sys_id is absent",
+      },
+      // CREATE fields
+      short_description: {
+        type: "string",
+        description: "[create] One-line summary of the work to be performed",
+      },
+      description: {
+        type: "string",
+        description: "[create] Long description / instructions for the technician",
+      },
+      priority: {
+        type: "number",
+        description: "[create] Priority (1 = Critical, 2 = High, 3 = Moderate, 4 = Low, 5 = Planning)",
+        enum: [1, 2, 3, 4, 5],
+      },
+      location: {
+        type: "string",
+        description: "[create] cmn_location sys_id or name where the work is performed",
+      },
+      contact: {
+        type: "string",
+        description: "[create] sys_user sys_id of the on-site contact for the work order",
+      },
+      company: {
+        type: "string",
+        description: "[create] core_company sys_id of the customer / account",
+      },
+      // ASSIGN fields
+      assignment_group: {
+        type: "string",
+        description: "[create/assign] sys_user_group sys_id or name of the dispatch group",
+      },
+      assigned_to: {
+        type: "string",
+        description: "[create/assign] sys_user sys_id or user_name of the technician",
+      },
+      // SCHEDULE fields
+      work_start: {
+        type: "string",
+        description: "[create/schedule] Scheduled start datetime (YYYY-MM-DD HH:MM:SS in instance TZ)",
+      },
+      work_end: {
+        type: "string",
+        description: "[create/schedule] Scheduled end datetime (YYYY-MM-DD HH:MM:SS in instance TZ)",
+      },
+      // STATE
+      state: {
+        type: "string",
+        description: "[update_status] New state name. Resolved against the wm_order state choice list on the target instance.",
+        enum: [...WORK_ORDER_STATES],
+      },
+      close_notes: {
+        type: "string",
+        description: "[update_status] Close notes (recorded when state is set to Closed Complete or Closed Incomplete)",
+      },
+      // FILTERS for list / list_tasks
+      filter_state: {
+        type: "string",
+        description: "[list] Filter by state name (matches the same choice list as update_status)",
+      },
+      filter_assigned_to: {
+        type: "string",
+        description: "[list] Filter by assigned_to (sys_user sys_id or user_name)",
+      },
+      filter_assignment_group: {
+        type: "string",
+        description: "[list] Filter by assignment_group (sys_user_group sys_id or name)",
+      },
+      filter_location: {
+        type: "string",
+        description: "[list] Filter by location (cmn_location sys_id or name)",
+      },
+      limit: {
+        type: "number",
+        description: "[list/list_tasks] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_tasks] Comma-separated list of fields to return (defaults to a curated set)",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create":
+        return await executeCreate(args, context)
+      case "assign":
+        return await executeAssign(args, context)
+      case "schedule":
+        return await executeSchedule(args, context)
+      case "update_status":
+        return await executeUpdateStatus(args, context)
+      case "list_tasks":
+        return await executeListTasks(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create, assign, schedule, update_status, list_tasks`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    const wrapped = wrapFsmError(err, action)
+    return createErrorResult(wrapped)
+  }
+}
+
+// ==================== HELPERS ====================
+
+function wrapFsmError(err: Error, action: string): SnowFlowError {
+  const msg = err.message || ""
+  // ServiceNow returns "Invalid table" / 404 when a plugin-gated table
+  // is missing. Surface a clear remediation message instead of the raw
+  // ServiceNow error.
+  if (msg.indexOf("Invalid table") !== -1 || msg.indexOf("404") !== -1) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Field Service Management tables are not available on this instance. Activate the Field Service Management plugin (${FSM_PLUGIN}) and retry.`,
+      { details: { plugin: FSM_PLUGIN, originalMessage: msg } },
+    )
+  }
+  if (err instanceof SnowFlowError) return err
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `FSM work_order ${action} failed: ${msg}`, {
+    originalError: err,
+  })
+}
+
+async function findWorkOrder(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  number: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/${WORK_ORDER_TABLE}/${sysId}`)
+    if (direct.data.result && (direct.data.result as Record<string, unknown>).sys_id) {
+      return direct.data.result as Record<string, unknown>
+    }
+  }
+  if (number) {
+    const search = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+      params: {
+        sysparm_query: `number=${number}`,
+        sysparm_limit: 1,
+      },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+async function resolveStateValue(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  stateName: string,
+): Promise<string | null> {
+  // wm_order.state is a choice field — the stored value is numeric.
+  // Look up the value for the given label on the wm_order table.
+  // TODO: verify the state choice list table name and label format on
+  // a live instance — sys_choice rows for FSM are added by the
+  // com.snc.work_management plugin.
+  const response = await client.get("/api/now/table/sys_choice", {
+    params: {
+      sysparm_query: `name=${WORK_ORDER_TABLE}^element=state^label=${stateName}`,
+      sysparm_fields: "value,label",
+      sysparm_limit: 1,
+    },
+  })
+  const rows = (response.data.result || []) as Array<Record<string, unknown>>
+  if (rows.length === 0) return null
+  const value = rows[0].value
+  return typeof value === "string" ? value : null
+}
+
+const DEFAULT_LIST_FIELDS =
+  "sys_id,number,short_description,state,priority,assignment_group,assigned_to,location,contact,work_start,work_end,sys_updated_on"
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const filter_state = args.filter_state as string | undefined
+  const filter_assigned_to = args.filter_assigned_to as string | undefined
+  const filter_assignment_group = args.filter_assignment_group as string | undefined
+  const filter_location = args.filter_location as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = (args.fields as string) || DEFAULT_LIST_FIELDS
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (filter_state) {
+    const stateValue = await resolveStateValue(client, filter_state)
+    if (stateValue !== null) queryParts.push(`state=${stateValue}`)
+    else queryParts.push(`stateLABEL=${filter_state}`)
+  }
+  if (filter_assigned_to) queryParts.push(`assigned_to=${filter_assigned_to}`)
+  if (filter_assignment_group) queryParts.push(`assignment_group=${filter_assignment_group}`)
+  if (filter_location) queryParts.push(`location=${filter_location}`)
+
+  const response = await client.get(`/api/now/table/${WORK_ORDER_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_updated_on",
+      sysparm_order: "desc",
+      sysparm_fields: fields,
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    work_orders: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      state: r.state,
+      priority: r.priority,
+      assignment_group: r.assignment_group,
+      assigned_to: r.assigned_to,
+      location: r.location,
+      contact: r.contact,
+      work_start: r.work_start,
+      work_end: r.work_end,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for get action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrder = await findWorkOrder(client, sys_id, number)
+  if (!workOrder) {
+    return createErrorResult(`Work order not found: ${sys_id || number}`)
+  }
+
+  const workOrderSysId = workOrder.sys_id as string
+
+  // Best-effort counts of dependent tasks and history rows.
+  let taskCount = 0
+  let historyCount = 0
+  try {
+    const tasks = await client.get(`/api/now/table/${WORK_TASK_TABLE}`, {
+      params: { sysparm_query: `parent=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    taskCount = ((tasks.data.result || []) as Array<unknown>).length
+  } catch {
+    // wm_task may not be present on every instance variant. Swallow.
+  }
+  try {
+    const history = await client.get(`/api/now/table/${WORK_ORDER_HISTORY_TABLE}`, {
+      params: { sysparm_query: `order=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    historyCount = ((history.data.result || []) as Array<unknown>).length
+  } catch {
+    // TODO: verify wm_order_history join column on a live instance — some
+    // variants use `work_order` rather than `order`.
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id: workOrderSysId,
+    number: workOrder.number,
+    work_order: workOrder,
+    related: {
+      task_count: taskCount,
+      history_count: historyCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${workOrderSysId}`,
+  })
+}
+
+// ==================== CREATE ====================
+
+async function executeCreate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const short_description = args.short_description as string | undefined
+  if (!short_description) {
+    return createErrorResult("short_description is required for create action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = { short_description }
+  if (args.description) payload.description = args.description
+  if (args.priority !== undefined) payload.priority = args.priority
+  if (args.location) payload.location = args.location
+  if (args.contact) payload.contact = args.contact
+  if (args.company) payload.company = args.company
+  if (args.assignment_group) payload.assignment_group = args.assignment_group
+  if (args.assigned_to) payload.assigned_to = args.assigned_to
+  if (args.work_start) payload.work_start = args.work_start
+  if (args.work_end) payload.work_end = args.work_end
+
+  const response = await client.post(`/api/now/table/${WORK_ORDER_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create",
+    created: true,
+    sys_id: created.sys_id,
+    number: created.number,
+    work_order: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== ASSIGN ====================
+
+async function executeAssign(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const assigned_to = args.assigned_to as string | undefined
+  const assignment_group = args.assignment_group as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for assign action")
+  }
+  if (!assigned_to && !assignment_group) {
+    return createErrorResult("Provide at least one of assigned_to or assignment_group for assign action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrder = await findWorkOrder(client, sys_id, number)
+  if (!workOrder) {
+    return createErrorResult(`Work order not found: ${sys_id || number}`)
+  }
+
+  const targetSysId = workOrder.sys_id as string
+  const patch: Record<string, unknown> = {}
+  if (assigned_to) patch.assigned_to = assigned_to
+  if (assignment_group) patch.assignment_group = assignment_group
+
+  const response = await client.patch(`/api/now/table/${WORK_ORDER_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "assign",
+    assigned: true,
+    sys_id: targetSysId,
+    number: updated.number,
+    assigned_to: updated.assigned_to,
+    assignment_group: updated.assignment_group,
+    work_order: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== SCHEDULE ====================
+
+async function executeSchedule(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const work_start = args.work_start as string | undefined
+  const work_end = args.work_end as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for schedule action")
+  }
+  if (!work_start && !work_end) {
+    return createErrorResult("Provide at least one of work_start or work_end for schedule action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrder = await findWorkOrder(client, sys_id, number)
+  if (!workOrder) {
+    return createErrorResult(`Work order not found: ${sys_id || number}`)
+  }
+
+  const targetSysId = workOrder.sys_id as string
+  const patch: Record<string, unknown> = {}
+  if (work_start) patch.work_start = work_start
+  if (work_end) patch.work_end = work_end
+
+  const response = await client.patch(`/api/now/table/${WORK_ORDER_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "schedule",
+    scheduled: true,
+    sys_id: targetSysId,
+    number: updated.number,
+    work_start: updated.work_start,
+    work_end: updated.work_end,
+    work_order: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== UPDATE_STATUS ====================
+
+async function executeUpdateStatus(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const state = args.state as string | undefined
+  const close_notes = args.close_notes as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for update_status action")
+  }
+  if (!state) {
+    return createErrorResult("state is required for update_status action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrder = await findWorkOrder(client, sys_id, number)
+  if (!workOrder) {
+    return createErrorResult(`Work order not found: ${sys_id || number}`)
+  }
+
+  const stateValue = await resolveStateValue(client, state)
+  if (stateValue === null) {
+    return createErrorResult(
+      `State "${state}" is not configured on this instance for ${WORK_ORDER_TABLE}. Verify the state choice list — FSM state labels can be customised per instance.`,
+    )
+  }
+
+  const targetSysId = workOrder.sys_id as string
+  const patch: Record<string, unknown> = { state: stateValue }
+  if (close_notes) patch.close_notes = close_notes
+
+  const response = await client.patch(`/api/now/table/${WORK_ORDER_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "update_status",
+    updated: true,
+    sys_id: targetSysId,
+    number: updated.number,
+    new_state_value: stateValue,
+    new_state_label: state,
+    work_order: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${WORK_ORDER_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== LIST_TASKS ====================
+
+async function executeListTasks(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = (args.fields as string) || "sys_id,number,short_description,state,assigned_to,parent,sys_updated_on"
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for list_tasks action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const workOrder = await findWorkOrder(client, sys_id, number)
+  if (!workOrder) {
+    return createErrorResult(`Work order not found: ${sys_id || number}`)
+  }
+
+  const workOrderSysId = workOrder.sys_id as string
+  const response = await client.get(`/api/now/table/${WORK_TASK_TABLE}`, {
+    params: {
+      sysparm_query: `parent=${workOrderSysId}`,
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_fields: fields,
+    },
+  })
+
+  const tasks = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_tasks",
+    work_order: { sys_id: workOrderSysId, number: workOrder.number },
+    count: tasks.length,
+    tasks: tasks.map((t) => ({
+      sys_id: t.sys_id,
+      number: t.number,
+      short_description: t.short_description,
+      state: t.state,
+      assigned_to: t.assigned_to,
+      updated_at: t.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${WORK_TASK_TABLE}.do?sys_id=${t.sys_id}`,
+    })),
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/index.ts
@@ -234,3 +234,6 @@ export * from "./blast-radius/index.js"
 
 // Agile Development 2.0 (14 tools)
 export * from "./agile/index.js"
+
+// Field Service Management (3 tools)
+export * from "./fsm/index.js"


### PR DESCRIPTION
Fixes #122.

Adds the first Field Service Management coverage to the unified MCP server under a new `tools/fsm/` domain. Three tools wrap the core FSM workflow tables.

| Tool                        | Tables                                                          | Actions |
|-----------------------------|-----------------------------------------------------------------|---------|
| `snow_fsm_work_order_manage`| `wm_order`, `wm_task`, `wm_order_history`                       | 7       |
| `snow_fsm_dispatch_manage`  | `wm_agent`, `wm_dispatch_group`, `wm_skill`, `wm_qualification` | 5       |
| `snow_fsm_parts_manage`     | `pc_part`, `wm_part_requirement`, `pc_part_request`, `pc_stock_level` | 5 |

## Plugin gating

All three tools surface a clear `PLUGIN_MISSING` error mentioning `com.snc.work_management` when the primary table query 404s, instead of leaking the raw ServiceNow "Invalid table" error.

## Notes

- `wm_order.state` codes are resolved at runtime via `sys_choice` rather than hardcoded, because FSM state labels are configurable per instance. The `inputSchema` enum lists human-readable names (Draft, Scheduled, En Route, Onsite, Closed Complete, etc.).
- `snow_fsm_dispatch_manage.suggest_agent` is intentionally a read-only smart query (skill + availability window). It does NOT call FSM's AI dispatch / scheduling engines — those are separate plugins, out of scope per the issue.

## Verification status (GREENFIELD)

This is the first FSM coverage in the repo — no in-repo template existed to copy from. `docs.servicenow.com` is gated (every fetch redirected to login during this branch), so table and field names are best-effort against the documented FSM data model. Every uncertain field is flagged with a `TODO` comment in-source.

Local `bun packages/opencode/script/generate-tools-json.ts` run: 0 import failures, 3 new tools land in a new `field-service` subcategory.

Needs verification against a live instance with FSM plugin (`com.snc.work_management`) activated before merge.