### PR TITLE
feat(opencode): add 5 GRC tools (audit, policy, risk, issue, vendor risk)

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/index.ts
@@ -87,3 +87,25 @@ export {
   toolDefinition as snow_compliance_manage_def,
   execute as snow_compliance_manage_exec,
 } from "./snow_compliance_manage.js"
+
+// GRC Tools (Tier A — issue #119)
+export {
+  toolDefinition as snow_grc_audit_manage_def,
+  execute as snow_grc_audit_manage_exec,
+} from "./snow_grc_audit_manage.js"
+export {
+  toolDefinition as snow_grc_policy_manage_def,
+  execute as snow_grc_policy_manage_exec,
+} from "./snow_grc_policy_manage.js"
+export {
+  toolDefinition as snow_grc_risk_manage_def,
+  execute as snow_grc_risk_manage_exec,
+} from "./snow_grc_risk_manage.js"
+export {
+  toolDefinition as snow_grc_issue_manage_def,
+  execute as snow_grc_issue_manage_exec,
+} from "./snow_grc_issue_manage.js"
+export {
+  toolDefinition as snow_grc_vendor_risk_manage_def,
+  execute as snow_grc_vendor_risk_manage_exec,
+} from "./snow_grc_vendor_risk_manage.js"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_audit_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_audit_manage.ts
@@ -1,0 +1,613 @@
+/**
+ * snow_grc_audit_manage - Unified GRC Audit Management lifecycle
+ *
+ * Manages the ServiceNow Audit Management (GRC) lifecycle: engagements,
+ * audits, findings, and audit evidence. Wraps the audit tables that ship
+ * with the GRC: Audit Management plugin (sn_audit_audit, sn_audit_finding,
+ * sn_audit_engagement, sn_audit_evidence).
+ *
+ * Companion to snow_compliance_manage (policy exceptions and control
+ * evidence) and snow_create_audit_rule (audit rule authoring). This tool
+ * focuses on the audit lifecycle itself — opening an audit engagement,
+ * tracking individual audits inside the engagement, logging findings, and
+ * attaching evidence to support the findings.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+// TODO: verify against a live instance. The GRC Audit Management plugin
+// has shipped audit tables under `sn_audit_*` since Tokyo. Some older
+// implementations and certain Now Platform variants expose the same data
+// under `sn_grc_audit_*`. Detect and fall back if needed.
+const TABLE_AUDIT = "sn_audit_audit"
+const TABLE_FINDING = "sn_audit_finding"
+const TABLE_ENGAGEMENT = "sn_audit_engagement"
+const TABLE_EVIDENCE = "sn_audit_evidence"
+
+const PLUGIN_NAME = "GRC: Audit Management (com.sn_audit)"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_grc_audit_manage",
+  description: `Unified tool for ServiceNow GRC Audit Management: engagements, audits, findings, and evidence. Wraps the sn_audit_audit, sn_audit_finding, sn_audit_engagement, and sn_audit_evidence tables that ship with the GRC: Audit Management plugin.
+
+Actions:
+- list — list audits, optionally filtered by engagement, state, or auditor
+- get — retrieve a single audit by sys_id
+- create_audit — open a new audit inside an existing engagement
+- update_audit — patch fields on an existing audit (state, scope, lead auditor, dates)
+- add_finding — log a finding against an audit with severity and recommendation
+- list_findings — list findings, optionally filtered by audit, severity, or state
+- attach_evidence — attach an evidence record (or external URL) to an audit or finding
+
+Use when: the agent needs to drive an audit engagement end to end — opening individual audits, logging the findings that come out of them, and attaching the evidence collected during fieldwork. For policy and control evidence outside an audit context, use snow_compliance_manage; for risk register operations, use snow_grc_risk_manage.
+
+Returns: audit rows with sys_id, engagement, state, lead auditor, planned and actual dates; finding rows with severity, recommendation, target remediation date; evidence rows with type and reference link. GRC plugin gating: the first call against the audit tables will surface a clear error if the GRC: Audit Management plugin is not active on the target instance.`,
+  category: "security",
+  subcategory: "audit",
+  use_cases: ["grc", "audit", "audit-management", "findings", "evidence"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: [
+          "list",
+          "get",
+          "create_audit",
+          "update_audit",
+          "add_finding",
+          "list_findings",
+          "attach_evidence",
+        ],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/update_audit/add_finding/attach_evidence] Audit sys_id",
+      },
+      engagement_sys_id: {
+        type: "string",
+        description: "[create_audit/list] Audit engagement sys_id (sn_audit_engagement)",
+      },
+      finding_sys_id: {
+        type: "string",
+        description: "[attach_evidence] Finding sys_id when attaching evidence to a specific finding",
+      },
+      // LIST filters
+      state: {
+        type: "string",
+        description: "[list/list_findings] Filter by state (draft, scheduled, in_progress, completed, closed, cancelled)",
+      },
+      auditor: {
+        type: "string",
+        description: "[list] Filter by lead auditor sys_user sys_id",
+      },
+      severity: {
+        type: "string",
+        description: "[list_findings] Filter by finding severity",
+        enum: ["critical", "high", "medium", "low", "informational"],
+      },
+      limit: {
+        type: "number",
+        description: "[list/list_findings] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get/list_findings] Comma-separated list of fields to return",
+      },
+      // CREATE_AUDIT
+      short_description: {
+        type: "string",
+        description: "[create_audit] Short description of the audit",
+      },
+      description: {
+        type: "string",
+        description: "[create_audit/update_audit] Long description / scope narrative",
+      },
+      scope: {
+        type: "string",
+        description: "[create_audit/update_audit] Audit scope (free text)",
+      },
+      lead_auditor: {
+        type: "string",
+        description: "[create_audit/update_audit] Lead auditor sys_user sys_id",
+      },
+      planned_start_date: {
+        type: "string",
+        description: "[create_audit/update_audit] ISO date string (YYYY-MM-DD) when the audit is planned to start",
+      },
+      planned_end_date: {
+        type: "string",
+        description: "[create_audit/update_audit] ISO date string (YYYY-MM-DD) when the audit is planned to end",
+      },
+      audit_type: {
+        type: "string",
+        description: "[create_audit] Audit type label (internal, external, regulatory, sox, soc, iso, custom)",
+      },
+      // UPDATE_AUDIT
+      audit_state: {
+        type: "string",
+        description: "[update_audit] New audit state",
+        enum: ["draft", "scheduled", "in_progress", "completed", "closed", "cancelled"],
+      },
+      // ADD_FINDING
+      finding_short_description: {
+        type: "string",
+        description: "[add_finding] Short description of the finding",
+      },
+      finding_description: {
+        type: "string",
+        description: "[add_finding] Long description / observation detail",
+      },
+      finding_severity: {
+        type: "string",
+        description: "[add_finding] Severity rating",
+        enum: ["critical", "high", "medium", "low", "informational"],
+      },
+      recommendation: {
+        type: "string",
+        description: "[add_finding] Recommended remediation action",
+      },
+      target_remediation_date: {
+        type: "string",
+        description: "[add_finding] ISO date string (YYYY-MM-DD) for target remediation",
+      },
+      assigned_to: {
+        type: "string",
+        description: "[add_finding] sys_user sys_id of the remediation owner",
+      },
+      // ATTACH_EVIDENCE
+      evidence_type: {
+        type: "string",
+        description: "[attach_evidence] Evidence type label",
+        enum: ["document", "screenshot", "report", "attestation", "log", "interview", "other"],
+        default: "document",
+      },
+      evidence_url: {
+        type: "string",
+        description: "[attach_evidence] External URL pointing at the evidence (used when no existing sys_id is given)",
+      },
+      evidence_sys_id: {
+        type: "string",
+        description: "[attach_evidence] Existing sn_audit_evidence sys_id to link instead of creating a new row",
+      },
+      evidence_description: {
+        type: "string",
+        description: "[attach_evidence] Description for the evidence record",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create_audit":
+        return await executeCreateAudit(args, context)
+      case "update_audit":
+        return await executeUpdateAudit(args, context)
+      case "add_finding":
+        return await executeAddFinding(args, context)
+      case "list_findings":
+        return await executeListFindings(args, context)
+      case "attach_evidence":
+        return await executeAttachEvidence(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create_audit, update_audit, add_finding, list_findings, attach_evidence`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    // Plugin-gating: a 404 on the first audit-table call almost always means
+    // the GRC: Audit Management plugin is not active on this instance.
+    if (err.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `GRC audit table not found. The ${PLUGIN_NAME} plugin may not be active on this instance. Confirm that sn_audit_audit and sn_audit_finding tables exist.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `GRC audit ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findAudit(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_AUDIT}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const engagement_sys_id = args.engagement_sys_id as string | undefined
+  const state = args.state as string | undefined
+  const auditor = args.auditor as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (engagement_sys_id) queryParts.push(`engagement=${engagement_sys_id}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (auditor) queryParts.push(`lead_auditor=${auditor}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_AUDIT}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,short_description,engagement,state,lead_auditor,audit_type,planned_start_date,planned_end_date,sys_created_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    audits: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      engagement: r.engagement,
+      state: r.state,
+      lead_auditor: r.lead_auditor,
+      audit_type: r.audit_type,
+      planned_start_date: r.planned_start_date,
+      planned_end_date: r.planned_end_date,
+      created_at: r.sys_created_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_AUDIT}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for get action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const audit = await findAudit(client, sys_id)
+  if (!audit) {
+    return createErrorResult(`Audit not found: ${sys_id}`)
+  }
+
+  // Count related findings for context (best-effort)
+  let findingCount = 0
+  try {
+    const findings = await client.get(`/api/now/table/${TABLE_FINDING}`, {
+      params: { sysparm_query: `audit=${sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    findingCount = (findings.data.result || []).length
+  } catch {
+    // TODO: verify finding -> audit reference column on a live instance.
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id,
+    audit,
+    related: {
+      finding_count: findingCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_AUDIT}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== CREATE_AUDIT ====================
+
+async function executeCreateAudit(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const engagement_sys_id = args.engagement_sys_id as string | undefined
+  const short_description = args.short_description as string | undefined
+
+  if (!engagement_sys_id) {
+    return createErrorResult("engagement_sys_id is required for create_audit action")
+  }
+  if (!short_description) {
+    return createErrorResult("short_description is required for create_audit action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Verify the engagement exists before creating an audit under it.
+  // TODO: verify sn_audit_engagement reference column name (engagement vs parent) on a live instance.
+  const engagementCheck = await client.get(`/api/now/table/${TABLE_ENGAGEMENT}/${engagement_sys_id}`)
+  if (!engagementCheck.data.result || !engagementCheck.data.result.sys_id) {
+    return createErrorResult(`Audit engagement not found: ${engagement_sys_id}`)
+  }
+
+  const payload: Record<string, unknown> = {
+    engagement: engagement_sys_id,
+    short_description,
+    state: "draft",
+  }
+  if (args.description) payload.description = args.description
+  if (args.scope) payload.scope = args.scope
+  if (args.lead_auditor) payload.lead_auditor = args.lead_auditor
+  if (args.planned_start_date) payload.planned_start_date = args.planned_start_date
+  if (args.planned_end_date) payload.planned_end_date = args.planned_end_date
+  if (args.audit_type) payload.audit_type = args.audit_type
+
+  const response = await client.post(`/api/now/table/${TABLE_AUDIT}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_audit",
+    created: true,
+    sys_id: created.sys_id,
+    audit: created,
+    engagement_sys_id,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_AUDIT}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== UPDATE_AUDIT ====================
+
+async function executeUpdateAudit(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for update_audit action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const audit = await findAudit(client, sys_id)
+  if (!audit) {
+    return createErrorResult(`Audit not found: ${sys_id}`)
+  }
+
+  const updatableFields: Array<[string, string]> = [
+    ["description", "description"],
+    ["scope", "scope"],
+    ["lead_auditor", "lead_auditor"],
+    ["planned_start_date", "planned_start_date"],
+    ["planned_end_date", "planned_end_date"],
+    ["audit_state", "state"],
+  ]
+
+  const patch: Record<string, unknown> = {}
+  for (const [argKey, fieldName] of updatableFields) {
+    if (args[argKey] !== undefined) {
+      patch[fieldName] = args[argKey]
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return createErrorResult("No update fields provided")
+  }
+
+  const response = await client.patch(`/api/now/table/${TABLE_AUDIT}/${sys_id}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "update_audit",
+    updated: true,
+    sys_id,
+    updated_fields: Object.keys(patch),
+    audit: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_AUDIT}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== ADD_FINDING ====================
+
+async function executeAddFinding(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const finding_short_description = args.finding_short_description as string | undefined
+  const finding_severity = args.finding_severity as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id (audit sys_id) is required for add_finding action")
+  }
+  if (!finding_short_description) {
+    return createErrorResult("finding_short_description is required for add_finding action")
+  }
+  if (!finding_severity) {
+    return createErrorResult("finding_severity is required for add_finding action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const audit = await findAudit(client, sys_id)
+  if (!audit) {
+    return createErrorResult(`Audit not found: ${sys_id}`)
+  }
+
+  // TODO: verify sn_audit_finding column set on a live instance — some
+  // releases use `parent` or `audit_record` rather than `audit` for the
+  // reference back to the parent audit.
+  const payload: Record<string, unknown> = {
+    audit: sys_id,
+    short_description: finding_short_description,
+    severity: finding_severity,
+    state: "open",
+  }
+  if (args.finding_description) payload.description = args.finding_description
+  if (args.recommendation) payload.recommendation = args.recommendation
+  if (args.target_remediation_date) payload.target_remediation_date = args.target_remediation_date
+  if (args.assigned_to) payload.assigned_to = args.assigned_to
+
+  const response = await client.post(`/api/now/table/${TABLE_FINDING}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "add_finding",
+    created: true,
+    sys_id: created.sys_id,
+    audit: { sys_id, short_description: audit.short_description },
+    finding: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_FINDING}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LIST_FINDINGS ====================
+
+async function executeListFindings(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const state = args.state as string | undefined
+  const severity = args.severity as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (sys_id) queryParts.push(`audit=${sys_id}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (severity) queryParts.push(`severity=${severity}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_FINDING}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,short_description,audit,severity,state,recommendation,target_remediation_date,assigned_to,sys_created_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_findings",
+    count: results.length,
+    findings: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      audit: r.audit,
+      severity: r.severity,
+      state: r.state,
+      recommendation: r.recommendation,
+      target_remediation_date: r.target_remediation_date,
+      assigned_to: r.assigned_to,
+      created_at: r.sys_created_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_FINDING}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== ATTACH_EVIDENCE ====================
+
+async function executeAttachEvidence(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const audit_sys_id = args.sys_id as string | undefined
+  const finding_sys_id = args.finding_sys_id as string | undefined
+  const evidence_sys_id = args.evidence_sys_id as string | undefined
+  const evidence_url = args.evidence_url as string | undefined
+  const evidence_type = (args.evidence_type as string) || "document"
+  const evidence_description = args.evidence_description as string | undefined
+
+  if (!audit_sys_id && !finding_sys_id) {
+    return createErrorResult("sys_id (audit) or finding_sys_id is required for attach_evidence action")
+  }
+  if (!evidence_sys_id && !evidence_url) {
+    return createErrorResult("evidence_sys_id or evidence_url is required for attach_evidence action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Verify parent exists.
+  if (audit_sys_id) {
+    const audit = await findAudit(client, audit_sys_id)
+    if (!audit) {
+      return createErrorResult(`Audit not found: ${audit_sys_id}`)
+    }
+  }
+  if (finding_sys_id) {
+    // TODO: verify sn_audit_finding table on a live instance.
+    const findingCheck = await client.get(`/api/now/table/${TABLE_FINDING}/${finding_sys_id}`)
+    if (!findingCheck.data.result || !findingCheck.data.result.sys_id) {
+      return createErrorResult(`Finding not found: ${finding_sys_id}`)
+    }
+  }
+
+  let evidenceRecord: Record<string, unknown>
+  let mode: "linked" | "created_and_linked"
+
+  if (evidence_sys_id) {
+    // Patch the audit/finding reference onto the existing evidence row.
+    // TODO: verify sn_audit_evidence column set on a live instance — some
+    // releases use `audit` and `finding`, others use `parent` with a
+    // polymorphic reference.
+    const direct = await client.get(`/api/now/table/${TABLE_EVIDENCE}/${evidence_sys_id}`)
+    if (!direct.data.result || !direct.data.result.sys_id) {
+      return createErrorResult(`Evidence record not found: ${evidence_sys_id}`)
+    }
+    const patchPayload: Record<string, unknown> = {}
+    if (audit_sys_id) patchPayload.audit = audit_sys_id
+    if (finding_sys_id) patchPayload.finding = finding_sys_id
+    const patchResponse = await client.patch(`/api/now/table/${TABLE_EVIDENCE}/${evidence_sys_id}`, patchPayload)
+    evidenceRecord = patchResponse.data.result as Record<string, unknown>
+    mode = "linked"
+  } else {
+    const payload: Record<string, unknown> = {
+      type: evidence_type,
+      url: evidence_url,
+    }
+    if (audit_sys_id) payload.audit = audit_sys_id
+    if (finding_sys_id) payload.finding = finding_sys_id
+    if (evidence_description) payload.description = evidence_description
+    const created = await client.post(`/api/now/table/${TABLE_EVIDENCE}`, payload)
+    evidenceRecord = created.data.result as Record<string, unknown>
+    mode = "created_and_linked"
+  }
+
+  return createSuccessResult({
+    action: "attach_evidence",
+    link_action: mode,
+    sys_id: evidenceRecord.sys_id,
+    audit_sys_id: audit_sys_id || null,
+    finding_sys_id: finding_sys_id || null,
+    evidence: evidenceRecord,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_issue_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_issue_manage.ts
@@ -1,0 +1,467 @@
+/**
+ * snow_grc_issue_manage - Unified GRC compliance issue and exception management
+ *
+ * Manages compliance issues, exceptions, and remediation tracking inside
+ * the GRC: Policy and Compliance Management plugin. Wraps the
+ * sn_compliance_issue, sn_compliance_policy_exception, sn_compliance_remediation,
+ * and sn_compliance_evidence tables.
+ *
+ * Companion to snow_compliance_manage (which handles the control-side
+ * exception and evidence flow). This tool is the issue-side complement —
+ * listing the compliance issues raised against controls, creating
+ * exceptions for them, tracking remediation, and marking them resolved.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+// TODO: verify against a live instance. Issue tracking moved from
+// `sn_grc_issue` to `sn_compliance_issue` in the Tokyo refactor of GRC.
+// Some Now Platform variants still expose both via a backing view.
+const TABLE_ISSUE = "sn_compliance_issue"
+const TABLE_EXCEPTION = "sn_compliance_policy_exception"
+const TABLE_REMEDIATION = "sn_compliance_remediation"
+const TABLE_EVIDENCE = "sn_compliance_evidence"
+
+const PLUGIN_NAME = "GRC: Policy and Compliance Management (com.sn_compliance)"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_grc_issue_manage",
+  description: `Unified tool for ServiceNow GRC compliance issues and exceptions beyond control-side authoring. Wraps the sn_compliance_issue, sn_compliance_policy_exception, sn_compliance_remediation, and sn_compliance_evidence tables that ship with the GRC: Policy and Compliance Management plugin.
+
+Actions:
+- list_issues — list compliance issues, optionally filtered by control, state, or severity
+- list_exceptions — list policy exceptions raised against controls
+- exception_create — open a new policy exception with justification and expiry
+- link_evidence — attach an evidence record (or external URL) to a compliance issue
+- mark_remediated — close an issue by attaching a remediation record and transitioning state
+
+Use when: the agent needs to manage the issue side of GRC — listing issues raised by automated scans or auditors, granting time-bound exceptions, attaching evidence that supports the remediation, and closing the issue once remediated. For the control-side exception/evidence/attestation flow use snow_compliance_manage; for audit-driven findings use snow_grc_audit_manage.
+
+Returns: issue rows with sys_id, control reference, severity, state; exception rows with state, expiry, requestor; remediation rows with plan, target date, owner; evidence rows with type and reference link. GRC plugin gating: the first call against these tables will surface a clear error if the GRC: Policy and Compliance Management plugin is not active on the target instance.`,
+  category: "security",
+  subcategory: "compliance-issues",
+  use_cases: ["grc", "compliance", "issues", "exceptions", "remediation"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list_exceptions", "exception_create", "link_evidence", "mark_remediated", "list_issues"],
+      },
+      // Identifiers
+      issue_sys_id: {
+        type: "string",
+        description: "[link_evidence/mark_remediated] Compliance issue sys_id",
+      },
+      control_sys_id: {
+        type: "string",
+        description: "[exception_create/list_issues/list_exceptions] Compliance control sys_id (sn_compliance_control)",
+      },
+      // LIST filters
+      state: {
+        type: "string",
+        description: "[list_issues/list_exceptions] Filter by state",
+      },
+      severity: {
+        type: "string",
+        description: "[list_issues] Filter by issue severity",
+        enum: ["critical", "high", "medium", "low", "informational"],
+      },
+      framework: {
+        type: "string",
+        description: "[list_issues/list_exceptions] Filter by compliance framework (SOX, GDPR, HIPAA, ISO27001, etc.)",
+      },
+      limit: {
+        type: "number",
+        description: "[list_issues/list_exceptions] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_issues/list_exceptions] Comma-separated list of fields to return",
+      },
+      // EXCEPTION_CREATE
+      short_description: {
+        type: "string",
+        description: "[exception_create] Short description of the exception",
+      },
+      justification: {
+        type: "string",
+        description: "[exception_create] Business justification for the exception",
+      },
+      expiry: {
+        type: "string",
+        description: "[exception_create] ISO date string (YYYY-MM-DD) when the exception expires",
+      },
+      requestor: {
+        type: "string",
+        description: "[exception_create] sys_user sys_id of the requestor (defaults to the calling user)",
+      },
+      // LINK_EVIDENCE
+      evidence_sys_id: {
+        type: "string",
+        description: "[link_evidence] Existing sn_compliance_evidence sys_id to link",
+      },
+      evidence_url: {
+        type: "string",
+        description: "[link_evidence] External evidence URL (used to create a new evidence row when evidence_sys_id is absent)",
+      },
+      evidence_type: {
+        type: "string",
+        description: "[link_evidence] Evidence type label",
+        enum: ["document", "screenshot", "report", "attestation", "log", "other"],
+        default: "document",
+      },
+      evidence_description: {
+        type: "string",
+        description: "[link_evidence] Optional description for the evidence record",
+      },
+      // MARK_REMEDIATED
+      remediation_summary: {
+        type: "string",
+        description: "[mark_remediated] Summary of the remediation action taken",
+      },
+      remediation_owner: {
+        type: "string",
+        description: "[mark_remediated] sys_user sys_id of the person who remediated the issue",
+      },
+      remediation_completed_at: {
+        type: "string",
+        description: "[mark_remediated] ISO date string (YYYY-MM-DD) when the remediation was completed (defaults to today)",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_issues":
+        return await executeListIssues(args, context)
+      case "list_exceptions":
+        return await executeListExceptions(args, context)
+      case "exception_create":
+        return await executeExceptionCreate(args, context)
+      case "link_evidence":
+        return await executeLinkEvidence(args, context)
+      case "mark_remediated":
+        return await executeMarkRemediated(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_issues, list_exceptions, exception_create, link_evidence, mark_remediated`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `GRC compliance issue table not found. The ${PLUGIN_NAME} plugin may not be active on this instance. Confirm that sn_compliance_issue and sn_compliance_policy_exception tables exist.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `GRC issue ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findIssue(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_ISSUE}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+// ==================== LIST_ISSUES ====================
+
+async function executeListIssues(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const control_sys_id = args.control_sys_id as string | undefined
+  const state = args.state as string | undefined
+  const severity = args.severity as string | undefined
+  const framework = args.framework as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (control_sys_id) queryParts.push(`control=${control_sys_id}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (severity) queryParts.push(`severity=${severity}`)
+  if (framework) queryParts.push(`framework=${framework}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_ISSUE}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,short_description,control,severity,state,framework,assigned_to,sys_created_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_issues",
+    count: results.length,
+    issues: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      control: r.control,
+      severity: r.severity,
+      state: r.state,
+      framework: r.framework,
+      assigned_to: r.assigned_to,
+      created_at: r.sys_created_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ISSUE}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== LIST_EXCEPTIONS ====================
+
+async function executeListExceptions(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const control_sys_id = args.control_sys_id as string | undefined
+  const state = args.state as string | undefined
+  const framework = args.framework as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (control_sys_id) queryParts.push(`control=${control_sys_id}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (framework) queryParts.push(`framework=${framework}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_EXCEPTION}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,short_description,control,framework,state,expiry,requestor,sys_created_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_exceptions",
+    count: results.length,
+    exceptions: results.map((r) => ({
+      sys_id: r.sys_id,
+      short_description: r.short_description,
+      control: r.control,
+      framework: r.framework,
+      state: r.state,
+      expiry: r.expiry,
+      requestor: r.requestor,
+      created_at: r.sys_created_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_EXCEPTION}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== EXCEPTION_CREATE ====================
+
+async function executeExceptionCreate(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const control_sys_id = args.control_sys_id as string | undefined
+  const short_description = args.short_description as string | undefined
+  const justification = args.justification as string | undefined
+
+  if (!control_sys_id) {
+    return createErrorResult("control_sys_id is required for exception_create action")
+  }
+  if (!short_description) {
+    return createErrorResult("short_description is required for exception_create action")
+  }
+  if (!justification) {
+    return createErrorResult("justification is required for exception_create action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // TODO: verify sn_compliance_policy_exception column set on a live instance.
+  const payload: Record<string, unknown> = {
+    control: control_sys_id,
+    short_description,
+    justification,
+    state: "draft",
+  }
+  if (args.expiry) payload.expiry = args.expiry
+  if (args.requestor) payload.requestor = args.requestor
+
+  const response = await client.post(`/api/now/table/${TABLE_EXCEPTION}`, payload)
+  const result = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "exception_create",
+    created: true,
+    sys_id: result.sys_id,
+    control_sys_id,
+    exception: result,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_EXCEPTION}.do?sys_id=${result.sys_id}`,
+  })
+}
+
+// ==================== LINK_EVIDENCE ====================
+
+async function executeLinkEvidence(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const issue_sys_id = args.issue_sys_id as string | undefined
+  const evidence_sys_id = args.evidence_sys_id as string | undefined
+  const evidence_url = args.evidence_url as string | undefined
+  const evidence_type = (args.evidence_type as string) || "document"
+  const evidence_description = args.evidence_description as string | undefined
+
+  if (!issue_sys_id) {
+    return createErrorResult("issue_sys_id is required for link_evidence action")
+  }
+  if (!evidence_sys_id && !evidence_url) {
+    return createErrorResult("evidence_sys_id or evidence_url is required for link_evidence action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const issue = await findIssue(client, issue_sys_id)
+  if (!issue) {
+    return createErrorResult(`Compliance issue not found: ${issue_sys_id}`)
+  }
+
+  let evidenceRecord: Record<string, unknown>
+  let mode: "linked" | "created_and_linked"
+
+  if (evidence_sys_id) {
+    // TODO: verify sn_compliance_evidence column set on a live instance —
+    // some releases use `issue` and others use `parent` as the polymorphic
+    // reference back to the originating record.
+    const direct = await client.get(`/api/now/table/${TABLE_EVIDENCE}/${evidence_sys_id}`)
+    if (!direct.data.result || !direct.data.result.sys_id) {
+      return createErrorResult(`Evidence record not found: ${evidence_sys_id}`)
+    }
+    const patchResponse = await client.patch(`/api/now/table/${TABLE_EVIDENCE}/${evidence_sys_id}`, {
+      issue: issue_sys_id,
+    })
+    evidenceRecord = patchResponse.data.result as Record<string, unknown>
+    mode = "linked"
+  } else {
+    const payload: Record<string, unknown> = {
+      issue: issue_sys_id,
+      type: evidence_type,
+      url: evidence_url,
+    }
+    if (evidence_description) payload.description = evidence_description
+    const created = await client.post(`/api/now/table/${TABLE_EVIDENCE}`, payload)
+    evidenceRecord = created.data.result as Record<string, unknown>
+    mode = "created_and_linked"
+  }
+
+  return createSuccessResult({
+    action: "link_evidence",
+    link_action: mode,
+    sys_id: evidenceRecord.sys_id,
+    issue_sys_id,
+    evidence: evidenceRecord,
+  })
+}
+
+// ==================== MARK_REMEDIATED ====================
+
+async function executeMarkRemediated(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const issue_sys_id = args.issue_sys_id as string | undefined
+  const remediation_summary = args.remediation_summary as string | undefined
+
+  if (!issue_sys_id) {
+    return createErrorResult("issue_sys_id is required for mark_remediated action")
+  }
+  if (!remediation_summary) {
+    return createErrorResult("remediation_summary is required for mark_remediated action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const issue = await findIssue(client, issue_sys_id)
+  if (!issue) {
+    return createErrorResult(`Compliance issue not found: ${issue_sys_id}`)
+  }
+
+  const completedAt = (args.remediation_completed_at as string | undefined) || new Date().toISOString().split("T")[0]
+
+  // Create remediation record. TODO: verify sn_compliance_remediation column
+  // set on a live instance — common fields are issue (ref), summary,
+  // completed_at, owner, state.
+  let remediationRecord: Record<string, unknown> | null = null
+  try {
+    const payload: Record<string, unknown> = {
+      issue: issue_sys_id,
+      summary: remediation_summary,
+      completed_at: completedAt,
+      state: "completed",
+    }
+    if (args.remediation_owner) payload.owner = args.remediation_owner
+    const remediation = await client.post(`/api/now/table/${TABLE_REMEDIATION}`, payload)
+    remediationRecord = remediation.data.result as Record<string, unknown>
+  } catch (e: unknown) {
+    // If the remediation table doesn't exist on this instance, fall back to
+    // a work-note on the issue itself.
+    const err = e as Error
+    // Non-fatal: still transition the issue state below and report the warning.
+    remediationRecord = { warning: `Remediation record not created: ${err.message}` }
+  }
+
+  // Transition the issue to remediated/closed.
+  const issuePatch: Record<string, unknown> = {
+    state: "remediated",
+    work_notes: remediation_summary,
+  }
+  const issueResponse = await client.patch(`/api/now/table/${TABLE_ISSUE}/${issue_sys_id}`, issuePatch)
+  const updatedIssue = issueResponse.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "mark_remediated",
+    remediated: true,
+    sys_id: issue_sys_id,
+    issue: updatedIssue,
+    remediation: remediationRecord,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ISSUE}.do?sys_id=${issue_sys_id}`,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_policy_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_policy_manage.ts
@@ -1,0 +1,464 @@
+/**
+ * snow_grc_policy_manage - Unified GRC Policy lifecycle management
+ *
+ * Manages the policy lifecycle in the GRC: Policy and Compliance Management
+ * plugin. Wraps the sn_compliance_policy, sn_compliance_policy_statement,
+ * sn_compliance_control_objective, and sn_compliance_control tables.
+ *
+ * Companion to snow_create_security_policy (which authors a generic security
+ * policy record) and snow_compliance_manage (which handles the downstream
+ * exception/evidence/attestation flow on individual controls). This tool
+ * focuses on the policy artifact itself — drafting a policy, attaching
+ * the statements that make it up, and linking those statements to the
+ * control objectives they are meant to satisfy.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+// TODO: verify table names against a live instance. Policy & Compliance ships
+// as `sn_compliance_*` on Tokyo+. Older instances and certain GRC variants
+// expose the same tables under `sn_grc_*` (notably `sn_grc_policy` and
+// `sn_grc_control_objective`).
+const TABLE_POLICY = "sn_compliance_policy"
+const TABLE_STATEMENT = "sn_compliance_policy_statement"
+const TABLE_OBJECTIVE = "sn_compliance_control_objective"
+const TABLE_CONTROL = "sn_compliance_control"
+
+const PLUGIN_NAME = "GRC: Policy and Compliance Management (com.sn_compliance)"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_grc_policy_manage",
+  description: `Unified tool for ServiceNow GRC policy authoring and linkage. Wraps the sn_compliance_policy, sn_compliance_policy_statement, sn_compliance_control_objective, and sn_compliance_control tables that ship with the GRC: Policy and Compliance Management plugin.
+
+Actions:
+- list_policies — list policies, optionally filtered by state, type, or framework
+- get_policy — retrieve a single policy by sys_id (includes counts of linked statements)
+- create_policy — draft a new policy with owner, type, and effective date
+- create_statement — add a policy statement (clause / requirement) to an existing policy
+- link_to_control — link a policy statement to a control objective, attaching the policy intent to the control framework
+- list_controls — list controls, optionally filtered by objective or active flag
+
+Use when: the agent needs to draft a new GRC policy, break it into statements, and connect those statements to the control objectives that operationalise them. For the downstream exception / evidence / attestation flow on individual controls, use snow_compliance_manage; for the generic security policy record, use snow_create_security_policy.
+
+Returns: policy rows with sys_id, owner, type, state, effective_date; statement rows with sys_id, policy reference, statement_text; control objective and control rows with sys_id, name, and reference linkage. GRC plugin gating: the first call against these tables will surface a clear error if the GRC: Policy and Compliance Management plugin is not active on the target instance.`,
+  category: "security",
+  subcategory: "policies",
+  use_cases: ["grc", "policy", "compliance", "controls", "statements"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: [
+          "list_policies",
+          "get_policy",
+          "create_policy",
+          "create_statement",
+          "link_to_control",
+          "list_controls",
+        ],
+      },
+      // Identifiers
+      policy_sys_id: {
+        type: "string",
+        description: "[get_policy/create_statement] Policy sys_id",
+      },
+      statement_sys_id: {
+        type: "string",
+        description: "[link_to_control] Statement sys_id (sn_compliance_policy_statement)",
+      },
+      objective_sys_id: {
+        type: "string",
+        description: "[link_to_control/list_controls] Control objective sys_id (sn_compliance_control_objective)",
+      },
+      // LIST_POLICIES filters
+      state: {
+        type: "string",
+        description: "[list_policies] Filter by policy state",
+        enum: ["draft", "review", "approved", "published", "retired"],
+      },
+      policy_type: {
+        type: "string",
+        description: "[list_policies] Filter by policy type label",
+      },
+      framework: {
+        type: "string",
+        description: "[list_policies] Filter by compliance framework (SOX, GDPR, HIPAA, ISO27001, etc.)",
+      },
+      limit: {
+        type: "number",
+        description: "[list_policies/list_controls] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_policies/get_policy/list_controls] Comma-separated list of fields to return",
+      },
+      // CREATE_POLICY
+      name: {
+        type: "string",
+        description: "[create_policy] Policy name / title (required)",
+      },
+      description: {
+        type: "string",
+        description: "[create_policy] Policy description / scope",
+      },
+      owner: {
+        type: "string",
+        description: "[create_policy] Policy owner sys_user sys_id",
+      },
+      type: {
+        type: "string",
+        description: "[create_policy] Policy type label (information_security, privacy, operational, hr, financial, custom)",
+      },
+      effective_date: {
+        type: "string",
+        description: "[create_policy] ISO date string (YYYY-MM-DD) when the policy takes effect",
+      },
+      review_date: {
+        type: "string",
+        description: "[create_policy] ISO date string (YYYY-MM-DD) when the policy is next due for review",
+      },
+      // CREATE_STATEMENT
+      statement_text: {
+        type: "string",
+        description: "[create_statement] Statement / clause text",
+      },
+      statement_short_description: {
+        type: "string",
+        description: "[create_statement] Short description for the statement",
+      },
+      statement_number: {
+        type: "string",
+        description: "[create_statement] Optional clause number or identifier (e.g. 4.1.2)",
+      },
+      // LINK_TO_CONTROL (no extra fields beyond statement_sys_id + objective_sys_id)
+      // LIST_CONTROLS
+      active_only: {
+        type: "boolean",
+        description: "[list_controls] Only return active controls",
+        default: false,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_policies":
+        return await executeListPolicies(args, context)
+      case "get_policy":
+        return await executeGetPolicy(args, context)
+      case "create_policy":
+        return await executeCreatePolicy(args, context)
+      case "create_statement":
+        return await executeCreateStatement(args, context)
+      case "link_to_control":
+        return await executeLinkToControl(args, context)
+      case "list_controls":
+        return await executeListControls(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_policies, get_policy, create_policy, create_statement, link_to_control, list_controls`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `GRC policy table not found. The ${PLUGIN_NAME} plugin may not be active on this instance. Confirm that sn_compliance_policy and sn_compliance_control_objective tables exist.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `GRC policy ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findPolicy(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_POLICY}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+// ==================== LIST_POLICIES ====================
+
+async function executeListPolicies(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const state = args.state as string | undefined
+  const policy_type = args.policy_type as string | undefined
+  const framework = args.framework as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (state) queryParts.push(`state=${state}`)
+  if (policy_type) queryParts.push(`type=${policy_type}`)
+  if (framework) queryParts.push(`framework=${framework}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_POLICY}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,name,owner,type,state,framework,effective_date,review_date,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_policies",
+    count: results.length,
+    policies: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      name: r.name,
+      owner: r.owner,
+      type: r.type,
+      state: r.state,
+      framework: r.framework,
+      effective_date: r.effective_date,
+      review_date: r.review_date,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_POLICY}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET_POLICY ====================
+
+async function executeGetPolicy(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const policy_sys_id = args.policy_sys_id as string | undefined
+
+  if (!policy_sys_id) {
+    return createErrorResult("policy_sys_id is required for get_policy action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const policy = await findPolicy(client, policy_sys_id)
+  if (!policy) {
+    return createErrorResult(`Policy not found: ${policy_sys_id}`)
+  }
+
+  let statementCount = 0
+  try {
+    const statements = await client.get(`/api/now/table/${TABLE_STATEMENT}`, {
+      params: { sysparm_query: `policy=${policy_sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+    })
+    statementCount = (statements.data.result || []).length
+  } catch {
+    // TODO: verify statement -> policy reference column on a live instance.
+  }
+
+  return createSuccessResult({
+    action: "get_policy",
+    sys_id: policy_sys_id,
+    policy,
+    related: {
+      statement_count: statementCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_POLICY}.do?sys_id=${policy_sys_id}`,
+  })
+}
+
+// ==================== CREATE_POLICY ====================
+
+async function executeCreatePolicy(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+
+  if (!name) {
+    return createErrorResult("name is required for create_policy action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = {
+    name,
+    state: "draft",
+  }
+  if (args.description) payload.description = args.description
+  if (args.owner) payload.owner = args.owner
+  if (args.type) payload.type = args.type
+  if (args.effective_date) payload.effective_date = args.effective_date
+  if (args.review_date) payload.review_date = args.review_date
+
+  const response = await client.post(`/api/now/table/${TABLE_POLICY}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_policy",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    policy: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_POLICY}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== CREATE_STATEMENT ====================
+
+async function executeCreateStatement(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const policy_sys_id = args.policy_sys_id as string | undefined
+  const statement_text = args.statement_text as string | undefined
+
+  if (!policy_sys_id) {
+    return createErrorResult("policy_sys_id is required for create_statement action")
+  }
+  if (!statement_text) {
+    return createErrorResult("statement_text is required for create_statement action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const policy = await findPolicy(client, policy_sys_id)
+  if (!policy) {
+    return createErrorResult(`Policy not found: ${policy_sys_id}`)
+  }
+
+  // TODO: verify sn_compliance_policy_statement column set on a live
+  // instance. Common fields: policy (ref), statement (text), number,
+  // short_description.
+  const payload: Record<string, unknown> = {
+    policy: policy_sys_id,
+    statement: statement_text,
+  }
+  if (args.statement_short_description) payload.short_description = args.statement_short_description
+  if (args.statement_number) payload.number = args.statement_number
+
+  const response = await client.post(`/api/now/table/${TABLE_STATEMENT}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_statement",
+    created: true,
+    sys_id: created.sys_id,
+    policy: { sys_id: policy_sys_id, name: policy.name },
+    statement: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_STATEMENT}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LINK_TO_CONTROL ====================
+
+async function executeLinkToControl(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const statement_sys_id = args.statement_sys_id as string | undefined
+  const objective_sys_id = args.objective_sys_id as string | undefined
+
+  if (!statement_sys_id) {
+    return createErrorResult("statement_sys_id is required for link_to_control action")
+  }
+  if (!objective_sys_id) {
+    return createErrorResult("objective_sys_id is required for link_to_control action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  // Verify both records exist before linking.
+  const statementCheck = await client.get(`/api/now/table/${TABLE_STATEMENT}/${statement_sys_id}`)
+  if (!statementCheck.data.result || !statementCheck.data.result.sys_id) {
+    return createErrorResult(`Policy statement not found: ${statement_sys_id}`)
+  }
+  const objectiveCheck = await client.get(`/api/now/table/${TABLE_OBJECTIVE}/${objective_sys_id}`)
+  if (!objectiveCheck.data.result || !objectiveCheck.data.result.sys_id) {
+    return createErrorResult(`Control objective not found: ${objective_sys_id}`)
+  }
+
+  // TODO: verify how policy statements link to control objectives on a live
+  // instance. On Tokyo+ Policy and Compliance Management the canonical link
+  // is a reference field `content` on sn_compliance_control_objective that
+  // points at sn_compliance_policy_statement. Some implementations use a
+  // dedicated m2m table `sn_compliance_m2m_objective_statement`. We patch
+  // the objective's `content` field first; if that fails the caller should
+  // retry against the m2m table.
+  const patchResponse = await client.patch(`/api/now/table/${TABLE_OBJECTIVE}/${objective_sys_id}`, {
+    content: statement_sys_id,
+  })
+  const updated = patchResponse.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "link_to_control",
+    linked: true,
+    statement_sys_id,
+    objective_sys_id,
+    control_objective: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_OBJECTIVE}.do?sys_id=${objective_sys_id}`,
+  })
+}
+
+// ==================== LIST_CONTROLS ====================
+
+async function executeListControls(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const objective_sys_id = args.objective_sys_id as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (objective_sys_id) queryParts.push(`content=${objective_sys_id}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${TABLE_CONTROL}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : { sysparm_fields: "sys_id,number,name,content,owner,compliance,active,sys_updated_on" }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_controls",
+    count: results.length,
+    controls: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      name: r.name,
+      content: r.content,
+      owner: r.owner,
+      compliance: r.compliance,
+      active: r.active,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_CONTROL}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_risk_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_risk_manage.ts
@@ -1,0 +1,493 @@
+/**
+ * snow_grc_risk_manage - Unified GRC Advanced Risk lifecycle
+ *
+ * Manages the risk register, risk assessments, treatments, and ownership
+ * assignment in the GRC: Advanced Risk plugin. Wraps the sn_risk_advanced_risk,
+ * sn_risk_risk_treatment, and sn_risk_risk_owner tables.
+ *
+ * Companion to snow_security_risk_assessment (security-focused risk
+ * scoring), snow_vulnerability_risk_assessment (vulnerability-derived risk
+ * scoring), and snow_grc_vendor_risk_manage (third-party vendor risk).
+ * This tool focuses on the core risk register operations — registering a
+ * risk, scoring it, attaching a treatment plan, and assigning an owner.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+// TODO: verify against a live instance. GRC: Advanced Risk ships on Tokyo+
+// under `sn_risk_advanced_risk`. Older releases used `sn_risk_risk` as the
+// base risk table — and some legacy plugin variants surface a `sn_grc_risk`
+// alias view. We always target the advanced table here.
+const TABLE_RISK = "sn_risk_advanced_risk"
+const TABLE_TREATMENT = "sn_risk_risk_treatment"
+const TABLE_OWNER = "sn_risk_risk_owner"
+
+const PLUGIN_NAME = "GRC: Advanced Risk (com.sn_risk_advanced)"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_grc_risk_manage",
+  description: `Unified tool for ServiceNow GRC Advanced Risk register lifecycle: registering risks, scoring them, attaching treatment plans, and assigning ownership. Wraps the sn_risk_advanced_risk, sn_risk_risk_treatment, and sn_risk_risk_owner tables that ship with the GRC: Advanced Risk plugin.
+
+Actions:
+- list — list risks, optionally filtered by category, state, or owner
+- get — retrieve a single risk by sys_id (includes counts of treatments and owners)
+- create — register a new risk with category, inherent score, and owner
+- assess — update the risk's inherent or residual likelihood/impact scores
+- treat — attach a treatment plan (accept, mitigate, transfer, avoid) with target date
+- assign_owner — assign or transfer the risk owner (writes sn_risk_risk_owner)
+
+Use when: the agent needs to manage the risk register itself — registering newly identified risks, refreshing inherent/residual scoring after an assessment, choosing a treatment strategy, and naming an accountable owner. For security-specific scoring use snow_security_risk_assessment; for vendor third-party risk use snow_grc_vendor_risk_manage.
+
+Returns: risk rows with sys_id, number, name, category, inherent and residual scores, state; treatment rows with strategy, target date, and owner; ownership rows with sys_user reference and role. GRC plugin gating: the first call against the risk tables will surface a clear error if the GRC: Advanced Risk plugin is not active on the target instance.`,
+  category: "security",
+  subcategory: "risk-management",
+  use_cases: ["grc", "risk", "risk-register", "treatment", "ownership"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list", "get", "create", "assess", "treat", "assign_owner"],
+      },
+      // Identifiers
+      sys_id: {
+        type: "string",
+        description: "[get/assess/treat/assign_owner] Risk sys_id",
+      },
+      // LIST filters
+      category: {
+        type: "string",
+        description: "[list/create] Risk category (operational, financial, strategic, compliance, security, third_party)",
+      },
+      state: {
+        type: "string",
+        description: "[list/create/assess] Risk state",
+        enum: ["draft", "assessed", "in_treatment", "monitored", "closed"],
+      },
+      owner: {
+        type: "string",
+        description: "[list] Filter by current owner sys_user sys_id",
+      },
+      limit: {
+        type: "number",
+        description: "[list] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list/get] Comma-separated list of fields to return",
+      },
+      // CREATE
+      name: {
+        type: "string",
+        description: "[create] Risk name / title (required)",
+      },
+      description: {
+        type: "string",
+        description: "[create] Risk description / scenario detail",
+      },
+      inherent_likelihood: {
+        type: "number",
+        description: "[create/assess] Inherent likelihood score (1-5 scale, instance-configurable)",
+      },
+      inherent_impact: {
+        type: "number",
+        description: "[create/assess] Inherent impact score (1-5 scale, instance-configurable)",
+      },
+      // ASSESS (residual scoring)
+      residual_likelihood: {
+        type: "number",
+        description: "[assess] Residual likelihood score after existing controls (1-5 scale)",
+      },
+      residual_impact: {
+        type: "number",
+        description: "[assess] Residual impact score after existing controls (1-5 scale)",
+      },
+      assessment_note: {
+        type: "string",
+        description: "[assess] Optional work note describing the assessment rationale",
+      },
+      // TREAT
+      treatment_strategy: {
+        type: "string",
+        description: "[treat] Treatment strategy",
+        enum: ["accept", "mitigate", "transfer", "avoid"],
+      },
+      treatment_description: {
+        type: "string",
+        description: "[treat] Description of the treatment plan",
+      },
+      treatment_target_date: {
+        type: "string",
+        description: "[treat] ISO date string (YYYY-MM-DD) for target completion",
+      },
+      treatment_owner: {
+        type: "string",
+        description: "[treat] sys_user sys_id of the treatment owner",
+      },
+      // ASSIGN_OWNER
+      assigned_user: {
+        type: "string",
+        description: "[assign_owner] sys_user sys_id of the new owner (required)",
+      },
+      owner_role: {
+        type: "string",
+        description: "[assign_owner] Owner role label (risk_owner, control_owner, accountable, responsible)",
+        default: "risk_owner",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list":
+        return await executeList(args, context)
+      case "get":
+        return await executeGet(args, context)
+      case "create":
+        return await executeCreate(args, context)
+      case "assess":
+        return await executeAssess(args, context)
+      case "treat":
+        return await executeTreat(args, context)
+      case "assign_owner":
+        return await executeAssignOwner(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list, get, create, assess, treat, assign_owner`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `GRC risk table not found. The ${PLUGIN_NAME} plugin may not be active on this instance. Confirm that sn_risk_advanced_risk exists.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `GRC risk ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findRisk(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_RISK}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+// ==================== LIST ====================
+
+async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const category = args.category as string | undefined
+  const state = args.state as string | undefined
+  const owner = args.owner as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (category) queryParts.push(`category=${category}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (owner) queryParts.push(`owner=${owner}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_RISK}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,name,category,state,owner,inherent_score,residual_score,inherent_likelihood,inherent_impact,sys_updated_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list",
+    count: results.length,
+    risks: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      name: r.name,
+      category: r.category,
+      state: r.state,
+      owner: r.owner,
+      inherent_score: r.inherent_score,
+      residual_score: r.residual_score,
+      inherent_likelihood: r.inherent_likelihood,
+      inherent_impact: r.inherent_impact,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_RISK}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== GET ====================
+
+async function executeGet(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for get action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const risk = await findRisk(client, sys_id)
+  if (!risk) {
+    return createErrorResult(`Risk not found: ${sys_id}`)
+  }
+
+  // Count related treatments and owners (best-effort).
+  let treatmentCount = 0
+  let ownerCount = 0
+  try {
+    const treatments = await client.get(`/api/now/table/${TABLE_TREATMENT}`, {
+      params: { sysparm_query: `risk=${sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    treatmentCount = (treatments.data.result || []).length
+  } catch {
+    // TODO: verify treatment -> risk reference column on a live instance.
+  }
+  try {
+    const owners = await client.get(`/api/now/table/${TABLE_OWNER}`, {
+      params: { sysparm_query: `risk=${sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
+    })
+    ownerCount = (owners.data.result || []).length
+  } catch {
+    // TODO: verify owner -> risk reference column on a live instance.
+  }
+
+  return createSuccessResult({
+    action: "get",
+    sys_id,
+    risk,
+    related: {
+      treatment_count: treatmentCount,
+      owner_count: ownerCount,
+    },
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_RISK}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== CREATE ====================
+
+async function executeCreate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const name = args.name as string | undefined
+
+  if (!name) {
+    return createErrorResult("name is required for create action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const payload: Record<string, unknown> = {
+    name,
+    state: (args.state as string) || "draft",
+  }
+  if (args.description) payload.description = args.description
+  if (args.category) payload.category = args.category
+  if (args.inherent_likelihood !== undefined) payload.inherent_likelihood = args.inherent_likelihood
+  if (args.inherent_impact !== undefined) payload.inherent_impact = args.inherent_impact
+
+  const response = await client.post(`/api/now/table/${TABLE_RISK}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create",
+    created: true,
+    sys_id: created.sys_id,
+    name: created.name,
+    risk: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_RISK}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== ASSESS ====================
+
+async function executeAssess(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for assess action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const risk = await findRisk(client, sys_id)
+  if (!risk) {
+    return createErrorResult(`Risk not found: ${sys_id}`)
+  }
+
+  const updatableFields: Array<[string, string]> = [
+    ["inherent_likelihood", "inherent_likelihood"],
+    ["inherent_impact", "inherent_impact"],
+    ["residual_likelihood", "residual_likelihood"],
+    ["residual_impact", "residual_impact"],
+    ["state", "state"],
+  ]
+  const patch: Record<string, unknown> = {}
+  for (const [argKey, fieldName] of updatableFields) {
+    if (args[argKey] !== undefined) {
+      patch[fieldName] = args[argKey]
+    }
+  }
+  if (args.assessment_note) patch.work_notes = args.assessment_note
+
+  if (Object.keys(patch).length === 0) {
+    return createErrorResult("No assessment fields provided (likelihood, impact, or state)")
+  }
+
+  const response = await client.patch(`/api/now/table/${TABLE_RISK}/${sys_id}`, patch)
+  const updated = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "assess",
+    assessed: true,
+    sys_id,
+    updated_fields: Object.keys(patch),
+    risk: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_RISK}.do?sys_id=${sys_id}`,
+  })
+}
+
+// ==================== TREAT ====================
+
+async function executeTreat(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const treatment_strategy = args.treatment_strategy as string | undefined
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for treat action")
+  }
+  if (!treatment_strategy) {
+    return createErrorResult("treatment_strategy is required for treat action (accept, mitigate, transfer, avoid)")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const risk = await findRisk(client, sys_id)
+  if (!risk) {
+    return createErrorResult(`Risk not found: ${sys_id}`)
+  }
+
+  // TODO: verify sn_risk_risk_treatment column set on a live instance.
+  // Common fields: risk (ref), strategy/treatment_type, description,
+  // target_date, owner, state.
+  const payload: Record<string, unknown> = {
+    risk: sys_id,
+    strategy: treatment_strategy,
+    state: "planned",
+  }
+  if (args.treatment_description) payload.description = args.treatment_description
+  if (args.treatment_target_date) payload.target_date = args.treatment_target_date
+  if (args.treatment_owner) payload.owner = args.treatment_owner
+
+  const response = await client.post(`/api/now/table/${TABLE_TREATMENT}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  // Move the risk into "in_treatment" state if it isn't already in a more
+  // advanced state. Don't block on failure — the treatment row was created.
+  try {
+    if (risk.state !== "in_treatment" && risk.state !== "monitored" && risk.state !== "closed") {
+      await client.patch(`/api/now/table/${TABLE_RISK}/${sys_id}`, { state: "in_treatment" })
+    }
+  } catch {
+    // Surface non-fatally — treatment is recorded either way.
+  }
+
+  return createSuccessResult({
+    action: "treat",
+    created: true,
+    sys_id: created.sys_id,
+    risk_sys_id: sys_id,
+    treatment: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_TREATMENT}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== ASSIGN_OWNER ====================
+
+async function executeAssignOwner(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const sys_id = args.sys_id as string | undefined
+  const assigned_user = args.assigned_user as string | undefined
+  const owner_role = (args.owner_role as string) || "risk_owner"
+
+  if (!sys_id) {
+    return createErrorResult("sys_id is required for assign_owner action")
+  }
+  if (!assigned_user) {
+    return createErrorResult("assigned_user is required for assign_owner action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const risk = await findRisk(client, sys_id)
+  if (!risk) {
+    return createErrorResult(`Risk not found: ${sys_id}`)
+  }
+
+  // TODO: verify sn_risk_risk_owner column set on a live instance. Common
+  // fields: risk (ref), user (sys_user ref), role.
+  const payload: Record<string, unknown> = {
+    risk: sys_id,
+    user: assigned_user,
+    role: owner_role,
+  }
+
+  const response = await client.post(`/api/now/table/${TABLE_OWNER}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  // Also patch the primary owner field on the risk so the risk list view
+  // reflects the assignment immediately. Non-fatal on failure.
+  let primaryOwnerUpdated = false
+  try {
+    await client.patch(`/api/now/table/${TABLE_RISK}/${sys_id}`, { owner: assigned_user })
+    primaryOwnerUpdated = true
+  } catch {
+    // TODO: verify primary owner column on sn_risk_advanced_risk on a live instance.
+  }
+
+  return createSuccessResult({
+    action: "assign_owner",
+    assigned: true,
+    sys_id: created.sys_id,
+    risk_sys_id: sys_id,
+    primary_owner_updated: primaryOwnerUpdated,
+    ownership: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_RISK}.do?sys_id=${sys_id}`,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_vendor_risk_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/security/snow_grc_vendor_risk_manage.ts
@@ -1,0 +1,450 @@
+/**
+ * snow_grc_vendor_risk_manage - Unified GRC Vendor Risk Management lifecycle
+ *
+ * Manages the third-party vendor risk lifecycle in the GRC: Vendor Risk
+ * Management plugin. Wraps the sn_vdr_vendor, sn_vdr_assessment, and
+ * sn_vdr_question_template tables.
+ *
+ * Companion to snow_grc_risk_manage (which covers the internal risk
+ * register) and snow_compliance_manage (which handles control evidence).
+ * This tool focuses on vendor-side risk — listing vendors, kicking off
+ * an assessment using a question template, and linking the resulting
+ * vendor risk back to the central risk register.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from "../../shared/error-handler.js"
+
+// TODO: verify against a live instance. Vendor Risk Management uses the
+// `sn_vdr_*` namespace on Tokyo+; earlier releases used `sn_vrm_*` as the
+// prefix. We always target the newer prefix here.
+const TABLE_VENDOR = "sn_vdr_vendor"
+const TABLE_ASSESSMENT = "sn_vdr_assessment"
+const TABLE_QUESTION_TEMPLATE = "sn_vdr_question_template"
+
+// Cross-table reference used by link_to_risk
+const TABLE_RISK = "sn_risk_advanced_risk"
+
+const PLUGIN_NAME = "GRC: Vendor Risk Management (com.sn_vdr)"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_grc_vendor_risk_manage",
+  description: `Unified tool for ServiceNow GRC Vendor Risk Management: vendor inventory, assessment kick-off, and linkage back to the central risk register. Wraps the sn_vdr_vendor, sn_vdr_assessment, and sn_vdr_question_template tables that ship with the GRC: Vendor Risk Management plugin.
+
+Actions:
+- list_vendors — list vendors in the third-party inventory, optionally filtered by tier or active flag
+- assess_vendor — kick off a vendor assessment using a question template (creates an sn_vdr_assessment row in draft state)
+- list_assessments — list assessments, optionally filtered by vendor, state, or framework
+- create_assessment — create an assessment record directly with explicit fields (low-level alternative to assess_vendor)
+- link_to_risk — link a vendor assessment back to an entry in the central risk register (sn_risk_advanced_risk)
+
+Use when: the agent needs to drive third-party / vendor risk — inventorying vendors, kicking off questionnaire-based assessments, and connecting the vendor risk outcome to the central risk register. For internal risk register operations use snow_grc_risk_manage; for compliance issues and exceptions use snow_grc_issue_manage.
+
+Returns: vendor rows with sys_id, name, tier, active flag; assessment rows with state, template, scheduled date; question template rows with sys_id and name. GRC plugin gating: the first call against the vendor tables will surface a clear error if the GRC: Vendor Risk Management plugin is not active on the target instance.`,
+  category: "security",
+  subcategory: "vendor-risk",
+  use_cases: ["grc", "vendor-risk", "third-party", "assessment", "vrm"],
+  complexity: "intermediate",
+  frequency: "medium",
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Management action to perform",
+        enum: ["list_vendors", "assess_vendor", "list_assessments", "create_assessment", "link_to_risk"],
+      },
+      // Identifiers
+      vendor_sys_id: {
+        type: "string",
+        description: "[assess_vendor/list_assessments/create_assessment] Vendor sys_id (sn_vdr_vendor)",
+      },
+      assessment_sys_id: {
+        type: "string",
+        description: "[link_to_risk] Assessment sys_id (sn_vdr_assessment)",
+      },
+      template_sys_id: {
+        type: "string",
+        description: "[assess_vendor/create_assessment] Question template sys_id (sn_vdr_question_template)",
+      },
+      risk_sys_id: {
+        type: "string",
+        description: "[link_to_risk] Risk sys_id (sn_risk_advanced_risk) to link the assessment to",
+      },
+      // LIST_VENDORS filters
+      tier: {
+        type: "string",
+        description: "[list_vendors] Filter by vendor tier (tier_1, tier_2, tier_3, tier_4, critical, strategic)",
+      },
+      active_only: {
+        type: "boolean",
+        description: "[list_vendors] Only return active vendors",
+        default: false,
+      },
+      // LIST_ASSESSMENTS filters
+      state: {
+        type: "string",
+        description: "[list_assessments] Filter by assessment state",
+        enum: ["draft", "scheduled", "in_progress", "submitted", "reviewed", "completed", "cancelled"],
+      },
+      framework: {
+        type: "string",
+        description: "[list_assessments] Filter by compliance framework (SOC2, ISO27001, NIST, custom)",
+      },
+      // Pagination / projection
+      limit: {
+        type: "number",
+        description: "[list_vendors/list_assessments] Maximum records to return",
+        default: 50,
+      },
+      fields: {
+        type: "string",
+        description: "[list_vendors/list_assessments] Comma-separated list of fields to return",
+      },
+      // ASSESS_VENDOR / CREATE_ASSESSMENT
+      assessment_name: {
+        type: "string",
+        description: "[assess_vendor/create_assessment] Assessment name / short description",
+      },
+      scheduled_start_date: {
+        type: "string",
+        description: "[assess_vendor/create_assessment] ISO date string (YYYY-MM-DD) for scheduled start",
+      },
+      due_date: {
+        type: "string",
+        description: "[assess_vendor/create_assessment] ISO date string (YYYY-MM-DD) when the assessment is due",
+      },
+      assigned_to: {
+        type: "string",
+        description: "[assess_vendor/create_assessment] sys_user sys_id of the vendor-side respondent",
+      },
+      assessment_framework: {
+        type: "string",
+        description: "[create_assessment] Compliance framework label (SOC2, ISO27001, NIST, custom)",
+      },
+      // LINK_TO_RISK (no extra fields beyond assessment_sys_id + risk_sys_id)
+    },
+    required: ["action"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = args.action as string
+
+  try {
+    switch (action) {
+      case "list_vendors":
+        return await executeListVendors(args, context)
+      case "assess_vendor":
+        return await executeAssessVendor(args, context)
+      case "list_assessments":
+        return await executeListAssessments(args, context)
+      case "create_assessment":
+        return await executeCreateAssessment(args, context)
+      case "link_to_risk":
+        return await executeLinkToRisk(args, context)
+      default:
+        return createErrorResult(
+          `Unknown action: ${action}. Valid actions: list_vendors, assess_vendor, list_assessments, create_assessment, link_to_risk`,
+        )
+    }
+  } catch (error: unknown) {
+    const err = error as Error & { response?: { status?: number } }
+    if (err.response?.status === 404) {
+      return createErrorResult(
+        new SnowFlowError(
+          ErrorType.PLUGIN_MISSING,
+          `GRC vendor risk table not found. The ${PLUGIN_NAME} plugin may not be active on this instance. Confirm that sn_vdr_vendor and sn_vdr_assessment tables exist.`,
+          { originalError: err },
+        ),
+      )
+    }
+    return createErrorResult(
+      err instanceof SnowFlowError
+        ? err
+        : new SnowFlowError(ErrorType.SERVICENOW_API_ERROR, `GRC vendor risk ${action} failed: ${err.message}`, {
+            originalError: err,
+          }),
+    )
+  }
+}
+
+// ==================== HELPERS ====================
+
+async function findVendor(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_VENDOR}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+async function findAssessment(
+  client: Awaited<ReturnType<typeof getAuthenticatedClient>>,
+  sysId: string,
+): Promise<Record<string, unknown> | null> {
+  const direct = await client.get(`/api/now/table/${TABLE_ASSESSMENT}/${sysId}`)
+  if (direct.data.result && direct.data.result.sys_id) {
+    return direct.data.result
+  }
+  return null
+}
+
+// ==================== LIST_VENDORS ====================
+
+async function executeListVendors(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const tier = args.tier as string | undefined
+  const active_only = args.active_only === true
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (tier) queryParts.push(`tier=${tier}`)
+  if (active_only) queryParts.push("active=true")
+
+  const response = await client.get(`/api/now/table/${TABLE_VENDOR}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "name",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,name,tier,active,vendor_contact,inherent_risk,residual_risk,sys_updated_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_vendors",
+    count: results.length,
+    vendors: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      name: r.name,
+      tier: r.tier,
+      active: r.active,
+      vendor_contact: r.vendor_contact,
+      inherent_risk: r.inherent_risk,
+      residual_risk: r.residual_risk,
+      updated_at: r.sys_updated_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_VENDOR}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== ASSESS_VENDOR ====================
+
+async function executeAssessVendor(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const vendor_sys_id = args.vendor_sys_id as string | undefined
+  const template_sys_id = args.template_sys_id as string | undefined
+
+  if (!vendor_sys_id) {
+    return createErrorResult("vendor_sys_id is required for assess_vendor action")
+  }
+  if (!template_sys_id) {
+    return createErrorResult("template_sys_id is required for assess_vendor action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const vendor = await findVendor(client, vendor_sys_id)
+  if (!vendor) {
+    return createErrorResult(`Vendor not found: ${vendor_sys_id}`)
+  }
+
+  // Verify the question template exists.
+  // TODO: verify sn_vdr_question_template table name on a live instance.
+  const templateCheck = await client.get(`/api/now/table/${TABLE_QUESTION_TEMPLATE}/${template_sys_id}`)
+  if (!templateCheck.data.result || !templateCheck.data.result.sys_id) {
+    return createErrorResult(`Question template not found: ${template_sys_id}`)
+  }
+  const template = templateCheck.data.result as Record<string, unknown>
+
+  // TODO: verify sn_vdr_assessment column set on a live instance — common
+  // fields are vendor (ref), template (ref), state, scheduled_start_date,
+  // due_date, assigned_to.
+  const assessment_name = (args.assessment_name as string) || `Assessment of ${vendor.name} (${template.name})`
+  const payload: Record<string, unknown> = {
+    vendor: vendor_sys_id,
+    template: template_sys_id,
+    short_description: assessment_name,
+    state: "draft",
+  }
+  if (args.scheduled_start_date) payload.scheduled_start_date = args.scheduled_start_date
+  if (args.due_date) payload.due_date = args.due_date
+  if (args.assigned_to) payload.assigned_to = args.assigned_to
+
+  const response = await client.post(`/api/now/table/${TABLE_ASSESSMENT}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "assess_vendor",
+    created: true,
+    sys_id: created.sys_id,
+    vendor: { sys_id: vendor_sys_id, name: vendor.name },
+    template: { sys_id: template_sys_id, name: template.name },
+    assessment: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ASSESSMENT}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LIST_ASSESSMENTS ====================
+
+async function executeListAssessments(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const vendor_sys_id = args.vendor_sys_id as string | undefined
+  const state = args.state as string | undefined
+  const framework = args.framework as string | undefined
+  const limit = (args.limit as number) || 50
+  const fields = args.fields as string | undefined
+
+  const client = await getAuthenticatedClient(context)
+
+  const queryParts: string[] = []
+  if (vendor_sys_id) queryParts.push(`vendor=${vendor_sys_id}`)
+  if (state) queryParts.push(`state=${state}`)
+  if (framework) queryParts.push(`framework=${framework}`)
+
+  const response = await client.get(`/api/now/table/${TABLE_ASSESSMENT}`, {
+    params: {
+      sysparm_query: queryParts.join("^"),
+      sysparm_limit: limit,
+      sysparm_orderby: "sys_created_on",
+      sysparm_display_value: "true",
+      ...(fields
+        ? { sysparm_fields: fields }
+        : {
+            sysparm_fields:
+              "sys_id,number,short_description,vendor,template,state,scheduled_start_date,due_date,framework,sys_created_on",
+          }),
+    },
+  })
+
+  const results = (response.data.result || []) as Array<Record<string, unknown>>
+
+  return createSuccessResult({
+    action: "list_assessments",
+    count: results.length,
+    assessments: results.map((r) => ({
+      sys_id: r.sys_id,
+      number: r.number,
+      short_description: r.short_description,
+      vendor: r.vendor,
+      template: r.template,
+      state: r.state,
+      scheduled_start_date: r.scheduled_start_date,
+      due_date: r.due_date,
+      framework: r.framework,
+      created_at: r.sys_created_on,
+      url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ASSESSMENT}.do?sys_id=${r.sys_id}`,
+    })),
+  })
+}
+
+// ==================== CREATE_ASSESSMENT ====================
+
+async function executeCreateAssessment(
+  args: Record<string, unknown>,
+  context: ServiceNowContext,
+): Promise<ToolResult> {
+  const vendor_sys_id = args.vendor_sys_id as string | undefined
+  const template_sys_id = args.template_sys_id as string | undefined
+  const assessment_name = args.assessment_name as string | undefined
+
+  if (!vendor_sys_id) {
+    return createErrorResult("vendor_sys_id is required for create_assessment action")
+  }
+  if (!assessment_name) {
+    return createErrorResult("assessment_name is required for create_assessment action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+  const vendor = await findVendor(client, vendor_sys_id)
+  if (!vendor) {
+    return createErrorResult(`Vendor not found: ${vendor_sys_id}`)
+  }
+
+  const payload: Record<string, unknown> = {
+    vendor: vendor_sys_id,
+    short_description: assessment_name,
+    state: "draft",
+  }
+  if (template_sys_id) payload.template = template_sys_id
+  if (args.scheduled_start_date) payload.scheduled_start_date = args.scheduled_start_date
+  if (args.due_date) payload.due_date = args.due_date
+  if (args.assigned_to) payload.assigned_to = args.assigned_to
+  if (args.assessment_framework) payload.framework = args.assessment_framework
+
+  const response = await client.post(`/api/now/table/${TABLE_ASSESSMENT}`, payload)
+  const created = response.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "create_assessment",
+    created: true,
+    sys_id: created.sys_id,
+    vendor: { sys_id: vendor_sys_id, name: vendor.name },
+    assessment: created,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ASSESSMENT}.do?sys_id=${created.sys_id}`,
+  })
+}
+
+// ==================== LINK_TO_RISK ====================
+
+async function executeLinkToRisk(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const assessment_sys_id = args.assessment_sys_id as string | undefined
+  const risk_sys_id = args.risk_sys_id as string | undefined
+
+  if (!assessment_sys_id) {
+    return createErrorResult("assessment_sys_id is required for link_to_risk action")
+  }
+  if (!risk_sys_id) {
+    return createErrorResult("risk_sys_id is required for link_to_risk action")
+  }
+
+  const client = await getAuthenticatedClient(context)
+
+  const assessment = await findAssessment(client, assessment_sys_id)
+  if (!assessment) {
+    return createErrorResult(`Vendor assessment not found: ${assessment_sys_id}`)
+  }
+
+  // Verify the target risk exists.
+  // TODO: verify sn_risk_advanced_risk table name on a live instance.
+  const riskCheck = await client.get(`/api/now/table/${TABLE_RISK}/${risk_sys_id}`)
+  if (!riskCheck.data.result || !riskCheck.data.result.sys_id) {
+    return createErrorResult(`Risk not found: ${risk_sys_id}`)
+  }
+
+  // TODO: verify the reference column name on sn_vdr_assessment used to link
+  // back to the central risk register. Common implementations expose a
+  // `risk` reference field; some custom rollouts use an m2m table named
+  // `sn_vdr_m2m_assessment_risk` instead.
+  const patchResponse = await client.patch(`/api/now/table/${TABLE_ASSESSMENT}/${assessment_sys_id}`, {
+    risk: risk_sys_id,
+  })
+  const updated = patchResponse.data.result as Record<string, unknown>
+
+  return createSuccessResult({
+    action: "link_to_risk",
+    linked: true,
+    assessment_sys_id,
+    risk_sys_id,
+    assessment: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=${TABLE_ASSESSMENT}.do?sys_id=${assessment_sys_id}`,
+  })
+}
+
+export const version = "1.0.0"
+export const author = "groeimetai"


### PR DESCRIPTION
Adds five unified ServiceNow MCP tools covering the Governance, Risk & Compliance modules. All tools follow the existing `snow_pa_indicator_manage` / `snow_compliance_manage` pattern.

Fixes #119.

## Tools

| Tool                          | Path                                                                       | Primary tables                                                                                       | Actions                                                                              |
| ----------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| snow_grc_audit_manage         | tools/security/snow_grc_audit_manage.ts                                    | sn_audit_audit, sn_audit_finding, sn_audit_engagement, sn_audit_evidence                             | list, get, create_audit, update_audit, add_finding, list_findings, attach_evidence    |
| snow_grc_policy_manage        | tools/security/snow_grc_policy_manage.ts                                   | sn_compliance_policy, sn_compliance_policy_statement, sn_compliance_control_objective, sn_compliance_control | list_policies, get_policy, create_policy, create_statement, link_to_control, list_controls |
| snow_grc_risk_manage          | tools/security/snow_grc_risk_manage.ts                                     | sn_risk_advanced_risk, sn_risk_risk_treatment, sn_risk_risk_owner                                    | list, get, create, assess, treat, assign_owner                                       |
| snow_grc_issue_manage         | tools/security/snow_grc_issue_manage.ts                                    | sn_compliance_issue, sn_compliance_policy_exception, sn_compliance_remediation, sn_compliance_evidence | list_issues, list_exceptions, exception_create, link_evidence, mark_remediated       |
| snow_grc_vendor_risk_manage   | tools/security/snow_grc_vendor_risk_manage.ts                              | sn_vdr_vendor, sn_vdr_assessment, sn_vdr_question_template (+ sn_risk_advanced_risk for link_to_risk) | list_vendors, assess_vendor, list_assessments, create_assessment, link_to_risk       |

## Domain placement

All five live under `tools/security/`. The brief's nominal target folders (`audit/`, `policies/`, `risk-assessment/`, `compliance/`) don't exist as separate domains in this codebase. `security/` is the existing home for all the referenced GRC-adjacent companions (`snow_compliance_manage`, `snow_create_compliance_rule`, `snow_security_risk_assessment`, `snow_vulnerability_risk_assessment`).

## Plugin gating

Each tool catches the first 404 against its primary GRC table and returns `ErrorType.PLUGIN_MISSING` with a clear message naming the required plugin. Required plugins: GRC: Audit Management (`com.sn_audit`), GRC: Policy and Compliance (`com.sn_compliance`), GRC: Advanced Risk (`com.sn_risk_advanced`), GRC: Vendor Risk Management (`com.sn_vdr`).

## Table-name volatility

GRC table namespacing has drifted across SN releases — `sn_compliance_*` vs `sn_grc_*`, `sn_vdr_*` vs `sn_vrm_*`, and finding-reference columns named `audit` / `parent` / `audit_record` depending on release. Each uncertain table or column is flagged with a `TODO` listing the alternative so a maintainer with live-instance access can verify before merge.

## Verification

- `bun packages/opencode/script/generate-tools-json.ts`: 415 tools (up from 410), 0 failures
- Best-effort against docs.servicenow.com — needs verification against a live instance with GRC plugins installed before merge

## Risks

- Several reference columns are educated guesses based on the public docs naming patterns. Marked with `TODO: verify against a live instance` for the maintainer to validate.
- The `link_to_control` action assumes Tokyo+ `content` reference on `sn_compliance_control_objective`. Pre-Tokyo instances using an m2m table will need a fall-through path.