### PR TITLE
feat(opencode): add 4 SIR tools (incident, playbook, evidence, indicator)

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
@@ -109,3 +109,21 @@ export {
   toolDefinition as snow_grc_vendor_risk_manage_def,
   execute as snow_grc_vendor_risk_manage_exec,
 } from "./snow_grc_vendor_risk_manage.js"
+
+// Security Incident Response (SIR) Tools
+export {
+  toolDefinition as snow_sir_incident_manage_def,
+  execute as snow_sir_incident_manage_exec,
+} from "./snow_sir_incident_manage.js"
+export {
+  toolDefinition as snow_sir_playbook_orchestrate_def,
+  execute as snow_sir_playbook_orchestrate_exec,
+} from "./snow_sir_playbook_orchestrate.js"
+export {
+  toolDefinition as snow_sir_evidence_manage_def,
+  execute as snow_sir_evidence_manage_exec,
+} from "./snow_sir_evidence_manage.js"
+export {
+  toolDefinition as snow_sir_indicator_manage_def,
+  execute as snow_sir_indicator_manage_exec,
+} from "./snow_sir_indicator_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_evidence_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_evidence_manage.ts
@@ -1,0 +1,581 @@
+/**
+ * snow_sir_evidence_manage - Unified Security Incident Response (SIR) evidence and forensic artifact handling
+ *
+ * Manages forensic evidence attached to SIR incidents on sn_si_evidence and
+ * sn_si_artifact. Provides chain-of-custody operations needed for an audit
+ * trail: attach evidence to an incident, list evidence for an incident,
+ * fetch a single record, verify a stored artifact's SHA-256 hash, and
+ * export the evidence index for an incident.
+ *
+ * Companion to snow_sir_incident_manage (incident lifecycle) and
+ * snow_sir_playbook_orchestrate (SOAR playbook steps). Use this tool when
+ * the incident has produced evidence (memory dumps, PCAPs, screenshots,
+ * exported logs) that needs to be tracked and integrity-verified.
+ *
+ * Requires the Security Incident Response plugin (com.snc.security_incident).
+ * A 404 on the primary table is surfaced as a clear missing-plugin error.
+ *
+ * Hash verification: hash_verify recomputes the SHA-256 hash of the stored
+ * artifact server-side using GlideDigest and compares it to the value
+ * captured at attach time. Mismatches indicate tampering or storage
+ * corruption. Server-side script is ES5-only (Rhino engine).
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+import { executeServerScript } from "../../shared/scripted-exec.js"
+
+const SIR_PLUGIN = "com.snc.security_incident"
+const SIR_EVIDENCE_TABLE = "sn_si_evidence"
+const SIR_ARTIFACT_TABLE = "sn_si_artifact"
+const SIR_ATTACHMENT_TABLE = "sn_si_attachment"
+const SIR_INCIDENT_TABLE = "sn_si_incident"
+const SYS_ATTACHMENT_TABLE = "sys_attachment"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_sir_evidence_manage",
+  description: `Unified tool for Security Incident Response (SIR) evidence and forensic artifact chain-of-custody on sn_si_evidence, sn_si_artifact, and sn_si_attachment. Critical for audit trails — every action records who attached/exported the evidence and when.
+
+Actions:
+- attach — attach a new evidence record to a SIR incident with type, description, source, and an optional sys_attachment reference
+- list — list evidence rows linked to an incident
+- get — retrieve a single evidence row with related artifact and attachment metadata
+- hash_verify — recompute the SHA-256 hash of a stored artifact server-side (GlideDigest) and compare to the value recorded at attach time. Used to detect tampering or storage corruption
+- export — return a structured manifest of all evidence for an incident, suitable for handing off to legal/IR review
+
+Use when: the agent has produced or received forensic evidence (memory dumps, PCAPs, screenshots, exported logs) tied to a SIR incident and needs to track it under chain of custody. Companion tools: snow_sir_incident_manage (incident lifecycle), snow_sir_playbook_orchestrate (playbook steps that produce the evidence).
+
+Plugin gating: requires com.snc.security_incident. A 404 on sn_si_evidence is surfaced with the required plugin name. The hash_verify action uses GlideDigest via ES5-only server-side script execution.
+
+Returns: action-specific data. attach returns the created evidence row. list returns evidence summaries with hash and attached_by. get returns the row with related artifact records. hash_verify returns the recomputed hash, the stored hash, and a verified boolean. export returns the full evidence manifest for the incident.`,
+  category: "security",
+  subcategory: "incidents",
+  use_cases: ["sir", "forensics", "evidence", "chain-of-custody", "security"],
+  complexity: "advanced",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Evidence management action to perform",
+        enum: ["attach", "list", "get", "hash_verify", "export"],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/hash_verify] Evidence record sys_id on sn_si_evidence",
+      },
+      incident_sys_id: {
+        type: "string",
+        description: "[attach/list/export] Parent SIR incident sys_id (sn_si_incident)",
+      },
+      incident_number: {
+        type: "string",
+        description: "[attach/list/export] Parent SIR incident number (e.g. SIR0010001), alternative to incident_sys_id",
+      },
+      attachment_sys_id: {
+        type: "string",
+        description: "[attach/hash_verify] sys_attachment sys_id pointing at the stored file (when evidence is file-based)",
+      },
+      artifact_sys_id: {
+        type: "string",
+        description: "[attach] Existing sn_si_artifact sys_id to link to the evidence (alternative to attachment_sys_id)",
+      },
+      // ATTACH
+      short_description: {
+        type: "string",
+        description: "[attach] Short description of the evidence",
+      },
+      description: {
+        type: "string",
+        description: "[attach] Detailed description / context of how the evidence was produced",
+      },
+      evidence_type: {
+        type: "string",
+        description: "[attach] Evidence type",
+        enum: [
+          "memory_dump",
+          "pcap",
+          "log",
+          "screenshot",
+          "file",
+          "registry_export",
+          "process_list",
+          "network_capture",
+          "other",
+        ],
+      },
+      source: {
+        type: "string",
+        description: "[attach] Source system / collection method (EDR, SIEM, manual)",
+      },
+      sha256: {
+        type: "string",
+        description: "[attach] SHA-256 hash of the evidence as captured at collection time (lowercase hex)",
+      },
+      collected_by: {
+        type: "string",
+        description: "[attach] sys_user sys_id of the analyst who collected the evidence (defaults to caller)",
+      },
+      // LIST
+      limit: {
+        type: "number",
+        description: "[list] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/export] Comma-separated list of fields to return",
+      },
+      // EXPORT
+      include_artifacts: {
+        type: "boolean",
+        description: "[export] Include linked sn_si_artifact rows in the manifest",
+        default: true,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "attach":
+        return await executeAttach(args, context)
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "hash_verify":
+        return await executeHashVerify(args, context)
+      case "export":
+        return await executeExport(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: attach, list, get, hash_verify, export`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `SIR evidence ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function plugin404(err: unknown, table: string): SnowFlowError {
+  const e = err as { response?: { status?: number }; message?: string }
+  if (e?.response?.status === 404) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Security Incident Response plugin not installed. The ${table} table was not found on this instance. Activate the plugin (${SIR_PLUGIN}) under System Definition > Plugins.`,
+      { details: { plugin: SIR_PLUGIN, table } },
+    )
+  }
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, e?.message || "SIR API call failed", { originalError: err as Error })
+}
+
+async function resolveIncidentSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  incidentSysId: string | undefined,
+  incidentNumber: string | undefined,
+): Promise<string | null> {
+  if (incidentSysId) return incidentSysId
+  if (incidentNumber) {
+    const search = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, {
+      params: { sysparm_query: `number=${incidentNumber}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0].sys_id as string
+  }
+  return null
+}
+
+// ==================== ATTACH ====================
+
+async function executeAttach(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const attachment_sys_id = args.attachment_sys_id as string | undefined
+  const artifact_sys_id = args.artifact_sys_id as string | undefined
+  const short_description = args.short_description as string | undefined
+  const description = args.description as string | undefined
+  const evidence_type = args.evidence_type as string | undefined
+  const source = args.source as string | undefined
+  const sha256 = args.sha256 as string | undefined
+  const collected_by = args.collected_by as string | undefined
+
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for attach action")
+  }
+  if (!short_description) return createErrorResult("short_description is required for attach action")
+  if (!evidence_type) return createErrorResult("evidence_type is required for attach action")
+  if (!attachment_sys_id && !artifact_sys_id) {
+    return createErrorResult(
+      "attachment_sys_id or artifact_sys_id is required for attach action (point at the stored file or linked artifact)",
+    )
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  const payload: Record<string, unknown> = {
+    parent: incidentSysId,
+    short_description,
+    evidence_type,
+  }
+  if (description) payload.description = description
+  if (source) payload.source = source
+  if (sha256) payload.sha256 = sha256
+  if (collected_by) payload.collected_by = collected_by
+  if (attachment_sys_id) payload.attachment = attachment_sys_id
+  if (artifact_sys_id) payload.artifact = artifact_sys_id
+
+  try {
+    const response = await client.post(`/api/now/table/${SIR_EVIDENCE_TABLE}`, payload)
+    const created = response.data.result as Record<string, unknown>
+
+    // Optionally back-link an sn_si_attachment row if the platform expects
+    // it. Best-effort — older instances expose attachments via sys_attachment
+    // directly without the join table.
+    let backLinkSysId: string | null = null
+    if (attachment_sys_id) {
+      try {
+        const back = await client.post(`/api/now/table/${SIR_ATTACHMENT_TABLE}`, {
+          parent: incidentSysId,
+          evidence: created.sys_id,
+          sys_attachment: attachment_sys_id,
+        })
+        backLinkSysId = back.data.result.sys_id
+      } catch {
+        // sn_si_attachment may not be present on every release
+        // TODO: verify sn_si_attachment availability and field set on a live instance
+      }
+    }
+
+    return createSuccessResult({
+      action: "attach",
+      attached: true,
+      sys_id: created.sys_id,
+      evidence: created,
+      back_link_sys_id: backLinkSysId,
+      url: `${context.instanceUrl}/nav_to.do?uri=${SIR_EVIDENCE_TABLE}.do?sys_id=${created.sys_id}`,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_EVIDENCE_TABLE)
+  }
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for list action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_EVIDENCE_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}`,
+        sysparm_limit: limit,
+        sysparm_orderby: "sys_created_on",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,short_description,evidence_type,source,sha256,collected_by,attachment,artifact,sys_created_on",
+            }),
+      },
+    })
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list",
+      incident: { sys_id: incidentSysId },
+      count: results.length,
+      evidence: results.map((e) => ({
+        sys_id: e.sys_id,
+        short_description: e.short_description,
+        evidence_type: e.evidence_type,
+        source: e.source,
+        sha256: e.sha256,
+        collected_by: e.collected_by,
+        attachment: e.attachment,
+        artifact: e.artifact,
+        created_at: e.sys_created_on,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_EVIDENCE_TABLE}.do?sys_id=${e.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_EVIDENCE_TABLE)
+  }
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  if (!sys_id) return createErrorResult("sys_id is required for get action")
+
+  const client = await getAuthenticatedClient(context)
+  try {
+    const direct = await client.get(`/api/now/table/${SIR_EVIDENCE_TABLE}/${sys_id}`)
+    const evidence = direct.data.result as Record<string, unknown> | undefined
+    if (!evidence || !evidence.sys_id) {
+      return createErrorResult(`Evidence not found: ${sys_id}`)
+    }
+
+    // Fetch linked artifact record (best-effort)
+    let artifact: Record<string, unknown> | null = null
+    const artifactRef = evidence.artifact as { value?: string } | string | undefined
+    const artifactSysId = typeof artifactRef === "string"
+      ? artifactRef
+      : (artifactRef as { value?: string } | undefined)?.value
+    if (artifactSysId) {
+      try {
+        const a = await client.get(`/api/now/table/${SIR_ARTIFACT_TABLE}/${artifactSysId}`)
+        artifact = a.data.result as Record<string, unknown>
+      } catch {
+        // Artifact table may not be present
+      }
+    }
+
+    return createSuccessResult({
+      action: "get",
+      sys_id,
+      evidence,
+      artifact,
+      url: `${context.instanceUrl}/nav_to.do?uri=${SIR_EVIDENCE_TABLE}.do?sys_id=${sys_id}`,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_EVIDENCE_TABLE)
+  }
+}
+
+// ==================== HASH_VERIFY ====================
+
+/**
+ * Server-side ES5 script that recomputes the SHA-256 of a sys_attachment
+ * record using GlideDigest and prints it as lowercase hex. Returns an
+ * empty string when the attachment cannot be read.
+ *
+ * ES5 only — no const, let, arrow functions, template literals.
+ */
+function buildHashScript(attachmentSysId: string): string {
+  return (
+    "var attachmentId = " + JSON.stringify(attachmentSysId) + ";\n" +
+    "var gsa = new GlideSysAttachment();\n" +
+    "var bytes = gsa.getBytes(" + JSON.stringify(SYS_ATTACHMENT_TABLE) + ", attachmentId);\n" +
+    "if (!bytes || bytes.length === 0) {\n" +
+    "  gs.print('');\n" +
+    "} else {\n" +
+    "  var digest = GlideDigest.getSHA256Base64(bytes);\n" +
+    "  var raw = GlideStringUtil.base64Decode(digest);\n" +
+    "  var hex = '';\n" +
+    "  for (var i = 0; i < raw.length; i++) {\n" +
+    "    var b = raw.charCodeAt(i) & 0xff;\n" +
+    "    var h = b.toString(16);\n" +
+    "    if (h.length === 1) { h = '0' + h; }\n" +
+    "    hex += h;\n" +
+    "  }\n" +
+    "  gs.print(hex);\n" +
+    "}"
+  )
+}
+
+async function executeHashVerify(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const attachment_sys_id_override = args.attachment_sys_id as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (evidence sys_id) is required for hash_verify action")
+
+  const client = await getAuthenticatedClient(context)
+
+  // Load the evidence row to get the stored sha256 and attachment reference.
+  let evidence: Record<string, unknown>
+  try {
+    const direct = await client.get(`/api/now/table/${SIR_EVIDENCE_TABLE}/${sys_id}`)
+    evidence = direct.data.result as Record<string, unknown>
+    if (!evidence || !evidence.sys_id) {
+      return createErrorResult(`Evidence not found: ${sys_id}`)
+    }
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_EVIDENCE_TABLE)
+  }
+
+  const storedHash = (evidence.sha256 as string | undefined)?.toLowerCase() || ""
+  const attachmentRef = evidence.attachment as { value?: string } | string | undefined
+  const attachmentSysId =
+    attachment_sys_id_override
+    || (typeof attachmentRef === "string" ? attachmentRef : (attachmentRef as { value?: string } | undefined)?.value)
+
+  if (!attachmentSysId) {
+    return createErrorResult(
+      "No attachment reference found on the evidence row and no attachment_sys_id override provided. Cannot recompute hash.",
+    )
+  }
+
+  const script = buildHashScript(attachmentSysId)
+  const execResult = await executeServerScript(context, script, {
+    description: "SIR evidence SHA-256 verification",
+    timeout: 60000,
+  })
+
+  if (!execResult.success) {
+    return createErrorResult(
+      new SnowFlowError(
+        ErrorType.SERVICENOW_API_ERROR,
+        `Hash verification script failed: ${execResult.error || "unknown error"}`,
+      ),
+    )
+  }
+
+  const printed = (execResult.output || [])
+    .filter((o) => o.level === "print")
+    .map((o) => o.message)
+    .join("")
+    .trim()
+    .toLowerCase()
+
+  if (!printed) {
+    return createSuccessResult({
+      action: "hash_verify",
+      verified: false,
+      reason: "attachment_unreadable",
+      stored_hash: storedHash,
+      computed_hash: null,
+      evidence_sys_id: sys_id,
+      attachment_sys_id: attachmentSysId,
+    })
+  }
+
+  const verified = storedHash.length > 0 && storedHash === printed
+
+  return createSuccessResult({
+    action: "hash_verify",
+    verified,
+    stored_hash: storedHash || null,
+    computed_hash: printed,
+    evidence_sys_id: sys_id,
+    attachment_sys_id: attachmentSysId,
+    note: storedHash
+      ? verified
+        ? "Computed hash matches the value recorded on the evidence row."
+        : "Computed hash does NOT match the recorded value. Possible tampering or storage corruption."
+      : "No stored hash on the evidence row to compare against. Computed hash returned for reference.",
+  })
+}
+
+// ==================== EXPORT ====================
+
+async function executeExport(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const include_artifacts = args.include_artifacts !== false
+  const fields = args.fields as string | undefined
+
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for export action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  // Load incident header for the manifest.
+  let incidentHeader: Record<string, unknown> | null = null
+  try {
+    const i = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}/${incidentSysId}`)
+    incidentHeader = i.data.result as Record<string, unknown>
+  } catch {
+    // Even without the header, the export of evidence is still useful.
+  }
+
+  try {
+    const evidenceResponse = await client.get(`/api/now/table/${SIR_EVIDENCE_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}`,
+        sysparm_limit: 1000,
+        sysparm_orderby: "sys_created_on",
+        sysparm_display_value: "true",
+        ...(fields ? { sysparm_fields: fields } : {}),
+      },
+    })
+    const evidence = (evidenceResponse.data.result || []) as Array<Record<string, unknown>>
+
+    let artifacts: Array<Record<string, unknown>> = []
+    if (include_artifacts) {
+      try {
+        const artifactResponse = await client.get(`/api/now/table/${SIR_ARTIFACT_TABLE}`, {
+          params: {
+            sysparm_query: `parent=${incidentSysId}`,
+            sysparm_limit: 1000,
+            sysparm_orderby: "sys_created_on",
+          },
+        })
+        artifacts = (artifactResponse.data.result || []) as Array<Record<string, unknown>>
+      } catch {
+        // Artifact table may not be present
+      }
+    }
+
+    const manifest = {
+      generated_at: new Date().toISOString(),
+      incident: incidentHeader
+        ? {
+            sys_id: incidentHeader.sys_id,
+            number: incidentHeader.number,
+            short_description: incidentHeader.short_description,
+            state: incidentHeader.state,
+            category: incidentHeader.category,
+          }
+        : { sys_id: incidentSysId },
+      counts: {
+        evidence: evidence.length,
+        artifacts: artifacts.length,
+      },
+      evidence,
+      artifacts,
+    }
+
+    return createSuccessResult({
+      action: "export",
+      exported: true,
+      manifest,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_EVIDENCE_TABLE)
+  }
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_incident_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_incident_manage.ts
@@ -1,0 +1,554 @@
+/**
+ * snow_sir_incident_manage - Unified Security Incident Response (SIR) incident lifecycle
+ *
+ * Manages the lifecycle of Security Incident Response incidents on the
+ * sn_si_incident table and their associated tasks on sn_si_task. SIR
+ * incidents are a distinct artifact from the standard `incident` table —
+ * they ship with the Security Incident Response application and follow
+ * the NIST IR phases (triage, contain, eradicate, recover, close).
+ *
+ * Companion to snow_create_security_incident (which only creates an initial
+ * record) and snow_automate_threat_response (which fires automated response
+ * actions). This tool extends those by managing the full phase progression
+ * and exposing the per-incident task queue.
+ *
+ * Requires the Security Incident Response plugin (com.snc.security_incident)
+ * on the target instance. A 404 on the primary table is surfaced as a
+ * clear missing-plugin error.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const SIR_PLUGIN = "com.snc.security_incident"
+const SIR_INCIDENT_TABLE = "sn_si_incident"
+const SIR_TASK_TABLE = "sn_si_task"
+
+// SIR phase / state map. ServiceNow ships SIR with a numeric state field
+// on sn_si_incident; the exact codes can vary by release, so values are
+// written as strings the platform will coerce.
+// TODO: verify state code values against a live SIR-enabled instance.
+const SIR_PHASE_STATE: Record<string, string> = {
+  triage: "16", // Analysis / triage
+  contain: "18", // Contain
+  eradicate: "19", // Eradicate
+  recover: "20", // Recover
+  close: "3", // Closed
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_sir_incident_manage",
+  description: `Unified tool for ServiceNow Security Incident Response (SIR) incident lifecycle on sn_si_incident and sn_si_task. Walks an incident through the NIST IR phases: triage, contain, eradicate, recover, close.
+
+Actions:
+- list — list SIR incidents, optionally filtered by state, priority, or assignment_group
+- get — retrieve a single SIR incident by sys_id or number, with its related task summary
+- create — open a new SIR incident (short_description and category required)
+- triage — move an incident into the triage phase, optionally assigning analyst
+- contain — move an incident into the contain phase with a containment note
+- eradicate — move an incident into the eradicate phase with an eradication note
+- recover — move an incident into the recover phase with a recovery note
+- close — close an incident with a close code and resolution notes
+- list_tasks — list sn_si_task rows linked to the incident
+
+Use when: the agent needs to drive a security incident through the SIR phase model rather than just record one. Companion tools: snow_create_security_incident (initial record only), snow_automate_threat_response (run automated actions), snow_sir_playbook_orchestrate (run a multi-step playbook), snow_sir_evidence_manage (attach forensic evidence).
+
+Plugin gating: requires com.snc.security_incident. A 404 on sn_si_incident is surfaced with the required plugin name so the caller can install it.
+
+Returns: SIR incident records with sys_id, number, state, phase, priority, category, assigned_to, and the configured workflow phase. Task listings include sys_id, number, short_description, state, and assigned_to.`,
+  category: "security",
+  subcategory: "incidents",
+  use_cases: ["sir", "security", "incident-response", "soar", "nist-ir"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "create", "triage", "contain", "eradicate", "recover", "close", "list_tasks"],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/triage/contain/eradicate/recover/close/list_tasks] SIR incident sys_id",
+      },
+      number: {
+        type: "string",
+        description: "[get/triage/contain/eradicate/recover/close/list_tasks] SIR incident number (e.g. SIR0010001), alternative to sys_id",
+      },
+      // LIST filters
+      state: {
+        type: "string",
+        description: "[list] Filter by state code (numeric) or display value",
+      },
+      priority: {
+        type: "string",
+        description: "[list] Filter by priority (1-5)",
+      },
+      assignment_group: {
+        type: "string",
+        description: "[list] Filter by assignment_group sys_id",
+      },
+      limit: {
+        type: "number",
+        description: "[list/list_tasks] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_tasks] Comma-separated list of fields to return",
+      },
+      // CREATE
+      short_description: {
+        type: "string",
+        description: "[create] Short description of the incident",
+      },
+      description: {
+        type: "string",
+        description: "[create] Long description / initial observations",
+      },
+      category: {
+        type: "string",
+        description: "[create] SIR category (malware, phishing, unauthorized_access, etc.)",
+      },
+      subcategory: {
+        type: "string",
+        description: "[create] SIR subcategory",
+      },
+      priority_value: {
+        type: "string",
+        description: "[create] Priority (1=Critical, 2=High, 3=Moderate, 4=Low, 5=Planning)",
+        enum: ["1", "2", "3", "4", "5"],
+      },
+      caller: {
+        type: "string",
+        description: "[create] sys_user sys_id of the caller / reporter",
+      },
+      assigned_to: {
+        type: "string",
+        description: "[create/triage] sys_user sys_id of the analyst the incident is assigned to",
+      },
+      assignment_group_sys_id: {
+        type: "string",
+        description: "[create/triage] assignment_group sys_id",
+      },
+      // PHASE notes
+      triage_note: {
+        type: "string",
+        description: "[triage] Triage work note",
+      },
+      contain_note: {
+        type: "string",
+        description: "[contain] Containment work note describing isolation / blocking actions taken",
+      },
+      eradicate_note: {
+        type: "string",
+        description: "[eradicate] Eradication work note describing root-cause removal",
+      },
+      recover_note: {
+        type: "string",
+        description: "[recover] Recovery work note describing service restoration",
+      },
+      // CLOSE
+      close_code: {
+        type: "string",
+        description: "[close] Close code",
+        enum: ["resolved", "not_a_security_incident", "false_positive", "duplicate", "no_resolution"],
+      },
+      close_notes: {
+        type: "string",
+        description: "[close] Resolution notes",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create":
+        return await executeCreate(args, context)
+      case "triage":
+        return await executePhase(args, context, "triage")
+      case "contain":
+        return await executePhase(args, context, "contain")
+      case "eradicate":
+        return await executePhase(args, context, "eradicate")
+      case "recover":
+        return await executePhase(args, context, "recover")
+      case "close":
+        return await executeClose(args, context)
+      case "list_tasks":
+        return await executeListTasks(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create, triage, contain, eradicate, recover, close, list_tasks`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `SIR incident ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function plugin404(err: unknown): SnowFlowError {
+  const e = err as { response?: { status?: number }; message?: string }
+  if (e?.response?.status === 404) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Security Incident Response plugin not installed. The ${SIR_INCIDENT_TABLE} table was not found on this instance. Activate the plugin (${SIR_PLUGIN}) under System Definition > Plugins.`,
+      { details: { plugin: SIR_PLUGIN, table: SIR_INCIDENT_TABLE } },
+    )
+  }
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, e?.message || "SIR API call failed", { originalError: err as Error })
+}
+
+async function findIncident(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  number: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    try {
+      const direct = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}/${sysId}`)
+      if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+    } catch (err: unknown) {
+      const e = err as { response?: { status?: number } }
+      if (e?.response?.status === 404) {
+        // Could mean: missing plugin OR missing record. Probe the table.
+        const probe = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, { params: { sysparm_limit: 1 } })
+        if (!probe.data.result) throw plugin404(err)
+        return null
+      }
+      throw plugin404(err)
+    }
+  }
+  if (number) {
+    const search = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, {
+      params: { sysparm_query: `number=${number}`, sysparm_limit: 1 },
+    })
+    const results = search.data.result || []
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const state = args.state as string | undefined
+  const priority = args.priority as string | undefined
+  const assignment_group = args.assignment_group as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (state) queryParts.push(`state=${state}`)
+  if (priority) queryParts.push(`priority=${priority}`)
+  if (assignment_group) queryParts.push(`assignment_group=${assignment_group}`)
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, {
+      params: {
+        sysparm_query: queryParts.join("^"),
+        sysparm_limit: limit,
+        sysparm_orderby: "sys_created_on",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,number,short_description,state,priority,category,assigned_to,assignment_group,sys_created_on,sys_updated_on",
+            }),
+      },
+    })
+
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list",
+      count: results.length,
+      incidents: results.map((r) => ({
+        sys_id: r.sys_id,
+        number: r.number,
+        short_description: r.short_description,
+        state: r.state,
+        priority: r.priority,
+        category: r.category,
+        assigned_to: r.assigned_to,
+        assignment_group: r.assignment_group,
+        created_at: r.sys_created_on,
+        updated_at: r.sys_updated_on,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_INCIDENT_TABLE}.do?sys_id=${r.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err)
+  }
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for get action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incident = await findIncident(client, sys_id, number)
+  if (!incident) {
+    return createErrorResult(`SIR incident not found: ${sys_id || number}`)
+  }
+
+  const incidentSysId = incident.sys_id as string
+
+  // Count related SIR tasks (best-effort)
+  let taskCount = 0
+  try {
+    const tasks = await client.get(`/api/now/table/${SIR_TASK_TABLE}`, {
+      params: { sysparm_query: `parent=${incidentSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    taskCount = (tasks.data.result || []).length
+  } catch {
+    // SIR task table may not be reachable on stripped-down instances
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id: incidentSysId,
+    number: incident.number,
+    incident,
+    related: { task_count: taskCount },
+    url: `${context.instanceUrl}/nav_to.do?uri=${SIR_INCIDENT_TABLE}.do?sys_id=${incidentSysId}`,
+  })
+}
+
+// ==================== CREATE ====================
+
+async function executeCreate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const short_description = args.short_description as string | undefined
+  const description = args.description as string | undefined
+  const category = args.category as string | undefined
+  const subcategory = args.subcategory as string | undefined
+  const priority_value = args.priority_value as string | undefined
+  const caller = args.caller as string | undefined
+  const assigned_to = args.assigned_to as string | undefined
+  const assignment_group_sys_id = args.assignment_group_sys_id as string | undefined
+
+  if (!short_description) return createErrorResult("short_description is required for create action")
+  if (!category) return createErrorResult("category is required for create action")
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = {
+    short_description,
+    category,
+  }
+  if (description) payload.description = description
+  if (subcategory) payload.subcategory = subcategory
+  if (priority_value) payload.priority = priority_value
+  if (caller) payload.caller = caller
+  if (assigned_to) payload.assigned_to = assigned_to
+  if (assignment_group_sys_id) payload.assignment_group = assignment_group_sys_id
+
+  try {
+    const response = await client.post(`/api/now/table/${SIR_INCIDENT_TABLE}`, payload)
+    const created = response.data.result as Record<string, unknown>
+    return createSuccessResult({
+      action: "create",
+      created: true,
+      sys_id: created.sys_id,
+      number: created.number,
+      incident: created,
+      url: `${context.instanceUrl}/nav_to.do?uri=${SIR_INCIDENT_TABLE}.do?sys_id=${created.sys_id}`,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err)
+  }
+}
+
+// ==================== PHASE TRANSITIONS ====================
+
+async function executePhase(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+  phase: "triage" | "contain" | "eradicate" | "recover",
+): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult(`sys_id or number is required for ${phase} action`)
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incident = await findIncident(client, sys_id, number)
+  if (!incident) {
+    return createErrorResult(`SIR incident not found: ${sys_id || number}`)
+  }
+
+  const targetSysId = incident.sys_id as string
+  const stateCode = SIR_PHASE_STATE[phase]
+
+  const noteFieldByPhase: Record<string, string | undefined> = {
+    triage: args.triage_note as string | undefined,
+    contain: args.contain_note as string | undefined,
+    eradicate: args.eradicate_note as string | undefined,
+    recover: args.recover_note as string | undefined,
+  }
+  const work_notes = noteFieldByPhase[phase]
+
+  const patch: Record<string, unknown> = { state: stateCode }
+  if (work_notes) patch.work_notes = work_notes
+
+  // Triage may also re-assign the incident.
+  if (phase === "triage") {
+    const assigned_to = args.assigned_to as string | undefined
+    const assignment_group_sys_id = args.assignment_group_sys_id as string | undefined
+    if (assigned_to) patch.assigned_to = assigned_to
+    if (assignment_group_sys_id) patch.assignment_group = assignment_group_sys_id
+  }
+
+  const response = await client.patch(`/api/now/table/${SIR_INCIDENT_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: phase,
+    updated: true,
+    phase,
+    sys_id: targetSysId,
+    number: updated.number,
+    state: updated.state,
+    incident: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${SIR_INCIDENT_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== CLOSE ====================
+
+async function executeClose(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const close_code = args.close_code as string | undefined
+  const close_notes = args.close_notes as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for close action")
+  }
+  if (!close_notes) {
+    return createErrorResult("close_notes is required for close action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incident = await findIncident(client, sys_id, number)
+  if (!incident) {
+    return createErrorResult(`SIR incident not found: ${sys_id || number}`)
+  }
+
+  const targetSysId = incident.sys_id as string
+
+  const patch: Record<string, unknown> = {
+    state: SIR_PHASE_STATE.close,
+    close_notes,
+  }
+  if (close_code) patch.close_code = close_code
+
+  const response = await client.patch(`/api/now/table/${SIR_INCIDENT_TABLE}/${targetSysId}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "close",
+    closed: true,
+    sys_id: targetSysId,
+    number: updated.number,
+    state: updated.state,
+    close_code: updated.close_code,
+    incident: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${SIR_INCIDENT_TABLE}.do?sys_id=${targetSysId}`,
+  })
+}
+
+// ==================== LIST_TASKS ====================
+
+async function executeListTasks(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const number = args.number as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!sys_id && !number) {
+    return createErrorResult("sys_id or number is required for list_tasks action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incident = await findIncident(client, sys_id, number)
+  if (!incident) {
+    return createErrorResult(`SIR incident not found: ${sys_id || number}`)
+  }
+
+  const incidentSysId = incident.sys_id as string
+
+  // TODO: verify the parent linkage column on sn_si_task — the SIR plugin
+  // has historically used `parent`, but some releases shipped a dedicated
+  // `incident` reference column instead.
+  try {
+    const response = await client.get(`/api/now/table/${SIR_TASK_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}`,
+        sysparm_limit: limit,
+        sysparm_orderby: "sys_created_on",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,number,short_description,state,assigned_to,assignment_group,sys_created_on",
+            }),
+      },
+    })
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list_tasks",
+      incident: { sys_id: incidentSysId, number: incident.number },
+      count: results.length,
+      tasks: results.map((t) => ({
+        sys_id: t.sys_id,
+        number: t.number,
+        short_description: t.short_description,
+        state: t.state,
+        assigned_to: t.assigned_to,
+        assignment_group: t.assignment_group,
+        created_at: t.sys_created_on,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_TASK_TABLE}.do?sys_id=${t.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err)
+  }
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_indicator_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_indicator_manage.ts
@@ -1,0 +1,535 @@
+/**
+ * snow_sir_indicator_manage - Unified Indicator of Compromise (IOC) lifecycle for SIR / Threat Intelligence
+ *
+ * Manages the IOC catalogue used by Security Incident Response and the
+ * Threat Intelligence subapp. Wraps the observable and indicator tables
+ * (sn_ti_observable, sn_ti_indicator) where IOCs are persisted, looked up,
+ * linked to incidents, and aged out.
+ *
+ * Companion to snow_analyze_threat_intelligence (which correlates a single
+ * IOC against feeds in a one-shot read-only call). This tool focuses on
+ * the persistent lifecycle — creating IOC records, marking them
+ * active/resolved, linking them to incidents, and searching by value.
+ *
+ * Table-name volatility note: across SN releases the IOC table has been
+ * `sn_ti_observable`, `sn_ti_indicator`, and `sn_si_observable`. This
+ * tool defaults to sn_ti_observable and falls back to sn_si_observable
+ * if the first 404s. Mark all uncertain table names with TODO: verify.
+ *
+ * Requires either the Threat Intelligence application or the Security
+ * Incident Response plugin (com.snc.security_incident). A 404 on both
+ * fallback tables is surfaced as a plugin-missing error.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const SIR_PLUGIN = "com.snc.security_incident"
+// Primary IOC observable table. TODO: verify against a live instance.
+const TI_OBSERVABLE_TABLE = "sn_ti_observable"
+// Fallback when sn_ti_observable is not present on the instance.
+// TODO: verify sn_si_observable on releases that ship the SIR plugin without Threat Intel.
+const SI_OBSERVABLE_TABLE_FALLBACK = "sn_si_observable"
+// Higher-level indicator (groups observables under a single intel record).
+// TODO: verify sn_ti_indicator on a live instance.
+const TI_INDICATOR_TABLE = "sn_ti_indicator"
+const SIR_INCIDENT_TABLE = "sn_si_incident"
+// Join table used to attach observables/indicators to incidents.
+// TODO: verify against a live instance — release-dependent.
+const SIR_INCIDENT_OBSERVABLE_JOIN = "sn_si_m2m_observable_incident"
+
+// IOC state values used by the SIR/TI tables. The exact codes vary by
+// release; values are passed as strings to let the platform coerce.
+const IOC_STATE = {
+  active: "active",
+  resolved: "resolved",
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_sir_indicator_manage",
+  description: `Unified tool for the Indicator of Compromise (IOC) lifecycle on sn_ti_observable, sn_ti_indicator, and the SIR observable join table. Manages persistent IOC records — distinct from snow_analyze_threat_intelligence, which only correlates a single IOC against feeds without persisting state.
+
+Actions:
+- create_ioc — create a new IOC record (value, type, finding required) on sn_ti_observable
+- list_iocs — list IOCs, optionally filtered by type, state, source, or seen-since
+- link_to_incident — link an existing IOC to a SIR incident via the observable-incident join table
+- mark_active — mark an IOC active (re-open after resolution)
+- mark_resolved — mark an IOC resolved (closed, no longer interesting)
+- search_by_value — find IOCs by exact or fragment match on value (IP, domain, hash, URL, email)
+
+Use when: the agent needs to manage persistent IOC records — open a new IOC after triage, attach existing IOCs to a new incident, search for prior sightings of a value, or close out an IOC after eradication. Companion tools: snow_analyze_threat_intelligence (one-shot feed correlation), snow_sir_incident_manage (parent incident lifecycle), snow_sir_evidence_manage (evidence chain of custody).
+
+Table-name volatility: the IOC table name varies by SN release (sn_ti_observable / sn_ti_indicator / sn_si_observable). This tool defaults to sn_ti_observable and falls back to sn_si_observable if the primary table is absent.
+
+Plugin gating: requires either Threat Intelligence or the Security Incident Response plugin (com.snc.security_incident). A 404 on both fallback tables is surfaced with the required plugin name.
+
+Returns: action-specific data. create_ioc returns the created record. list_iocs / search_by_value return arrays of IOCs with value, type, state, source, last_seen. link_to_incident returns the join-row sys_id. mark_active / mark_resolved return the updated record.`,
+  category: "security",
+  subcategory: "threat-intelligence",
+  use_cases: ["sir", "threat-intelligence", "ioc", "indicators", "security"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Indicator management action to perform",
+        enum: [
+          "create_ioc",
+          "list_iocs",
+          "link_to_incident",
+          "mark_active",
+          "mark_resolved",
+          "search_by_value",
+        ],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[link_to_incident/mark_active/mark_resolved] sys_id of the IOC observable record",
+      },
+      incident_sys_id: {
+        type: "string",
+        description: "[link_to_incident] sys_id of the SIR incident the IOC should be attached to",
+      },
+      incident_number: {
+        type: "string",
+        description: "[link_to_incident] SIR incident number (e.g. SIR0010001), alternative to incident_sys_id",
+      },
+      // CREATE_IOC
+      ioc_value: {
+        type: "string",
+        description: "[create_ioc/search_by_value] The IOC value (IP, domain, hash, URL, email, file path)",
+      },
+      ioc_type: {
+        type: "string",
+        description: "[create_ioc/list_iocs/search_by_value] IOC type",
+        enum: [
+          "ip",
+          "domain",
+          "url",
+          "email",
+          "hash_md5",
+          "hash_sha1",
+          "hash_sha256",
+          "file_path",
+          "user_agent",
+          "registry_key",
+        ],
+      },
+      finding: {
+        type: "string",
+        description: "[create_ioc] Why this IOC is interesting (one-line finding / context)",
+      },
+      source: {
+        type: "string",
+        description: "[create_ioc/list_iocs] Source of the IOC (SIEM, EDR, threat feed name, manual)",
+      },
+      confidence: {
+        type: "string",
+        description: "[create_ioc] Confidence level",
+        enum: ["low", "medium", "high"],
+      },
+      tlp: {
+        type: "string",
+        description: "[create_ioc] Traffic Light Protocol marking",
+        enum: ["white", "green", "amber", "red"],
+      },
+      // LIST / SEARCH filters
+      state_filter: {
+        type: "string",
+        description: "[list_iocs] Filter by IOC state",
+        enum: ["active", "resolved"],
+      },
+      seen_since: {
+        type: "string",
+        description: "[list_iocs] Filter by last-seen date (encoded query date >= YYYY-MM-DD)",
+      },
+      match_mode: {
+        type: "string",
+        description: "[search_by_value] How to match the value",
+        enum: ["exact", "contains", "starts_with"],
+        default: "exact",
+      },
+      limit: {
+        type: "number",
+        description: "[list_iocs/search_by_value] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_iocs/search_by_value] Comma-separated list of fields to return",
+      },
+      // MARK transitions
+      note: {
+        type: "string",
+        description: "[mark_active/mark_resolved] Optional work note describing the state change",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "create_ioc":
+        return await executeCreateIoc(args, context)
+      case "list_iocs":
+        return await executeListIocs(args, context)
+      case "link_to_incident":
+        return await executeLinkToIncident(args, context)
+      case "mark_active":
+        return await executeMarkState(args, context, IOC_STATE.active)
+      case "mark_resolved":
+        return await executeMarkState(args, context, IOC_STATE.resolved)
+      case "search_by_value":
+        return await executeSearchByValue(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: create_ioc, list_iocs, link_to_incident, mark_active, mark_resolved, search_by_value`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `SIR indicator ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+/**
+ * Wraps a Table API call that targets the IOC observable table. Falls back
+ * from sn_ti_observable to sn_si_observable on 404 so this tool keeps
+ * working across SN releases that ship one but not the other. Returns
+ * the resolved table name alongside the call result so the caller can
+ * reuse it for subsequent calls on the same record.
+ */
+async function callOnObservableTable<T>(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  invoke: (table: string) => Promise<T>,
+): Promise<{ result: T; table: string }> {
+  try {
+    const result = await invoke(TI_OBSERVABLE_TABLE)
+    return { result, table: TI_OBSERVABLE_TABLE }
+  } catch (err: unknown) {
+    const e = err as { response?: { status?: number } }
+    if (e?.response?.status === 404) {
+      try {
+        const result = await invoke(SI_OBSERVABLE_TABLE_FALLBACK)
+        return { result, table: SI_OBSERVABLE_TABLE_FALLBACK }
+      } catch (err2: unknown) {
+        const e2 = err2 as { response?: { status?: number }; message?: string }
+        if (e2?.response?.status === 404) {
+          throw new SnowFlowError(
+            ErrorType.PLUGIN_MISSING,
+            `Neither ${TI_OBSERVABLE_TABLE} nor ${SI_OBSERVABLE_TABLE_FALLBACK} was found on this instance. Activate the Security Incident Response plugin (${SIR_PLUGIN}) or the Threat Intelligence application under System Definition > Plugins.`,
+            {
+              details: {
+                plugin: SIR_PLUGIN,
+                tried_tables: [TI_OBSERVABLE_TABLE, SI_OBSERVABLE_TABLE_FALLBACK],
+              },
+            },
+          )
+        }
+        throw new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, e2.message || "IOC API call failed", {
+          originalError: err2 as Error,
+        })
+      }
+    }
+    throw new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, (err as Error).message || "IOC API call failed", {
+      originalError: err as Error,
+    })
+  }
+}
+
+async function resolveIncidentSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  incidentSysId: string | undefined,
+  incidentNumber: string | undefined,
+): Promise<string | null> {
+  if (incidentSysId) return incidentSysId
+  if (incidentNumber) {
+    const search = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, {
+      params: { sysparm_query: `number=${incidentNumber}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0].sys_id as string
+  }
+  return null
+}
+
+// ==================== CREATE_IOC ====================
+
+async function executeCreateIoc(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const ioc_value = args.ioc_value as string | undefined
+  const ioc_type = args.ioc_type as string | undefined
+  const finding = args.finding as string | undefined
+  const source = args.source as string | undefined
+  const confidence = args.confidence as string | undefined
+  const tlp = args.tlp as string | undefined
+
+  if (!ioc_value) return createErrorResult("ioc_value is required for create_ioc action")
+  if (!ioc_type) return createErrorResult("ioc_type is required for create_ioc action")
+  if (!finding) return createErrorResult("finding is required for create_ioc action")
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = {
+    value: ioc_value,
+    type: ioc_type,
+    finding,
+    state: IOC_STATE.active,
+  }
+  if (source) payload.source = source
+  if (confidence) payload.confidence = confidence
+  if (tlp) payload.tlp = tlp
+
+  const { result, table } = await callOnObservableTable(client, async (t) => {
+    const response = await client.post(`/api/now/table/${t}`, payload)
+    return response.data.result as Record<string, unknown>
+  })
+
+  return createSuccessResult({
+    action: "create_ioc",
+    created: true,
+    sys_id: result.sys_id,
+    table,
+    ioc: result,
+    url: `${context.instanceUrl}/nav_to.do?uri=${table}.do?sys_id=${result.sys_id}`,
+  })
+}
+
+// ==================== LIST_IOCS ====================
+
+async function executeListIocs(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const ioc_type = args.ioc_type as string | undefined
+  const state_filter = args.state_filter as string | undefined
+  const source = args.source as string | undefined
+  const seen_since = args.seen_since as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (ioc_type) queryParts.push(`type=${ioc_type}`)
+  if (state_filter) queryParts.push(`state=${state_filter}`)
+  if (source) queryParts.push(`source=${source}`)
+  if (seen_since) queryParts.push(`last_seen>=${seen_since}`)
+
+  const { result, table } = await callOnObservableTable(client, async (t) => {
+    const response = await client.get(`/api/now/table/${t}`, {
+      params: {
+        sysparm_query: queryParts.join("^"),
+        sysparm_limit: limit,
+        sysparm_orderby: "sys_updated_on",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,value,type,state,source,confidence,tlp,finding,last_seen,sys_created_on,sys_updated_on",
+            }),
+      },
+    })
+    return (response.data.result || []) as Array<Record<string, unknown>>
+  })
+
+  return createSuccessResult({
+    action: "list_iocs",
+    count: result.length,
+    table,
+    iocs: result.map((r) => ({
+      sys_id: r.sys_id,
+      value: r.value,
+      type: r.type,
+      state: r.state,
+      source: r.source,
+      confidence: r.confidence,
+      tlp: r.tlp,
+      finding: r.finding,
+      last_seen: r.last_seen,
+      created_at: r.sys_created_on,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${table}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== LINK_TO_INCIDENT ====================
+
+async function executeLinkToIncident(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id (IOC sys_id) is required for link_to_incident action")
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for link_to_incident action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  // Try the documented m2m join table first.
+  // TODO: verify sn_si_m2m_observable_incident on a live instance — the join
+  // table name has varied: sn_si_m2m_observable_incident, sn_ti_m2m_indicator_incident.
+  try {
+    const linkResponse = await client.post(`/api/now/table/${SIR_INCIDENT_OBSERVABLE_JOIN}`, {
+      observable: sys_id,
+      incident: incidentSysId,
+    })
+    const link = linkResponse.data.result as Record<string, unknown>
+    return createSuccessResult({
+      action: "link_to_incident",
+      linked: true,
+      link_sys_id: link.sys_id,
+      ioc_sys_id: sys_id,
+      incident_sys_id: incidentSysId,
+      join_table: SIR_INCIDENT_OBSERVABLE_JOIN,
+    })
+  } catch (err: unknown) {
+    const e = err as { response?: { status?: number }; message?: string }
+    if (e?.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `IOC join table ${SIR_INCIDENT_OBSERVABLE_JOIN} not found. The observable-to-incident relationship may use a different join table on this release. Activate the Security Incident Response plugin (${SIR_PLUGIN}) and verify the join table name.`,
+          { details: { plugin: SIR_PLUGIN, tried_table: SIR_INCIDENT_OBSERVABLE_JOIN } },
+        ),
+      )
+    }
+    throw new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, e.message || "Failed to link IOC", {
+      originalError: err as Error,
+    })
+  }
+}
+
+// ==================== MARK_ACTIVE / MARK_RESOLVED ====================
+
+async function executeMarkState(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+  state: string,
+): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const note = args.note as string | undefined
+
+  if (!sys_id) return createErrorResult("sys_id is required for mark_active / mark_resolved actions")
+
+  const client = await getAuthenticatedClient(context)
+
+  const patch: Record<string, unknown> = { state }
+  if (note) patch.work_notes = note
+
+  const { result, table } = await callOnObservableTable(client, async (t) => {
+    const response = await client.patch(`/api/now/table/${t}/${sys_id}`, patch)
+    return response.data.result as Record<string, unknown>
+  })
+
+  return createSuccessResult({
+    action: state === IOC_STATE.active ? "mark_active" : "mark_resolved",
+    updated: true,
+    sys_id,
+    table,
+    state: result.state,
+    ioc: result,
+    url: `${context.instanceUrl}/nav_to.do?uri=${table}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== SEARCH_BY_VALUE ====================
+
+async function executeSearchByValue(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const ioc_value = args.ioc_value as string | undefined
+  const ioc_type = args.ioc_type as string | undefined
+  const match_mode = (args.match_mode as string | undefined) || "exact"
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  if (!ioc_value) return createErrorResult("ioc_value is required for search_by_value action")
+
+  const client = await getAuthenticatedClient(context)
+
+  const valueOperator =
+    match_mode === "contains" ? "valueLIKE" : match_mode === "starts_with" ? "valueSTARTSWITH" : "value="
+  const queryParts: string[] = [`${valueOperator}${ioc_value}`]
+  if (ioc_type) queryParts.push(`type=${ioc_type}`)
+
+  // Search across both observable tables so callers don't need to know
+  // which one the instance uses. Skip silently when one returns 404.
+  const tables = [TI_OBSERVABLE_TABLE, SI_OBSERVABLE_TABLE_FALLBACK, TI_INDICATOR_TABLE]
+  const hits: Array<Record<string, unknown>> = []
+  const triedTables: Array<{ table: string; count: number; error?: string }> = []
+
+  for (const t of tables) {
+    try {
+      const response = await client.get(`/api/now/table/${t}`, {
+        params: {
+          sysparm_query: queryParts.join("^"),
+          sysparm_limit: limit,
+          sysparm_orderby: "sys_updated_on",
+          sysparm_display_value: "true",
+          ...(fields
+            ? { sysparm_fields: fields }
+            : { sysparm_fields: "sys_id,value,type,state,source,confidence,last_seen,sys_updated_on" }),
+        },
+      })
+      const rows = (response.data.result || []) as Array<Record<string, unknown>>
+      triedTables.push({ table: t, count: rows.length })
+      for (const r of rows) {
+        hits.push({
+          ...r,
+          _source_table: t,
+          url: `${context.instanceUrl}/nav_to.do?uri=${t}.do?sys_id=${r.sys_id}`,
+        })
+      }
+    } catch (err: unknown) {
+      const e = err as { response?: { status?: number }; message?: string }
+      triedTables.push({ table: t, count: 0, error: e?.response?.status === 404 ? "table_not_found" : (e?.message || "error") })
+    }
+  }
+
+  if (triedTables.every((t) => t.error === "table_not_found")) {
+    return createErrorResult(
+      new SnowFlowError(
+        ErrorType.PLUGIN_MISSING,
+        `No IOC tables found on this instance. Tried ${tables.join(", ")}. Activate the Security Incident Response plugin (${SIR_PLUGIN}) or the Threat Intelligence application.`,
+        { details: { plugin: SIR_PLUGIN, tried_tables: tables } },
+      ),
+    )
+  }
+
+  return createSuccessResult({
+    action: "search_by_value",
+    count: hits.length,
+    match_mode,
+    tried_tables: triedTables,
+    iocs: hits,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_playbook_orchestrate.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_sir_playbook_orchestrate.ts
@@ -1,0 +1,579 @@
+/**
+ * snow_sir_playbook_orchestrate - Unified SIR playbook orchestration
+ *
+ * Drives multi-step Security Incident Response (SIR) playbooks on the
+ * sn_si_playbook and sn_si_playbook_task tables. A SIR playbook is a
+ * sequenced SOAR procedure (e.g. "Phishing email response") composed of
+ * playbook tasks; this tool starts a playbook against an incident, walks
+ * through its task instances, and tracks status.
+ *
+ * Companion to snow_execute_security_playbook (which only fires a playbook
+ * without managing per-step state) and snow_sir_incident_manage (which
+ * owns the incident itself). Use this tool when you need to drive a
+ * playbook step-by-step, inspect running playbooks, advance to the next
+ * step, or cancel mid-flight.
+ *
+ * Requires the Security Incident Response plugin (com.snc.security_incident).
+ * A 404 on the primary table is surfaced as a clear missing-plugin error.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+const SIR_PLUGIN = "com.snc.security_incident"
+const SIR_PLAYBOOK_TABLE = "sn_si_playbook"
+const SIR_PLAYBOOK_TASK_TABLE = "sn_si_playbook_task"
+const SIR_INCIDENT_TABLE = "sn_si_incident"
+
+// Playbook task states. The exact codes vary by release; values are
+// passed as strings to let the platform coerce.
+// TODO: verify state codes against a live SIR instance.
+const TASK_STATE = {
+  pending: "1",
+  in_progress: "2",
+  complete: "3",
+  cancelled: "4",
+  skipped: "7",
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_sir_playbook_orchestrate",
+  description: `Unified tool for orchestrating Security Incident Response (SIR) playbooks on sn_si_playbook and sn_si_playbook_task. Drives a playbook step-by-step against an incident, tracking task instance state from pending through complete.
+
+Actions:
+- list_playbooks — list playbook definitions on sn_si_playbook (catalogue of available procedures)
+- start — start a playbook against an incident (creates the run-time task instances and marks the first step in_progress)
+- list_running — list currently running playbook task instances, optionally filtered by incident
+- get_status — get the full step list for a running playbook on an incident with each step's state
+- advance_step — mark the current step complete (optionally skip) and move the next pending step to in_progress
+- cancel — cancel all remaining pending/in-progress steps for a playbook on an incident
+
+Use when: the agent needs full step-by-step state management around a SOAR playbook rather than the fire-and-forget behaviour of snow_execute_security_playbook. Companion tools: snow_execute_security_playbook (trigger only), snow_sir_incident_manage (manage the parent incident), snow_sir_evidence_manage (attach evidence to the incident).
+
+Plugin gating: requires com.snc.security_incident. A 404 on sn_si_playbook is surfaced with the required plugin name.
+
+Returns: action-specific data. list_playbooks returns playbook definitions with sys_id, name, description, category. start returns the created task instances with their order. get_status returns each step's sys_id, name, state, assigned_to, started_at, completed_at. advance_step / cancel return the post-update state snapshot.`,
+  category: "security",
+  subcategory: "playbooks",
+  use_cases: ["sir", "soar", "playbooks", "orchestration", "incident-response"],
+  complexity: "advanced",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Orchestration action to perform",
+        enum: ["list_playbooks", "start", "list_running", "get_status", "advance_step", "cancel"],
+      },
+      // Identifiers
+      playbook_sys_id: {
+        type: "string",
+        description: "[start] sys_id of the playbook definition on sn_si_playbook",
+      },
+      playbook_name: {
+        type: "string",
+        description: "[start] Name of the playbook (alternative to playbook_sys_id)",
+      },
+      incident_sys_id: {
+        type: "string",
+        description: "[start/list_running/get_status/advance_step/cancel] sys_id of the parent SIR incident (sn_si_incident)",
+      },
+      incident_number: {
+        type: "string",
+        description: "[start/get_status/advance_step/cancel] SIR incident number (e.g. SIR0010001), alternative to incident_sys_id",
+      },
+      task_sys_id: {
+        type: "string",
+        description: "[advance_step] sys_id of the specific task instance to advance (optional — defaults to the current in-progress step)",
+      },
+      // LIST
+      category: {
+        type: "string",
+        description: "[list_playbooks] Filter playbooks by category",
+      },
+      active_only: {
+        type: "boolean",
+        description: "[list_playbooks] Only return active playbooks",
+        default: true,
+      },
+      limit: {
+        type: "number",
+        description: "[list_playbooks/list_running] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_playbooks/list_running/get_status] Comma-separated list of fields to return",
+      },
+      // START
+      assigned_to: {
+        type: "string",
+        description: "[start] sys_user sys_id assigned to drive the playbook (defaults to incident's assignee)",
+      },
+      // ADVANCE_STEP
+      skip: {
+        type: "boolean",
+        description: "[advance_step] Skip the current step instead of marking it complete",
+        default: false,
+      },
+      step_note: {
+        type: "string",
+        description: "[advance_step] Work note attached to the completed/skipped step",
+      },
+      // CANCEL
+      cancel_reason: {
+        type: "string",
+        description: "[cancel] Reason for cancelling the playbook run",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_playbooks":
+        return await executeListPlaybooks(args, context)
+      case "start":
+        return await executeStart(args, context)
+      case "list_running":
+        return await executeListRunning(args, context)
+      case "get_status":
+        return await executeGetStatus(args, context)
+      case "advance_step":
+        return await executeAdvanceStep(args, context)
+      case "cancel":
+        return await executeCancel(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_playbooks, start, list_running, get_status, advance_step, cancel`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `SIR playbook ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+function plugin404(err: unknown, table: string): SnowFlowError {
+  const e = err as { response?: { status?: number }; message?: string }
+  if (e?.response?.status === 404) {
+    return new SnowFlowError(
+      ErrorType.PLUGIN_MISSING,
+      `Security Incident Response plugin not installed. The ${table} table was not found on this instance. Activate the plugin (${SIR_PLUGIN}) under System Definition > Plugins.`,
+      { details: { plugin: SIR_PLUGIN, table } },
+    )
+  }
+  return new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, e?.message || "SIR API call failed", { originalError: err as Error })
+}
+
+async function findPlaybook(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string | undefined,
+  name: string | undefined,
+): Promise<Record<string, unknown> | null> {
+  if (sysId) {
+    try {
+      const direct = await client.get(`/api/now/table/${SIR_PLAYBOOK_TABLE}/${sysId}`)
+      if (direct.data.result && direct.data.result.sys_id) return direct.data.result
+    } catch (err: unknown) {
+      throw plugin404(err, SIR_PLAYBOOK_TABLE)
+    }
+  }
+  if (name) {
+    const search = await client.get(`/api/now/table/${SIR_PLAYBOOK_TABLE}`, {
+      params: { sysparm_query: `name=${name}`, sysparm_limit: 1 },
+    })
+    const results = search.data.result || []
+    if (results.length > 0) return results[0]
+  }
+  return null
+}
+
+async function resolveIncidentSysId(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  incidentSysId: string | undefined,
+  incidentNumber: string | undefined,
+): Promise<string | null> {
+  if (incidentSysId) return incidentSysId
+  if (incidentNumber) {
+    const search = await client.get(`/api/now/table/${SIR_INCIDENT_TABLE}`, {
+      params: { sysparm_query: `number=${incidentNumber}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    if (results.length > 0) return results[0].sys_id as string
+  }
+  return null
+}
+
+// ==================== LIST_PLAYBOOKS ====================
+
+async function executeListPlaybooks(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const category = args.category as string | undefined
+  const active_only = args.active_only !== false
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (category) queryParts.push(`category=${category}`)
+  if (active_only) queryParts.push("active=true")
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_PLAYBOOK_TABLE}`, {
+      params: {
+        sysparm_query: queryParts.join("^"),
+        sysparm_limit: limit,
+        sysparm_orderby: "name",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : { sysparm_fields: "sys_id,name,description,category,active,sys_updated_on" }),
+      },
+    })
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list_playbooks",
+      count: results.length,
+      playbooks: results.map((p) => ({
+        sys_id: p.sys_id,
+        name: p.name,
+        description: p.description,
+        category: p.category,
+        active: p.active,
+        updated_at: p.sys_updated_on,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_PLAYBOOK_TABLE}.do?sys_id=${p.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_PLAYBOOK_TABLE)
+  }
+}
+
+// ==================== START ====================
+
+async function executeStart(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const playbook_sys_id = args.playbook_sys_id as string | undefined
+  const playbook_name = args.playbook_name as string | undefined
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const assigned_to = args.assigned_to as string | undefined
+
+  if (!playbook_sys_id && !playbook_name) {
+    return createErrorResult("playbook_sys_id or playbook_name is required for start action")
+  }
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for start action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const playbook = await findPlaybook(client, playbook_sys_id, playbook_name)
+  if (!playbook) {
+    return createErrorResult(`Playbook not found: ${playbook_sys_id || playbook_name}`)
+  }
+
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  // Create a task instance row referencing the playbook. The platform
+  // workflow normally clones each step from sn_si_playbook_task_template
+  // into sn_si_playbook_task; we create a single anchor record and let
+  // the platform fan out — this matches how snow_execute_security_playbook
+  // triggers without per-step authoring.
+  // TODO: verify the parent / playbook reference column names against a
+  // live SIR instance — older releases use `playbook` while newer ones
+  // use `sn_si_playbook` as the field name.
+  try {
+    const payload: Record<string, unknown> = {
+      parent: incidentSysId,
+      playbook: playbook.sys_id,
+      state: TASK_STATE.in_progress,
+    }
+    if (assigned_to) payload.assigned_to = assigned_to
+
+    const response = await client.post(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, payload)
+    const created = response.data.result as Record<string, unknown>
+
+    return createSuccessResult({
+      action: "start",
+      started: true,
+      sys_id: created.sys_id,
+      playbook: { sys_id: playbook.sys_id, name: playbook.name },
+      incident: { sys_id: incidentSysId },
+      task: created,
+      url: `${context.instanceUrl}/nav_to.do?uri=${SIR_PLAYBOOK_TASK_TABLE}.do?sys_id=${created.sys_id}`,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_PLAYBOOK_TASK_TABLE)
+  }
+}
+
+// ==================== LIST_RUNNING ====================
+
+async function executeListRunning(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = [`stateIN${TASK_STATE.pending},${TASK_STATE.in_progress}`]
+  if (incident_sys_id) queryParts.push(`parent=${incident_sys_id}`)
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, {
+      params: {
+        sysparm_query: queryParts.join("^"),
+        sysparm_limit: limit,
+        sysparm_orderby: "order",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,number,short_description,state,parent,playbook,assigned_to,order,sys_created_on",
+            }),
+      },
+    })
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+    return createSuccessResult({
+      action: "list_running",
+      count: results.length,
+      tasks: results.map((t) => ({
+        sys_id: t.sys_id,
+        number: t.number,
+        short_description: t.short_description,
+        state: t.state,
+        parent: t.parent,
+        playbook: t.playbook,
+        assigned_to: t.assigned_to,
+        order: t.order,
+        created_at: t.sys_created_on,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_PLAYBOOK_TASK_TABLE}.do?sys_id=${t.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_PLAYBOOK_TASK_TABLE)
+  }
+}
+
+// ==================== GET_STATUS ====================
+
+async function executeGetStatus(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const fields = args.fields as string | undefined
+
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for get_status action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}`,
+        sysparm_limit: 500,
+        sysparm_orderby: "order",
+        sysparm_display_value: "true",
+        ...(fields
+          ? { sysparm_fields: fields }
+          : {
+              sysparm_fields:
+                "sys_id,number,short_description,state,assigned_to,order,opened_at,closed_at,sys_created_on,sys_updated_on",
+            }),
+      },
+    })
+    const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+    const stateSummary: Record<string, number> = {}
+    for (const t of results) {
+      const s = String(t.state ?? "unknown")
+      stateSummary[s] = (stateSummary[s] || 0) + 1
+    }
+
+    return createSuccessResult({
+      action: "get_status",
+      incident: { sys_id: incidentSysId },
+      total_steps: results.length,
+      state_summary: stateSummary,
+      steps: results.map((t) => ({
+        sys_id: t.sys_id,
+        number: t.number,
+        short_description: t.short_description,
+        state: t.state,
+        assigned_to: t.assigned_to,
+        order: t.order,
+        opened_at: t.opened_at,
+        closed_at: t.closed_at,
+        url: `${context.instanceUrl}/nav_to.do?uri=${SIR_PLAYBOOK_TASK_TABLE}.do?sys_id=${t.sys_id}`,
+      })),
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_PLAYBOOK_TASK_TABLE)
+  }
+}
+
+// ==================== ADVANCE_STEP ====================
+
+async function executeAdvanceStep(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const task_sys_id = args.task_sys_id as string | undefined
+  const skip = args.skip === true
+  const step_note = args.step_note as string | undefined
+
+  if (!task_sys_id && !incident_sys_id && !incident_number) {
+    return createErrorResult(
+      "task_sys_id (or incident_sys_id/incident_number) is required for advance_step action",
+    )
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Resolve the task to advance: either explicit task_sys_id, or the
+  // current in-progress step on the given incident.
+  let currentTask: Record<string, unknown> | null = null
+  if (task_sys_id) {
+    try {
+      const direct = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}/${task_sys_id}`)
+      currentTask = direct.data.result
+    } catch (err: unknown) {
+      throw plugin404(err, SIR_PLAYBOOK_TASK_TABLE)
+    }
+  } else {
+    const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+    if (!incidentSysId) {
+      return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+    }
+    const search = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}^state=${TASK_STATE.in_progress}`,
+        sysparm_limit: 1,
+        sysparm_orderby: "order",
+      },
+    })
+    const results = (search.data.result || []) as Array<Record<string, unknown>>
+    currentTask = results.length > 0 ? results[0] : null
+  }
+
+  if (!currentTask) {
+    return createErrorResult("No in-progress playbook task found for the given incident")
+  }
+
+  const currentSysId = currentTask.sys_id as string
+  const currentOrder = currentTask.order as string | number | undefined
+  const parentSysId = (currentTask.parent as { value?: string } | string) as unknown
+  const parent = typeof parentSysId === "string"
+    ? parentSysId
+    : (parentSysId as { value?: string } | undefined)?.value || ""
+
+  // Mark the current step complete or skipped.
+  const currentPatch: Record<string, unknown> = {
+    state: skip ? TASK_STATE.skipped : TASK_STATE.complete,
+  }
+  if (step_note) currentPatch.work_notes = step_note
+
+  await client.patch(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}/${currentSysId}`, currentPatch)
+
+  // Find the next pending step on the same incident.
+  let nextTask: Record<string, unknown> | null = null
+  if (parent) {
+    const nextQuery = currentOrder !== undefined
+      ? `parent=${parent}^state=${TASK_STATE.pending}^order>${currentOrder}`
+      : `parent=${parent}^state=${TASK_STATE.pending}`
+    const nextResponse = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, {
+      params: { sysparm_query: nextQuery, sysparm_limit: 1, sysparm_orderby: "order" },
+    })
+    const nextResults = (nextResponse.data.result || []) as Array<Record<string, unknown>>
+    if (nextResults.length > 0) {
+      nextTask = nextResults[0]
+      await client.patch(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}/${nextTask.sys_id}`, {
+        state: TASK_STATE.in_progress,
+      })
+    }
+  }
+
+  return createSuccessResult({
+    action: "advance_step",
+    advanced: true,
+    completed: !skip,
+    skipped: skip,
+    previous_step: { sys_id: currentSysId, order: currentOrder },
+    next_step: nextTask ? { sys_id: nextTask.sys_id, order: nextTask.order, short_description: nextTask.short_description } : null,
+    playbook_complete: nextTask === null,
+  })
+}
+
+// ==================== CANCEL ====================
+
+async function executeCancel(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const incident_sys_id = args.incident_sys_id as string | undefined
+  const incident_number = args.incident_number as string | undefined
+  const cancel_reason = args.cancel_reason as string | undefined
+
+  if (!incident_sys_id && !incident_number) {
+    return createErrorResult("incident_sys_id or incident_number is required for cancel action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const incidentSysId = await resolveIncidentSysId(client, incident_sys_id, incident_number)
+  if (!incidentSysId) {
+    return createErrorResult(`SIR incident not found: ${incident_sys_id || incident_number}`)
+  }
+
+  try {
+    const response = await client.get(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}`, {
+      params: {
+        sysparm_query: `parent=${incidentSysId}^stateIN${TASK_STATE.pending},${TASK_STATE.in_progress}`,
+        sysparm_limit: 500,
+        sysparm_fields: "sys_id,number,order,state",
+      },
+    })
+    const open = (response.data.result || []) as Array<Record<string, unknown>>
+
+    const cancelled: Array<{ sys_id: string; number: unknown }> = []
+    for (const task of open) {
+      const patch: Record<string, unknown> = { state: TASK_STATE.cancelled }
+      if (cancel_reason) patch.work_notes = `Cancelled: ${cancel_reason}`
+      await client.patch(`/api/now/table/${SIR_PLAYBOOK_TASK_TABLE}/${task.sys_id}`, patch)
+      cancelled.push({ sys_id: task.sys_id as string, number: task.number })
+    }
+
+    return createSuccessResult({
+      action: "cancel",
+      cancelled_count: cancelled.length,
+      cancelled,
+      incident: { sys_id: incidentSysId },
+      reason: cancel_reason || null,
+    })
+  } catch (err: unknown) {
+    throw plugin404(err, SIR_PLAYBOOK_TASK_TABLE)
+  }
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"


### PR DESCRIPTION
Fixes #120.

Adds four unified Security Incident Response tools under `tools/security/`, covering the NIST IR phase model, SOAR playbook orchestration, forensic evidence chain-of-custody, and IOC lifecycle.

## Tools

| Tool | Primary tables | Actions |
| --- | --- | --- |
| `snow_sir_incident_manage` | `sn_si_incident`, `sn_si_task` | list, get, create, triage, contain, eradicate, recover, close, list_tasks |
| `snow_sir_playbook_orchestrate` | `sn_si_playbook`, `sn_si_playbook_task` | list_playbooks, start, list_running, get_status, advance_step, cancel |
| `snow_sir_evidence_manage` | `sn_si_evidence`, `sn_si_artifact`, `sn_si_attachment` | attach, list, get, hash_verify, export |
| `snow_sir_indicator_manage` | `sn_ti_observable` (primary), `sn_si_observable` (fallback), `sn_ti_indicator` | create_ioc, list_iocs, link_to_incident, mark_active, mark_resolved, search_by_value |

## Notes for reviewers

- All four tools share a `plugin404` helper that turns a 404 on the primary SIR table into a clear `PLUGIN_MISSING` error naming `com.snc.security_incident`.
- `snow_sir_indicator_manage` additionally falls back between `sn_ti_observable` and `sn_si_observable` since the IOC table name varies by SN release. All uncertain table names are flagged with `// TODO: verify`.
- `snow_sir_evidence_manage.hash_verify` recomputes the SHA-256 of the linked `sys_attachment` server-side using `GlideDigest.getSHA256Base64` via the shared scripted-exec path. The executed script is ES5-only (Rhino-safe).
- `tools.json` is auto-generated and intentionally left untouched; ran `bun packages/opencode/script/generate-tools-json.ts` locally — 414 tools across 129 subcategories, 0 failures, 4 new tools registered.

## Verification status

Best-effort against docs.servicenow.com — needs verification against a live instance with SIR plugin installed before merge. State codes (incident phases, playbook task states), parent/reference column names on `sn_si_task` and `sn_si_playbook_task`, and the observable-incident join table name are the most likely to differ across SN releases.