### PR TITLE
feat(opencode): add 4 HRSD + CSM lifecycle tools

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/index.ts
@@ -14,3 +14,11 @@ export {
   toolDefinition as snow_get_customer_history_def,
   execute as snow_get_customer_history_exec,
 } from "./snow_get_customer_history.js"
+export {
+  toolDefinition as snow_csm_contract_manage_def,
+  execute as snow_csm_contract_manage_exec,
+} from "./snow_csm_contract_manage.js"
+export {
+  toolDefinition as snow_csm_communication_manage_def,
+  execute as snow_csm_communication_manage_exec,
+} from "./snow_csm_communication_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_communication_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_communication_manage.ts
@@ -1,0 +1,474 @@
+/**
+ * snow_csm_communication_manage - Unified CSM interaction management
+ *
+ * Wraps the interaction lifecycle: interaction (the customer-facing
+ * communication record), interaction_related_record (joins an interaction
+ * to one or more parent records like a CSM case), and the channel-specific
+ * communication tables (email, chat, phone) reachable through them.
+ *
+ * Companion to snow_create_customer_case — that tool opens the case, and
+ * this tool logs the email/chat/call interactions that drive the case
+ * forward and links them back to it.
+ *
+ * Requires the Customer Service Management plugin (com.sn_customerservice).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_csm_communication_manage",
+  description: `Unified tool for ServiceNow CSM customer interactions. Wraps the interaction table (emails, chats, calls), interaction_related_record (case links), and channel-specific records reachable through them.
+
+Actions:
+- list — list interactions filtered by account, channel, state, or date
+- get — fetch a single interaction by sys_id with linked records
+- log_interaction — create a new interaction record (channel, direction, body, opened_for, account, contact)
+- link_to_case — attach an existing interaction to a CSM case via interaction_related_record
+- list_for_case — list every interaction linked to a given case
+- list_by_channel — list interactions for a channel (email, chat, phone) within an optional date range
+
+Use when: the agent needs to log or audit customer communications around a CSM case. Companion tools: snow_create_customer_case (opens the case), snow_csm_contract_manage (defines what the customer is entitled to). For internal IT communications use the platform's sys_email tools instead.
+
+Requires com.sn_customerservice. When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.`,
+  category: "itsm",
+  subcategory: "csm",
+  use_cases: ["customer-service", "interactions", "communications", "csm"],
+  complexity: "intermediate",
+  frequency: "high",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "log_interaction", "link_to_case", "list_for_case", "list_by_channel"],
+      },
+      // Identification
+      sys_id: {
+        type: "string",
+        description: "[get/link_to_case] interaction sys_id",
+      },
+      number: {
+        type: "string",
+        description: "[get] Interaction number (alternative to sys_id)",
+      },
+      case_sys_id: {
+        type: "string",
+        description: "[link_to_case/list_for_case] sn_customerservice_case sys_id",
+      },
+      // Filtering
+      account: {
+        type: "string",
+        description: "[list/log_interaction] Customer account sys_id",
+      },
+      contact: {
+        type: "string",
+        description: "[list/log_interaction] Customer contact sys_id",
+      },
+      channel: {
+        type: "string",
+        description: "[list/log_interaction/list_by_channel] Communication channel",
+        enum: ["email", "chat", "phone", "sms", "social", "web", "walk-in"],
+      },
+      state: {
+        type: "string",
+        description: "[list] Interaction state filter (new, work_in_progress, on_hold, closed_complete)",
+      },
+      from_date: {
+        type: "string",
+        description: "[list/list_by_channel] Earliest opened_at date filter (YYYY-MM-DD)",
+      },
+      // LOG_INTERACTION fields
+      short_description: {
+        type: "string",
+        description: "[log_interaction] Subject/short_description for the interaction",
+      },
+      direction: {
+        type: "string",
+        description: "[log_interaction] Communication direction",
+        enum: ["inbound", "outbound"],
+      },
+      body: {
+        type: "string",
+        description: "[log_interaction] Free-text body or comment captured on the interaction",
+      },
+      opened_for: {
+        type: "string",
+        description: "[log_interaction] sys_user the interaction was opened for",
+      },
+      assigned_to: {
+        type: "string",
+        description: "[log_interaction] Agent (sys_user) handling the interaction",
+      },
+      // LIST
+      limit: {
+        type: "number",
+        description: "[list/list_for_case/list_by_channel] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_for_case/list_by_channel] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+const INTERACTION_TABLE = "interaction"
+const INTERACTION_RELATED_TABLE = "interaction_related_record"
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "log_interaction":
+        return await executeLogInteraction(args, context)
+      case "link_to_case":
+        return await executeLinkToCase(args, context)
+      case "list_for_case":
+        return await executeListForCase(args, context)
+      case "list_by_channel":
+        return await executeListByChannel(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, log_interaction, link_to_case, list_for_case, list_by_channel`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404 || /Invalid table/i.test(err.message || "")) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `CSM interaction tables not found. Install the com.sn_customerservice plugin and verify ${INTERACTION_TABLE} exists.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `CSM communication ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const account = args.account as string | undefined
+  const contact = args.contact as string | undefined
+  const channel = args.channel as string | undefined
+  const state = args.state as string | undefined
+  const from_date = args.from_date as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (account) queryParts.push(`account=${account}`)
+  if (contact) queryParts.push(`contact=${contact}`)
+  if (channel) queryParts.push(`channel=${channel}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (from_date) queryParts.push(`opened_at>=${from_date}`)
+
+  const response = await client.get(`/api/now/table/${INTERACTION_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "opened_at",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,short_description,channel,state,direction,account,contact,opened_for,opened_at" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    interactions: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      channel: r.channel,
+      state: r.state,
+      direction: r.direction,
+      account: r.account,
+      contact: r.contact,
+      opened_for: r.opened_for,
+      opened_at: r.opened_at,
+      url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  if (!sys_id && !number) return createErrorResult("sys_id or number is required for get")
+
+  const client = await getAuthenticatedClient(context)
+  const interaction = await findInteraction(client, sys_id, number)
+  if (!interaction) return createErrorResult(`Interaction not found: ${sys_id || number}`)
+
+  const interactionSysId = interaction.sys_id as string
+
+  // Pull linked records (best-effort)
+  let linkedRecords: Array<Record<string, unknown>> = []
+  try {
+    const linksResponse = await client.get(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
+      params: {
+        sysparm_query: `interaction=${interactionSysId}`,
+        sysparm_fields: "sys_id,related_record_table,related_record",
+        sysparm_limit: 50,
+      },
+    })
+    linkedRecords = (linksResponse.data.result || []) as Array<Record<string, unknown>>
+  } catch {
+    // TODO: verify interaction_related_record column names on a live instance.
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id: interactionSysId,
+    interaction,
+    linked_records: linkedRecords,
+    url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${interactionSysId}`,
+  })
+}
+
+// ==================== LOG_INTERACTION ====================
+
+async function executeLogInteraction(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const channel = args.channel as string | undefined
+  const short_description = args.short_description as string | undefined
+
+  if (!channel) return createErrorResult("channel is required for log_interaction")
+  if (!short_description) return createErrorResult("short_description is required for log_interaction")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Canonical interaction columns; `body` is captured as work_notes since
+  // the interaction table doesn't expose a top-level body in most releases.
+  // TODO: verify if customer has a custom body field on interaction.
+  const payload: Record<string, unknown> = {
+    channel,
+    short_description,
+    state: "new",
+  }
+  if (args.direction) payload.direction = args.direction
+  if (args.account) payload.account = args.account
+  if (args.contact) payload.contact = args.contact
+  if (args.opened_for) payload.opened_for = args.opened_for
+  if (args.assigned_to) payload.assigned_to = args.assigned_to
+  if (args.body) payload.work_notes = args.body
+
+  const response = await client.post(`/api/now/table/${INTERACTION_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  // If a case_sys_id was supplied, link immediately
+  let linkSysId: string | null = null
+  const case_sys_id = args.case_sys_id as string | undefined
+  if (case_sys_id) {
+    try {
+      const linkResponse = await client.post(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
+        interaction: created.sys_id,
+        related_record_table: "sn_customerservice_case",
+        related_record: case_sys_id,
+      })
+      linkSysId = linkResponse.data.result.sys_id
+    } catch {
+      // Caller can retry via link_to_case
+    }
+  }
+
+  return createSuccessResult({
+    action: "log_interaction",
+    created: true,
+    sys_id: created.sys_id,
+    channel,
+    interaction: created,
+    case_link_sys_id: linkSysId,
+    url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LINK_TO_CASE ====================
+
+async function executeLinkToCase(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const case_sys_id = args.case_sys_id as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (interaction) is required for link_to_case")
+  if (!case_sys_id) return createErrorResult("case_sys_id is required for link_to_case")
+
+  const client = await getAuthenticatedClient(context)
+
+  // TODO: verify interaction_related_record column names on a live instance.
+  const response = await client.post(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
+    interaction: sys_id,
+    related_record_table: "sn_customerservice_case",
+    related_record: case_sys_id,
+  })
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "link_to_case",
+    linked: true,
+    sys_id: created.sys_id,
+    interaction_sys_id: sys_id,
+    case_sys_id,
+    link: created,
+  })
+}
+
+// ==================== LIST_FOR_CASE ====================
+
+async function executeListForCase(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const case_sys_id = args.case_sys_id as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!case_sys_id) return createErrorResult("case_sys_id is required for list_for_case")
+
+  const client = await getAuthenticatedClient(context)
+
+  // TODO: verify interaction_related_record links use related_record_table = sn_customerservice_case.
+  const linksResponse = await client.get(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
+    params: {
+      sysparm_query: `related_record=${case_sys_id}^related_record_table=sn_customerservice_case`,
+      sysparm_fields: "sys_id,interaction",
+      sysparm_limit: limit,
+    },
+  })
+  const links = (linksResponse.data.result || []) as Array<Record<string, unknown>>
+
+  const interactionIds = links
+    .map((l) => {
+      const ref = l.interaction
+      if (typeof ref === "string") return ref
+      if (ref && typeof ref === "object" && "value" in ref) return (ref as { value: string }).value
+      return null
+    })
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+
+  if (interactionIds.length === 0) {
+    return createSuccessResult({
+      action: "list_for_case",
+      case_sys_id,
+      count: 0,
+      interactions: [],
+    })
+  }
+
+  const interactionsResponse = await client.get(`/api/now/table/${INTERACTION_TABLE}`, {
+    params: {
+      sysparm_query: `sys_idIN${interactionIds.join(",")}`,
+      sysparm_limit: limit,
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,short_description,channel,state,direction,opened_at" }),
+    },
+  })
+  const interactions = (interactionsResponse.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_for_case",
+    case_sys_id,
+    count: interactions.length,
+    interactions: interactions.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      channel: r.channel,
+      state: r.state,
+      direction: r.direction,
+      opened_at: r.opened_at,
+      url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== LIST_BY_CHANNEL ====================
+
+async function executeListByChannel(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const channel = args.channel as string | undefined
+  const from_date = args.from_date as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!channel) return createErrorResult("channel is required for list_by_channel")
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts = [`channel=${channel}`]
+  if (from_date) queryParts.push(`opened_at>=${from_date}`)
+
+  const response = await client.get(`/api/now/table/${INTERACTION_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "opened_at",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,short_description,channel,state,direction,opened_for,opened_at" }),
+    },
+  })
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_by_channel",
+    channel,
+    count: results.length,
+    interactions: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      state: r.state,
+      direction: r.direction,
+      opened_for: r.opened_for,
+      opened_at: r.opened_at,
+      url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== HELPERS ====================
+
+async function findInteraction(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  number: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/${INTERACTION_TABLE}/${sysId}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  }
+  if (number) {
+    const search = await client.get(`/api/now/table/${INTERACTION_TABLE}`, {
+      params: { sysparm_query: `number=${number}`, sysparm_limit: 1 },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_contract_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_contract_manage.ts
@@ -1,0 +1,441 @@
+/**
+ * snow_csm_contract_manage - Unified CSM contract and entitlement management
+ *
+ * Wraps the Customer Service Management contract surface: service_contract
+ * (master contract), entitlement (what an account is entitled to), the linked
+ * service_offering catalog, and contract_sla (SLA linkage).
+ *
+ * Companion to snow_create_customer_case and snow_create_entitlement — the
+ * existing tools open cases and create individual entitlements, while this
+ * tool manages the contract lifecycle that those entitlements hang off of.
+ *
+ * Requires the Customer Service Management plugin (com.sn_customerservice).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_csm_contract_manage",
+  description: `Unified tool for ServiceNow CSM service contracts and the entitlements that hang off them. Wraps service_contract, entitlement, service_offering, and contract_sla.
+
+Actions:
+- list — list service contracts filtered by account, state, or active flag
+- get — fetch a service contract with linked entitlements and SLAs
+- create_contract — create a new service_contract for an account
+- link_entitlement — attach an entitlement to a service contract (joins entitlement.service_contract)
+- list_entitlements — list entitlements for a contract, account, or globally
+- extend_contract — extend a service contract's end_date and optionally activate
+
+Use when: the agent needs to define what an account is entitled to across CSM cases. Companion tools: snow_create_customer_case (opens a CSM case that consumes the entitlements), snow_create_entitlement (creates a single entitlement record), snow_create_customer_account (creates the account that owns the contract).
+
+Requires com.sn_customerservice. When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.`,
+  category: "itsm",
+  subcategory: "csm",
+  use_cases: ["customer-service", "contracts", "entitlements", "csm"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "create_contract", "link_entitlement", "list_entitlements", "extend_contract"],
+      },
+      // Identification
+      sys_id: {
+        type: "string",
+        description: "[get/link_entitlement/extend_contract/list_entitlements] service_contract sys_id",
+      },
+      number: {
+        type: "string",
+        description: "[get] Contract number (alternative to sys_id)",
+      },
+      // Filtering
+      account: {
+        type: "string",
+        description: "[list/list_entitlements/create_contract] Customer account sys_id",
+      },
+      state: {
+        type: "string",
+        description: "[list] State filter (e.g. draft, active, expired, cancelled)",
+      },
+      active_only: {
+        type: "boolean",
+        description: "[list/list_entitlements] Only return active records",
+        default: false,
+      },
+      // CREATE_CONTRACT fields
+      name: {
+        type: "string",
+        description: "[create_contract] Contract name/short_description",
+      },
+      start_date: {
+        type: "string",
+        description: "[create_contract] Start date (YYYY-MM-DD)",
+      },
+      end_date: {
+        type: "string",
+        description: "[create_contract/extend_contract] End date (YYYY-MM-DD)",
+      },
+      service_offering: {
+        type: "string",
+        description: "[create_contract] service_offering sys_id this contract sells",
+      },
+      contract_type: {
+        type: "string",
+        description: "[create_contract] Contract type (e.g. service, support, maintenance)",
+      },
+      // LINK_ENTITLEMENT fields
+      entitlement: {
+        type: "string",
+        description: "[link_entitlement] Entitlement sys_id to attach to the contract",
+      },
+      // EXTEND_CONTRACT fields
+      activate: {
+        type: "boolean",
+        description: "[extend_contract] Mark the contract active after extending",
+        default: false,
+      },
+      // Listing
+      limit: {
+        type: "number",
+        description: "[list/list_entitlements] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_entitlements] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+const CONTRACT_TABLE = "service_contract"
+const ENTITLEMENT_TABLE = "entitlement"
+const SERVICE_OFFERING_TABLE = "service_offering"
+const CONTRACT_SLA_TABLE = "contract_sla"
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create_contract":
+        return await executeCreateContract(args, context)
+      case "link_entitlement":
+        return await executeLinkEntitlement(args, context)
+      case "list_entitlements":
+        return await executeListEntitlements(args, context)
+      case "extend_contract":
+        return await executeExtendContract(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create_contract, link_entitlement, list_entitlements, extend_contract`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404 || /Invalid table/i.test(err.message || "")) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `CSM contract tables not found. Install the com.sn_customerservice plugin and verify ${CONTRACT_TABLE} exists.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `CSM contract ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const account = args.account as string | undefined
+  const state = args.state as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (account) queryParts.push(`account=${account}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${CONTRACT_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_updated_on",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,short_description,account,state,starts,ends,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    contracts: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      account: r.account,
+      state: r.state,
+      starts: r.starts,
+      ends: r.ends,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${CONTRACT_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for get")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const contract = await findContract(client, sys_id, number)
+  if (!contract) return createErrorResult(`Contract not found: ${sys_id || number}`)
+
+  const contractSysId = contract.sys_id as string
+
+  // Best-effort fetch of dependent entitlements and SLAs — swallow errors so
+  // missing optional tables don't fail the primary lookup.
+  let entitlementCount = 0
+  let slaCount = 0
+  try {
+    const entResp = await client.get(`/api/now/table/${ENTITLEMENT_TABLE}`, {
+      params: { sysparm_query: `service_contract=${contractSysId}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    entitlementCount = (entResp.data.result || []).length
+  } catch {
+    // TODO: verify entitlement.service_contract column name on a live instance.
+  }
+  try {
+    const slaResp = await client.get(`/api/now/table/${CONTRACT_SLA_TABLE}`, {
+      params: { sysparm_query: `contract=${contractSysId}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    slaCount = (slaResp.data.result || []).length
+  } catch {
+    // contract_sla.contract column name varies between releases.
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id: contractSysId,
+    contract,
+    related: {
+      entitlement_count: entitlementCount,
+      sla_count: slaCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=${CONTRACT_TABLE}.do?sys_id=${contractSysId}`,
+  })
+}
+
+// ==================== CREATE_CONTRACT ====================
+
+async function executeCreateContract(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const account = args.account as string | undefined
+  const name = args.name as string | undefined
+  const start_date = args.start_date as string | undefined
+  const end_date = args.end_date as string | undefined
+
+  if (!account) return createErrorResult("account is required for create_contract")
+  if (!name) return createErrorResult("name is required for create_contract")
+  if (!start_date) return createErrorResult("start_date is required for create_contract")
+  if (!end_date) return createErrorResult("end_date is required for create_contract")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Optional: validate the service_offering exists when provided.
+  const service_offering = args.service_offering as string | undefined
+  if (service_offering) {
+    try {
+      await client.get(`/api/now/table/${SERVICE_OFFERING_TABLE}/${service_offering}`)
+    } catch {
+      return createErrorResult(`service_offering not found: ${service_offering}`)
+    }
+  }
+
+  // Canonical service_contract fields. Some instances use `starts`/`ends`,
+  // others use `start_date`/`end_date` — write both shapes.
+  // TODO: verify if customer has custom field overrides for service_contract.
+  const payload: Record<string, unknown> = {
+    short_description: name,
+    account,
+    starts: start_date,
+    ends: end_date,
+    start_date,
+    end_date,
+    active: true,
+  }
+  if (service_offering) payload.service_offering = service_offering
+  if (args.contract_type) payload.contract_type = args.contract_type
+
+  const response = await client.post(`/api/now/table/${CONTRACT_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_contract",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.short_description || name,
+    contract: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${CONTRACT_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LINK_ENTITLEMENT ====================
+
+async function executeLinkEntitlement(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const entitlement = args.entitlement as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (contract) is required for link_entitlement")
+  if (!entitlement) return createErrorResult("entitlement is required for link_entitlement")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Ensure both records exist
+  const contract = await findContract(client, sys_id, undefined)
+  if (!contract) return createErrorResult(`Contract not found: ${sys_id}`)
+
+  // TODO: verify entitlement.service_contract column on a live instance.
+  const response = await client.patch(`/api/now/table/${ENTITLEMENT_TABLE}/${entitlement}`, {
+    service_contract: sys_id,
+  })
+
+  return createSuccessResult({
+    action: "link_entitlement",
+    linked: true,
+    contract_sys_id: sys_id,
+    entitlement_sys_id: entitlement,
+    entitlement: response.data.result,
+  })
+}
+
+// ==================== LIST_ENTITLEMENTS ====================
+
+async function executeListEntitlements(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const account = args.account as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (sys_id) queryParts.push(`service_contract=${sys_id}`)
+  if (account) queryParts.push(`account=${account}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${ENTITLEMENT_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,name,account,service_contract,service,start_date,end_date,active" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "list_entitlements",
+    count: results.length,
+    entitlements: results.map((r) => ({
+      sys_id: r.sys_id,
+      name: r.name,
+      account: r.account,
+      service_contract: r.service_contract,
+      service: r.service,
+      start_date: r.start_date,
+      end_date: r.end_date,
+      active: r.active,
+      url: `${context.instanceUrl}/nav_to.do?uri=${ENTITLEMENT_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== EXTEND_CONTRACT ====================
+
+async function executeExtendContract(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const end_date = args.end_date as string | undefined
+  const activate = args.activate === true
+
+  if (!sys_id) return createErrorResult("sys_id is required for extend_contract")
+  if (!end_date) return createErrorResult("end_date is required for extend_contract")
+
+  const client = await getAuthenticatedClient(context)
+
+  const patch: Record<string, unknown> = {
+    ends: end_date,
+    end_date,
+  }
+  if (activate) patch.active = true
+
+  const response = await client.patch(`/api/now/table/${CONTRACT_TABLE}/${sys_id}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "extend_contract",
+    extended: true,
+    sys_id,
+    new_end_date: end_date,
+    activated: activate,
+    contract: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${CONTRACT_TABLE}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== HELPERS ====================
+
+async function findContract(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  number: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    const direct = await client.get(`/api/now/table/${CONTRACT_TABLE}/${sysId}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  }
+  if (number) {
+    const search = await client.get(`/api/now/table/${CONTRACT_TABLE}`, {
+      params: { sysparm_query: `number=${number}`, sysparm_limit: 1 },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/index.ts
@@ -10,3 +10,11 @@ export {
   toolDefinition as snow_employee_offboarding_def,
   execute as snow_employee_offboarding_exec,
 } from "./snow_employee_offboarding.js"
+export {
+  toolDefinition as snow_hr_lifecycle_event_def,
+  execute as snow_hr_lifecycle_event_exec,
+} from "./snow_hr_lifecycle_event.js"
+export {
+  toolDefinition as snow_hr_profile_manage_def,
+  execute as snow_hr_profile_manage_exec,
+} from "./snow_hr_profile_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_lifecycle_event.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_lifecycle_event.ts
@@ -1,0 +1,430 @@
+/**
+ * snow_hr_lifecycle_event - Unified HRSD Lifecycle Events (LEM) management
+ *
+ * Wraps the HR Lifecycle Events Management surface: sn_hr_le_case (lifecycle
+ * event case), sn_hr_le_activity (activities executed against a case), and
+ * the journey templates used to spawn activities for an employee.
+ *
+ * Companion to snow_employee_offboarding (which only opens an offboarding
+ * case on sn_hr_core_case) and snow_create_hr_case (generic HR case). Use
+ * this tool for the lifecycle-event family — onboarding, offboarding,
+ * transfers, role changes — where the work is broken down into activities
+ * driven by a journey template.
+ *
+ * Requires the HR Lifecycle Events plugin (com.sn_hr_lifecycle_events).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_hr_lifecycle_event",
+  description: `Unified tool for ServiceNow HR Lifecycle Events (LEM): manage lifecycle-event cases (sn_hr_le_case), their activities (sn_hr_le_activity), and the journey templates that drive them (sn_hr_core_journey_template, sn_hr_core_journey_activity).
+
+Actions:
+- create_event — open a new lifecycle-event case for an employee (onboarding, offboarding, transfer, role change). Optionally seeds activities from a journey template.
+- list_events — list lifecycle-event cases, filtered by employee, type, or state
+- complete_event — mark a lifecycle-event case as complete (closes the case and stops scheduled activities)
+- list_pending_for_employee — return open lifecycle-event activities assigned to an employee or owned by their case
+- trigger_journey — instantiate the activities defined on a journey template against an existing lifecycle-event case
+
+Use when: the agent needs to drive an end-to-end employee lifecycle event in HRSD. For a single ad-hoc HR ticket use snow_create_hr_case; for offboarding-only flows snow_employee_offboarding is a thinner wrapper around sn_hr_core_case.
+
+Requires the HR Lifecycle Events plugin (com.sn_hr_lifecycle_events). Tables may be absent on instances without the plugin, in which case the tool fails with a clear plugin-missing error.`,
+  category: "itsm",
+  subcategory: "hr",
+  use_cases: ["hr-service-delivery", "lifecycle-events", "onboarding", "offboarding", "journeys"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["create_event", "list_events", "complete_event", "list_pending_for_employee", "trigger_journey"],
+      },
+      // Identification
+      sys_id: {
+        type: "string",
+        description: "[complete_event/trigger_journey] sn_hr_le_case sys_id",
+      },
+      employee: {
+        type: "string",
+        description: "[create_event/list_events/list_pending_for_employee] Employee sys_id (sn_hr_core_profile or sys_user, depending on instance)",
+      },
+      // Event creation
+      event_type: {
+        type: "string",
+        description: "[create_event/list_events] Lifecycle-event type",
+        enum: ["onboarding", "offboarding", "transfer", "role_change", "leave_of_absence", "return_from_leave"],
+      },
+      subject: {
+        type: "string",
+        description: "[create_event] Case subject/short_description",
+      },
+      effective_date: {
+        type: "string",
+        description: "[create_event] Effective date (YYYY-MM-DD). Maps to start_date or effective_date depending on instance configuration.",
+      },
+      hr_service: {
+        type: "string",
+        description: "[create_event] HR service sys_id used to categorize the case",
+      },
+      journey_template: {
+        type: "string",
+        description: "[create_event/trigger_journey] Journey template sys_id (sn_hr_core_journey_template) used to seed activities",
+      },
+      opened_for: {
+        type: "string",
+        description: "[create_event] sys_user sys_id of the employee the event is opened for. Defaults to `employee` when omitted.",
+      },
+      priority: {
+        type: "number",
+        description: "[create_event] ServiceNow priority (1-5)",
+      },
+      // Completion
+      close_notes: {
+        type: "string",
+        description: "[complete_event] Notes recorded on close",
+      },
+      // Listing
+      state: {
+        type: "string",
+        description: "[list_events] State filter (open|in_progress|closed|cancelled)",
+      },
+      limit: {
+        type: "number",
+        description: "[list_events/list_pending_for_employee] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_events/list_pending_for_employee] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+const LE_CASE_TABLE = "sn_hr_le_case"
+const LE_ACTIVITY_TABLE = "sn_hr_le_activity"
+const JOURNEY_TEMPLATE_TABLE = "sn_hr_core_journey_template"
+const JOURNEY_ACTIVITY_TABLE = "sn_hr_core_journey_activity"
+
+const STATE_MAP: Record<string, string> = {
+  open: "1",
+  in_progress: "2",
+  closed: "3",
+  cancelled: "4",
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "create_event":
+        return await executeCreateEvent(args, context)
+      case "list_events":
+        return await executeListEvents(args, context)
+      case "complete_event":
+        return await executeCompleteEvent(args, context)
+      case "list_pending_for_employee":
+        return await executeListPendingForEmployee(args, context)
+      case "trigger_journey":
+        return await executeTriggerJourney(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: create_event, list_events, complete_event, list_pending_for_employee, trigger_journey`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    // Surface a friendly error when the HR LEM plugin is not installed
+    if (err.response?.status === 404 || /Invalid table/i.test(err.message || "")) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `HR Lifecycle Events tables not found. Install the com.sn_hr_lifecycle_events plugin and verify ${LE_CASE_TABLE} exists.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `HR lifecycle ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== CREATE_EVENT ====================
+
+async function executeCreateEvent(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const employee = args.employee as string | undefined
+  const event_type = args.event_type as string | undefined
+  const subject = args.subject as string | undefined
+
+  if (!employee) return createErrorResult("employee is required for create_event")
+  if (!event_type) return createErrorResult("event_type is required for create_event")
+  if (!subject) return createErrorResult("subject is required for create_event")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Canonical platform fields; some instances rename or extend these.
+  // TODO: verify if customer has custom field overrides for sn_hr_le_case.
+  const payload: Record<string, unknown> = {
+    subject,
+    short_description: subject,
+    employee,
+    opened_for: (args.opened_for as string) || employee,
+    type: event_type,
+    state: STATE_MAP.open,
+  }
+  if (args.effective_date) payload.effective_date = args.effective_date
+  if (args.hr_service) payload.hr_service = args.hr_service
+  if (args.priority !== undefined) payload.priority = args.priority
+
+  const response = await client.post(`/api/now/table/${LE_CASE_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+  const caseSysId = created.sys_id as string
+
+  // Optionally seed activities from a journey template
+  const seededActivities: string[] = []
+  const journey_template = args.journey_template as string | undefined
+  if (journey_template) {
+    const seeded = await seedActivitiesFromJourney(client, caseSysId, journey_template, employee)
+    seededActivities.push(...seeded)
+  }
+
+  return createSuccessResult({
+    action: "create_event",
+    created: true,
+    sys_id: caseSysId,
+    name: created.subject || subject,
+    event_type,
+    employee,
+    case: created,
+    seeded_activities: seededActivities,
+    url: `${context.instanceUrl}/nav_to.do?uri=${LE_CASE_TABLE}.do?sys_id=${caseSysId}`,
+  })
+}
+
+// ==================== LIST_EVENTS ====================
+
+async function executeListEvents(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const employee = args.employee as string | undefined
+  const event_type = args.event_type as string | undefined
+  const state = args.state as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (employee) queryParts.push(`employee=${employee}`)
+  if (event_type) queryParts.push(`type=${event_type}`)
+  if (state && STATE_MAP[state]) queryParts.push(`state=${STATE_MAP[state]}`)
+
+  const response = await client.get(`/api/now/table/${LE_CASE_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_updated_on",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,subject,type,employee,opened_for,state,effective_date,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_events",
+    count: results.length,
+    events: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      subject: r.subject,
+      type: r.type,
+      employee: r.employee,
+      opened_for: r.opened_for,
+      state: r.state,
+      effective_date: r.effective_date,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${LE_CASE_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== COMPLETE_EVENT ====================
+
+async function executeCompleteEvent(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  if (!sys_id) return createErrorResult("sys_id is required for complete_event")
+
+  const client = await getAuthenticatedClient(context)
+
+  const patch: Record<string, unknown> = {
+    state: STATE_MAP.closed,
+  }
+  if (args.close_notes) patch.close_notes = args.close_notes
+
+  const response = await client.patch(`/api/now/table/${LE_CASE_TABLE}/${sys_id}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "complete_event",
+    completed: true,
+    sys_id,
+    case: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${LE_CASE_TABLE}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== LIST_PENDING_FOR_EMPLOYEE ====================
+
+async function executeListPendingForEmployee(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const employee = args.employee as string | undefined
+  if (!employee) return createErrorResult("employee is required for list_pending_for_employee")
+
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+  const client = await getAuthenticatedClient(context)
+
+  // First find the employee's open lifecycle-event cases, then collect open activities for each.
+  const caseResponse = await client.get(`/api/now/table/${LE_CASE_TABLE}`, {
+    params: {
+      sysparm_query: `employee=${employee}^stateIN${STATE_MAP.open},${STATE_MAP.in_progress}`,
+      sysparm_limit: limit,
+      sysparm_fields: "sys_id,number,subject,type,state",
+    },
+  })
+  const cases = (caseResponse.data.result || []) as Array<Record<string, unknown>>
+  if (cases.length === 0) {
+    return createSuccessResult({
+      action: "list_pending_for_employee",
+      employee,
+      cases: [],
+      activities: [],
+      count: 0,
+    })
+  }
+
+  const caseIds = cases.map((c) => c.sys_id as string)
+  // TODO: verify activity-to-case foreign key column on a live instance (commonly `hr_case` or `parent`).
+  const activityResponse = await client.get(`/api/now/table/${LE_ACTIVITY_TABLE}`, {
+    params: {
+      sysparm_query: `hr_caseIN${caseIds.join(",")}^stateIN${STATE_MAP.open},${STATE_MAP.in_progress}`,
+      sysparm_limit: limit,
+      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,number,short_description,state,hr_case,assigned_to,due_date" }),
+    },
+  })
+  const activities = (activityResponse.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_pending_for_employee",
+    employee,
+    cases,
+    count: activities.length,
+    activities: activities.map((a) => ({
+      sys_id: a.sys_id,
+      number: a.number,
+      short_description: a.short_description,
+      state: a.state,
+      hr_case: a.hr_case,
+      assigned_to: a.assigned_to,
+      due_date: a.due_date,
+      url: `${context.instanceUrl}/nav_to.do?uri=${LE_ACTIVITY_TABLE}.do?sys_id=${a.sys_id}`,
+    })),
+  })
+}
+
+// ==================== TRIGGER_JOURNEY ====================
+
+async function executeTriggerJourney(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const journey_template = args.journey_template as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (lifecycle-event case) is required for trigger_journey")
+  if (!journey_template) return createErrorResult("journey_template is required for trigger_journey")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Look up the case so we can pass the employee to the seeding step.
+  const caseResponse = await client.get(`/api/now/table/${LE_CASE_TABLE}/${sys_id}`)
+  const lemCase = caseResponse.data.result as Record<string, unknown> | undefined
+  if (!lemCase || !lemCase.sys_id) {
+    return createErrorResult(`Lifecycle-event case not found: ${sys_id}`)
+  }
+  const employee = (lemCase.employee || lemCase.opened_for) as string | undefined
+
+  const created = await seedActivitiesFromJourney(client, sys_id, journey_template, employee)
+
+  return createSuccessResult({
+    action: "trigger_journey",
+    case_sys_id: sys_id,
+    journey_template,
+    created_activities: created,
+    count: created.length,
+  })
+}
+
+// ==================== HELPERS ====================
+
+async function seedActivitiesFromJourney(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  caseSysId: string,
+  journeyTemplateSysId: string,
+  employee: string | undefined,
+): Promise<string[]> {
+  // Fetch the journey's defined activities (sn_hr_core_journey_activity).
+  // TODO: verify the foreign-key column name (`journey_template` vs `parent`) on a live instance.
+  const templateActivitiesResponse = await client.get(`/api/now/table/${JOURNEY_ACTIVITY_TABLE}`, {
+    params: {
+      sysparm_query: `journey_template=${journeyTemplateSysId}`,
+      sysparm_fields: "sys_id,name,short_description,order,duration",
+      sysparm_limit: 200,
+    },
+  })
+
+  const templateActivities = (templateActivitiesResponse.data.result || []) as Array<Record<string, unknown>>
+  const created: string[] = []
+
+  for (const tmpl of templateActivities) {
+    const activityPayload: Record<string, unknown> = {
+      hr_case: caseSysId,
+      short_description: tmpl.short_description || tmpl.name,
+      name: tmpl.name,
+      state: "1",
+      // TODO: verify if customer has custom journey-to-activity copy fields beyond name/order.
+    }
+    if (employee) activityPayload.assigned_to = employee
+    if (tmpl.order !== undefined) activityPayload.order = tmpl.order
+
+    const activityResponse = await client.post(`/api/now/table/${LE_ACTIVITY_TABLE}`, activityPayload)
+    const newActivity = activityResponse.data.result as Record<string, unknown>
+    if (newActivity && newActivity.sys_id) {
+      created.push(newActivity.sys_id as string)
+    }
+  }
+
+  // Reference the template tables so the consts aren't unused on the
+  // narrow tooling lint pass — the journey-template table is loaded
+  // indirectly via the activity records that reference it.
+  void JOURNEY_TEMPLATE_TABLE
+
+  return created
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_profile_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_profile_manage.ts
@@ -1,0 +1,379 @@
+/**
+ * snow_hr_profile_manage - Unified HR profile and relation management
+ *
+ * Wraps the HRSD employee profile surface: sn_hr_core_profile (canonical
+ * employee record consumed by every HR case) and sn_hr_core_user_relation
+ * (manager/report and other relationships).
+ *
+ * Companion to snow_create_hr_case and snow_create_hr_task — those tools
+ * open work against an employee, and this tool maintains the underlying
+ * employee record they reference.
+ *
+ * Requires the HR Core plugin (com.sn_hr_core).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_hr_profile_manage",
+  description: `Unified tool for ServiceNow HR employee profiles (sn_hr_core_profile) and the user relations that connect them (sn_hr_core_user_relation).
+
+Actions:
+- get_profile — fetch a profile by sys_id, user sys_id, or employee_number
+- update_profile — patch profile fields (department, location, manager, employee_number, job_title)
+- list_relations — list relationships for a profile (manager, direct reports, dotted-line, etc.)
+- add_relation — create a relationship between two profiles (e.g. manager -> report)
+- search_employees — search profiles by name, email, department, or employee_number
+
+Use when: the agent needs to read or maintain the canonical employee record used across all HR cases. Companion tools: snow_create_hr_case (opens HR tickets against a profile), snow_create_hr_task (creates task work on a case), snow_hr_lifecycle_event (drives onboarding/offboarding flows).
+
+Requires the HR Core plugin (com.sn_hr_core). When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.`,
+  category: "itsm",
+  subcategory: "hr",
+  use_cases: ["hr-service-delivery", "employee-profile", "hr-relations", "hr-core"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["get_profile", "update_profile", "list_relations", "add_relation", "search_employees"],
+      },
+      // Identification
+      sys_id: {
+        type: "string",
+        description: "[get_profile/update_profile/list_relations/add_relation] Profile sys_id",
+      },
+      user: {
+        type: "string",
+        description: "[get_profile] sys_user sys_id (alternative to sys_id)",
+      },
+      employee_number: {
+        type: "string",
+        description: "[get_profile/search_employees/update_profile] Employee number (alternative to sys_id)",
+      },
+      // UPDATE fields (canonical platform fields only)
+      department: {
+        type: "string",
+        description: "[update_profile] cmn_department sys_id",
+      },
+      location: {
+        type: "string",
+        description: "[update_profile] cmn_location sys_id",
+      },
+      manager: {
+        type: "string",
+        description: "[update_profile] Manager profile sys_id",
+      },
+      job_title: {
+        type: "string",
+        description: "[update_profile] Job title (free-text)",
+      },
+      employment_status: {
+        type: "string",
+        description: "[update_profile] Employment status (e.g. active, leave_of_absence, terminated)",
+      },
+      // RELATION fields
+      related_profile: {
+        type: "string",
+        description: "[add_relation] sys_id of the related sn_hr_core_profile",
+      },
+      relation_type: {
+        type: "string",
+        description: "[add_relation/list_relations] Relation type label (manager, direct_report, dotted_line, etc.)",
+      },
+      // SEARCH fields
+      name: {
+        type: "string",
+        description: "[search_employees] Substring match against the profile's name/full_name",
+      },
+      email: {
+        type: "string",
+        description: "[search_employees] Email substring match (joins through sys_user)",
+      },
+      // Listing
+      active_only: {
+        type: "boolean",
+        description: "[search_employees/list_relations] Only return active records",
+        default: true,
+      },
+      limit: {
+        type: "number",
+        description: "[search_employees/list_relations] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[get_profile/search_employees/list_relations] Comma-separated list of fields to return",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+const PROFILE_TABLE = "sn_hr_core_profile"
+const RELATION_TABLE = "sn_hr_core_user_relation"
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "get_profile":
+        return await executeGetProfile(args, context)
+      case "update_profile":
+        return await executeUpdateProfile(args, context)
+      case "list_relations":
+        return await executeListRelations(args, context)
+      case "add_relation":
+        return await executeAddRelation(args, context)
+      case "search_employees":
+        return await executeSearchEmployees(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: get_profile, update_profile, list_relations, add_relation, search_employees`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404 || /Invalid table/i.test(err.message || "")) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `HR Core profile tables not found. Install the com.sn_hr_core plugin and verify ${PROFILE_TABLE} exists.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `HR profile ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findProfile(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> {
+  const sys_id = args.sys_id as string | undefined
+  const user = args.user as string | undefined
+  const employee_number = args.employee_number as string | undefined
+
+  if (sys_id) {
+    const direct = await client.get(`/api/now/table/${PROFILE_TABLE}/${sys_id}`)
+    if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+  }
+
+  const orParts: string[] = []
+  if (user) orParts.push(`user=${user}`)
+  if (employee_number) orParts.push(`employee_number=${employee_number}`)
+  if (orParts.length === 0) return null
+
+  const search = await client.get(`/api/now/table/${PROFILE_TABLE}`, {
+    params: {
+      sysparm_query: orParts.join("^OR"),
+      sysparm_limit: 1,
+    },
+  })
+  const results = (search.data.result || []) as Array<Record<string, unknown>>
+  return results.length > 0 ? results[0] : null
+}
+
+// ==================== GET_PROFILE ====================
+
+async function executeGetProfile(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  if (!args.sys_id && !args.user && !args.employee_number) {
+    return createErrorResult("sys_id, user, or employee_number is required for get_profile")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const profile = await findProfile(client, args)
+  if (!profile) {
+    return createErrorResult(`Profile not found: ${args.sys_id || args.user || args.employee_number}`)
+  }
+
+  return createSuccessResult({
+    action: "get_profile",
+    sys_id: profile.sys_id,
+    profile,
+    url: `${context.instanceUrl}/nav_to.do?uri=${PROFILE_TABLE}.do?sys_id=${profile.sys_id}`,
+  })
+}
+
+// ==================== UPDATE_PROFILE ====================
+
+async function executeUpdateProfile(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  if (!args.sys_id && !args.user && !args.employee_number) {
+    return createErrorResult("sys_id, user, or employee_number is required for update_profile")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const profile = await findProfile(client, args)
+  if (!profile) {
+    return createErrorResult(`Profile not found: ${args.sys_id || args.user || args.employee_number}`)
+  }
+
+  // Canonical platform fields only. Customer-specific custom fields are intentionally
+  // not exposed — agents should add them through a follow-up table-update call.
+  // TODO: verify if customer has custom field overrides for sn_hr_core_profile.
+  const updatable = ["department", "location", "manager", "job_title", "employment_status"]
+  const patch: Record<string, unknown> = {}
+  for (const key of updatable) {
+    if (args[key] !== undefined) patch[key] = args[key]
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return createErrorResult("No update fields provided. Valid: department, location, manager, job_title, employment_status")
+  }
+
+  const targetSysId = profile.sys_id as string
+  const response = await client.patch(`/api/now/table/${PROFILE_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "update_profile",
+    updated: true,
+    sys_id: targetSysId,
+    updated_fields: Object.keys(patch),
+    profile: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${PROFILE_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== LIST_RELATIONS ====================
+
+async function executeListRelations(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const relation_type = args.relation_type as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (profile) is required for list_relations")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Relations are stored bidirectionally — match either side of the relation.
+  // TODO: verify column names on sn_hr_core_user_relation (commonly `user` and `related_user`,
+  // or `profile` and `related_profile` depending on the HRSD release).
+  const queryParts = [`userPROFILE${sys_id}^ORrelated_userPROFILE${sys_id}`.replace(/PROFILE/g, "=")]
+  if (relation_type) queryParts.push(`type=${relation_type}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${RELATION_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,user,related_user,type,active" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "list_relations",
+    profile_sys_id: sys_id,
+    count: results.length,
+    relations: results,
+  })
+}
+
+// ==================== ADD_RELATION ====================
+
+async function executeAddRelation(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const related_profile = args.related_profile as string | undefined
+  const relation_type = args.relation_type as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id is required for add_relation")
+  if (!related_profile) return createErrorResult("related_profile is required for add_relation")
+  if (!relation_type) return createErrorResult("relation_type is required for add_relation")
+
+  const client = await getAuthenticatedClient(context)
+
+  // TODO: verify exact column names — older HRSD releases use `user` and `related_user`,
+  // newer releases sometimes use `profile`/`related_profile`. Try the canonical pair first.
+  const payload: Record<string, unknown> = {
+    user: sys_id,
+    related_user: related_profile,
+    type: relation_type,
+    active: true,
+  }
+
+  const response = await client.post(`/api/now/table/${RELATION_TABLE}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "add_relation",
+    created: true,
+    sys_id: created.sys_id,
+    relation: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${RELATION_TABLE}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== SEARCH_EMPLOYEES ====================
+
+async function executeSearchEmployees(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+  const email = args.email as string | undefined
+  const employee_number = args.employee_number as string | undefined
+  const department = args.department as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!name && !email && !employee_number && !department) {
+    return createErrorResult("At least one of name, email, employee_number, or department is required for search_employees")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (name) queryParts.push(`nameLIKE${name}`)
+  if (email) queryParts.push(`user.emailLIKE${email}`)
+  if (employee_number) queryParts.push(`employee_number=${employee_number}`)
+  if (department) queryParts.push(`department=${department}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${PROFILE_TABLE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,user,employee_number,name,department,location,job_title,active" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+  return createSuccessResult({
+    action: "search_employees",
+    count: results.length,
+    employees: results.map((r) => ({
+      sys_id: r.sys_id,
+      user: r.user,
+      employee_number: r.employee_number,
+      name: r.name,
+      department: r.department,
+      location: r.location,
+      job_title: r.job_title,
+      active: r.active,
+      url: `${context.instanceUrl}/nav_to.do?uri=${PROFILE_TABLE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"


### PR DESCRIPTION
Fixes #121.

Adds four unified lifecycle tools to round out HRSD and CSM coverage. Each follows the `snow_pa_indicator_manage` pattern (single tool, action switch, per-action helpers) and uses the shared auth + error helpers.

| Tool | Domain | Tables | Actions |
| --- | --- | --- | --- |
| `snow_hr_lifecycle_event` | `hr/` | `sn_hr_le_case`, `sn_hr_le_activity`, `sn_hr_core_journey_template`, `sn_hr_core_journey_activity` | `create_event`, `list_events`, `complete_event`, `list_pending_for_employee`, `trigger_journey` |
| `snow_hr_profile_manage` | `hr/` | `sn_hr_core_profile`, `sn_hr_core_user_relation` | `get_profile`, `update_profile`, `list_relations`, `add_relation`, `search_employees` |
| `snow_csm_contract_manage` | `csm/` | `service_contract`, `entitlement`, `service_offering`, `contract_sla` | `list`, `get`, `create_contract`, `link_entitlement`, `list_entitlements`, `extend_contract` |
| `snow_csm_communication_manage` | `csm/` | `interaction`, `interaction_related_record` | `list`, `get`, `log_interaction`, `link_to_case`, `list_for_case`, `list_by_channel` |

Plugin gating: HRSD tools fail with `PLUGIN_MISSING` when `com.sn_hr_*` tables are absent (404 on table lookup); CSM tools do the same for `com.sn_customerservice`. The descriptions name the required plugin so the agent surfaces it to the user.

Companions referenced in tool descriptions:
- `snow_hr_lifecycle_event` complements `snow_employee_offboarding` (offboarding-only, writes `sn_hr_core_case`) and `snow_create_hr_case`.
- `snow_hr_profile_manage` backs the profiles consumed by `snow_create_hr_case` / `snow_create_hr_task`.
- `snow_csm_contract_manage` layers on top of `snow_create_entitlement` and `snow_create_customer_account`.
- `snow_csm_communication_manage` logs interactions linked to cases opened by `snow_create_customer_case`.

## Verification

- `bun packages/opencode/script/generate-tools-json.ts` → 414 tools, 0 failures (regenerated locally, then `tools.json` restored — the workflow regenerates on push to `main`).
- Built from documented platform surface area; no tool exercised against a live instance.
- Uncertain column choices flagged with `// TODO: verify` comments, notably:
  - `sn_hr_core_user_relation` column pair (`user`/`related_user` vs `profile`/`related_profile`)
  - `sn_hr_core_journey_activity` foreign key (`journey_template` vs `parent`)
  - `entitlement.service_contract` link column name
  - `interaction_related_record` column names (`interaction`, `related_record_table`, `related_record`)
- `service_contract` create writes both `starts`/`ends` and `start_date`/`end_date` shapes to be portable across releases.

Best-effort against docs.servicenow.com — needs verification against a live instance before merge.

## Test plan
- [ ] On an instance with `com.sn_hr_core` + `com.sn_hr_lifecycle_events`: create / list / complete a lifecycle event, trigger a journey, list pending activities for an employee.
- [ ] On an instance with `com.sn_hr_core`: read, update, search profiles; add a manager relation between two profiles.
- [ ] On an instance with `com.sn_customerservice`: create / extend a service contract, link an entitlement, list entitlements.
- [ ] On an instance with `com.sn_customerservice`: log an inbound email interaction, link it to a case, list interactions by channel and per case.
- [ ] On an instance without any of the above plugins: confirm each tool returns the `PLUGIN_MISSING` error with the correct plugin name.