### PR TITLE
feat(opencode): extend snow_plugin_manage with repair + progress actions

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/plugins/snow_plugin_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/plugins/snow_plugin_manage.ts
@@ -11,18 +11,22 @@ import { createSuccessResult, createErrorResult } from "../../shared/error-handl
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_plugin_manage",
-  description: `Manage ServiceNow plugins: list, check status, activate, or deactivate.
+  description: `Manage ServiceNow plugins: list, check status, activate, deactivate, repair, or poll an async progress.
 
 Actions:
-• list — Search and list plugins. Filter by name/ID, show only active.
-• check — Get detailed info on a specific plugin (status, version, dependencies).
-• activate — Activate a plugin via CICD API (/api/sn_cicd/plugin) with sys_plugins table-PATCH fallback. Requires plugin-activation privileges in ServiceNow.
-• deactivate — Deactivate a plugin via CICD API (/api/sn_cicd/plugin) with sys_plugins table-PATCH fallback. Requires plugin-activation privileges in ServiceNow.
+- list — Search and list plugins. Filter by name/ID, show only active.
+- check — Get detailed info on a specific plugin (status, version, dependencies).
+- activate — Activate a plugin via CICD API (/api/sn_cicd/plugin) with sys_plugins table-PATCH fallback. Returns the progress_id so callers can poll completion. Pass wait=true to block until the plugin reaches a final state (or timeout_ms elapses, default 10 min).
+- deactivate — Deactivate a plugin via the same dual mechanism.
+- repair — Rollback the plugin then re-activate it (clean reinstall). Returns both progress_ids; pass wait=true to block until the activate phase completes. Requires plugin-activation privileges in ServiceNow.
+- progress — Poll a CICD progress record (/api/sn_cicd/progress/{id}) by progress_id. Use to check status of an earlier activate/repair without blocking.
 
 Examples:
-• { action: "list", search: "incident" }
-• { action: "check", plugin_id: "com.snc.incident" }
-• { action: "activate", plugin_id: "com.snc.incident" }`,
+- { action: "list", search: "incident" }
+- { action: "check", plugin_id: "com.snc.incident" }
+- { action: "activate", plugin_id: "com.snc.incident", wait: true }
+- { action: "repair", plugin_id: "com.snc.incident" }
+- { action: "progress", progress_id: "1227ba16937083101bf5f99bdd03d60c" }`,
   category: "advanced",
   subcategory: "administration",
   use_cases: ["plugin-discovery", "plugin-management", "plugin-status", "activation", "deactivation"],
@@ -36,11 +40,11 @@ Examples:
       action: {
         type: "string",
         description: "Operation to perform",
-        enum: ["list", "check", "activate", "deactivate"],
+        enum: ["list", "check", "activate", "deactivate", "repair", "progress"],
       },
       plugin_id: {
         type: "string",
-        description: '[check/activate/deactivate] Plugin identifier (e.g. "com.snc.incident") or sys_id',
+        description: '[check/activate/deactivate/repair] Plugin identifier (e.g. "com.snc.incident") or sys_id',
       },
       search: {
         type: "string",
@@ -55,6 +59,20 @@ Examples:
         type: "number",
         description: "[list] Max results to return (default 50)",
         default: 50,
+      },
+      progress_id: {
+        type: "string",
+        description: "[progress] CICD progress record sys_id, returned by a prior activate/repair call",
+      },
+      wait: {
+        type: "boolean",
+        description: "[activate/repair] Block until the install reaches a final state (Successful/Failed/Cancelled) or timeout_ms elapses. Default false — return progress_id immediately for async polling via the progress action.",
+        default: false,
+      },
+      timeout_ms: {
+        type: "number",
+        description: "[activate/repair when wait=true] Max time to wait in milliseconds. Default 600000 (10 min).",
+        default: 600000,
       },
     },
     required: ["action"],
@@ -73,8 +91,14 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
         return await executeActivate(args, context)
       case "deactivate":
         return await executeDeactivate(args, context)
+      case "repair":
+        return await executeRepair(args, context)
+      case "progress":
+        return await executeProgress(args, context)
       default:
-        return createErrorResult("Unknown action: " + action + ". Valid actions: list, check, activate, deactivate")
+        return createErrorResult(
+          "Unknown action: " + action + ". Valid actions: list, check, activate, deactivate, repair, progress",
+        )
     }
   } catch (error: any) {
     return createErrorResult(error.message)
@@ -179,15 +203,40 @@ async function executeActivate(args: any, context: ServiceNowContext): Promise<T
     )
   }
 
-  const { success, method, error } = await togglePlugin(client, plugin, "activate")
+  const { wait = false, timeout_ms = 600000 } = args
+  const { success, method, progress_id, status_label, error } = await togglePlugin(client, plugin, "activate")
   if (!success) return createErrorResult(error!)
 
+  // Sync mode: block until the CICD progress record reaches a final state.
+  if (wait && progress_id) {
+    const { result: progress, timed_out } = await waitForProgress(client, progress_id, timeout_ms)
+    const verified = await verifyPluginState(client, plugin.sys_id, true)
+    const finalStatus = progress.status_label || "?"
+    const summary = timed_out
+      ? 'Activation of "' + plugin.name + '" timed out after ' + timeout_ms + "ms (last status: " + finalStatus + ")."
+      : 'Plugin "' + plugin.name + '" (' + plugin.id + ") finished activation: " + finalStatus + "."
+    return createSuccessResult(
+      { action: "activate", plugin, activated: true, verified, method, progress_id, progress, timed_out },
+      {},
+      summary,
+    )
+  }
+
+  // Async mode (default): return immediately, caller polls via `progress`.
   const verified = await verifyPluginState(client, plugin.sys_id, true)
   const summary = verified
     ? 'Plugin "' + plugin.name + '" (' + plugin.id + ") activated successfully via " + method + "."
-    : 'Activation request sent for "' + plugin.name + '" via ' + method + ". May take a moment to fully activate."
+    : 'Activation request sent for "' +
+      plugin.name +
+      '" via ' +
+      method +
+      (progress_id ? " — progress_id " + progress_id + " (poll with action=progress)." : ".")
 
-  return createSuccessResult({ action: "activate", plugin, activated: true, verified, method }, {}, summary)
+  return createSuccessResult(
+    { action: "activate", plugin, activated: true, verified, method, progress_id, status_label },
+    {},
+    summary,
+  )
 }
 
 // ==================== DEACTIVATE ====================
@@ -235,16 +284,26 @@ async function lookupPlugin(client: any, pluginId: string): Promise<any | null> 
 async function togglePlugin(
   client: any,
   plugin: any,
-  operation: "activate" | "deactivate",
-): Promise<{ success: boolean; method: string; error?: string }> {
-  // Try CICD Plugin API first
+  operation: "activate" | "deactivate" | "rollback",
+): Promise<{ success: boolean; method: string; progress_id?: string; status_label?: string; error?: string }> {
+  // Try CICD Plugin API first. Successful CICD POSTs return a progress
+  // record sys_id we surface for async polling via the `progress` action.
   try {
-    await client.post("/api/sn_cicd/plugin/" + encodeURIComponent(plugin.id) + "/" + operation)
-    return { success: true, method: "cicd_api" }
+    const response = await client.post(
+      "/api/sn_cicd/plugin/" + encodeURIComponent(plugin.id) + "/" + operation,
+    )
+    const result = response?.data?.result || {}
+    const progress_id = result?.links?.progress?.id || undefined
+    return {
+      success: true,
+      method: "cicd_api",
+      progress_id,
+      status_label: result.status_label,
+    }
   } catch (cicdError: any) {
     const status = cicdError.response ? cicdError.response.status : 0
     if (status === 404 || status === 400) {
-      // Fallback to sys_plugins PATCH
+      // Fallback to sys_plugins PATCH (no progress tracking available here).
       try {
         const activeValue = operation === "activate" ? "true" : "false"
         await client.patch("/api/now/table/sys_plugins/" + plugin.sys_id, { active: activeValue })
@@ -267,6 +326,36 @@ async function togglePlugin(
   }
 }
 
+// Map CICD progress.status numeric/string values to a human label.
+// 0=Pending, 1=Running, 2=Successful, 3=Failed, 4=Cancelled.
+function isFinalStatus(status: any): boolean {
+  const s = String(status)
+  return s === "2" || s === "3" || s === "4"
+}
+
+async function fetchProgress(client: any, progressId: string): Promise<any> {
+  const response = await client.get("/api/sn_cicd/progress/" + encodeURIComponent(progressId))
+  return response?.data?.result || {}
+}
+
+// Block until the CICD progress record reaches a final state, or the
+// timeout elapses. Polls every 10 seconds. Returns the last fetched
+// result so callers can surface percent / message / error_message.
+async function waitForProgress(
+  client: any,
+  progressId: string,
+  timeoutMs: number,
+): Promise<{ result: any; timed_out: boolean }> {
+  const start = Date.now()
+  let result: any = {}
+  while (Date.now() - start < timeoutMs) {
+    result = await fetchProgress(client, progressId)
+    if (isFinalStatus(result.status)) return { result, timed_out: false }
+    await new Promise((resolve) => setTimeout(resolve, 10000))
+  }
+  return { result, timed_out: true }
+}
+
 async function verifyPluginState(client: any, sysId: string, expectActive: boolean): Promise<boolean> {
   try {
     const response = await client.get("/api/now/table/v_plugin", {
@@ -285,5 +374,129 @@ async function verifyPluginState(client: any, sysId: string, expectActive: boole
   }
 }
 
-export const version = "1.0.0"
+// ==================== REPAIR ====================
+// Repair = rollback then activate (clean reinstall). Useful when a plugin
+// got into a partial / corrupted state. Two CICD calls back-to-back; the
+// activate phase is the long one (often 5-15 min for big plugins).
+async function executeRepair(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  const { plugin_id, wait = false, timeout_ms = 600000 } = args
+  if (!plugin_id) return createErrorResult("plugin_id is required for repair action")
+
+  const client = await getAuthenticatedClient(context)
+  const plugin = await lookupPlugin(client, plugin_id)
+  if (!plugin) return createErrorResult("Plugin not found: " + plugin_id)
+
+  // Phase 1: rollback. Skip if already inactive — there's nothing to roll back.
+  let rollback_progress_id: string | undefined
+  let rollback_method: string | undefined
+  if (plugin.active === "true" || plugin.active === true) {
+    const rb = await togglePlugin(client, plugin, "rollback")
+    if (!rb.success) {
+      return createErrorResult("Repair phase 1 (rollback) failed: " + (rb.error || "unknown"))
+    }
+    rollback_progress_id = rb.progress_id
+    rollback_method = rb.method
+    if (wait && rb.progress_id) {
+      const { timed_out } = await waitForProgress(client, rb.progress_id, timeout_ms)
+      if (timed_out) {
+        return createErrorResult(
+          "Repair phase 1 (rollback) timed out after " + timeout_ms + "ms (progress_id: " + rb.progress_id + ")",
+        )
+      }
+    }
+  }
+
+  // Phase 2: activate. The interesting one — this is where the install runs.
+  const act = await togglePlugin(client, plugin, "activate")
+  if (!act.success) {
+    return createErrorResult(
+      "Repair phase 2 (activate) failed: " +
+        (act.error || "unknown") +
+        ". Phase 1 (rollback) did succeed — plugin is now inactive.",
+    )
+  }
+
+  if (wait && act.progress_id) {
+    const { result: progress, timed_out } = await waitForProgress(client, act.progress_id, timeout_ms)
+    const verified = await verifyPluginState(client, plugin.sys_id, true)
+    const finalStatus = progress.status_label || "?"
+    const summary = timed_out
+      ? 'Repair of "' + plugin.name + '" timed out in activate phase after ' + timeout_ms + "ms (last: " + finalStatus + ")."
+      : 'Plugin "' + plugin.name + '" (' + plugin.id + ") repaired (rollback + reactivate): " + finalStatus + "."
+    return createSuccessResult(
+      {
+        action: "repair",
+        plugin,
+        rollback_progress_id,
+        rollback_method,
+        activate_progress_id: act.progress_id,
+        activate_method: act.method,
+        progress,
+        verified,
+        timed_out,
+      },
+      {},
+      summary,
+    )
+  }
+
+  return createSuccessResult(
+    {
+      action: "repair",
+      plugin,
+      rollback_progress_id,
+      rollback_method,
+      activate_progress_id: act.progress_id,
+      activate_method: act.method,
+      status_label: act.status_label,
+    },
+    {},
+    'Repair started for "' +
+      plugin.name +
+      '" (' +
+      plugin.id +
+      ")" +
+      (act.progress_id ? " — activate progress_id " + act.progress_id + " (poll with action=progress)." : "."),
+  )
+}
+
+// ==================== PROGRESS ====================
+async function executeProgress(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  const { progress_id } = args
+  if (!progress_id) return createErrorResult("progress_id is required for progress action")
+
+  const client = await getAuthenticatedClient(context)
+  const result = await fetchProgress(client, progress_id)
+  if (!result || Object.keys(result).length === 0) {
+    return createErrorResult("Progress record not found: " + progress_id)
+  }
+
+  const status_label = result.status_label || "?"
+  const percent = result.percent_complete != null ? Number(result.percent_complete) : null
+  const summary =
+    "Progress " +
+    progress_id +
+    ": " +
+    status_label +
+    (percent != null ? " (" + percent + "%)" : "") +
+    (isFinalStatus(result.status) ? " — final" : " — still running")
+
+  return createSuccessResult(
+    {
+      action: "progress",
+      progress_id,
+      status: result.status,
+      status_label,
+      percent_complete: percent,
+      message: result.status_message || result.message,
+      error_message: result.error_message,
+      final: isFinalStatus(result.status),
+      raw: result,
+    },
+    {},
+    summary,
+  )
+}
+
+export const version = "1.1.0"
 export const author = "Snow-Flow"


### PR DESCRIPTION
## Summary

Extends existing `snow_plugin_manage` from 4 actions to **6**: adds `repair` and `progress`. Born from the experience of batch-activating plugins to validate the recent unified tools (#116-#118, #123-#126) against a live instance.

## New actions

| Action | What it does |
|---|---|
| `repair` | Rollback the plugin then re-activate it (clean reinstall). Useful for partially-installed/corrupted plugins. Returns both progress_ids. |
| `progress` | Poll `/api/sn_cicd/progress/{id}` by `progress_id`. Surfaces status_label, percent_complete, message, and a `final` flag. |

## Enhanced existing actions

- `activate` now returns the CICD `progress_id` from the response so callers can poll completion without scraping.
- Optional `wait: true` blocks until the install reaches a final state (Successful/Failed/Cancelled) or `timeout_ms` elapses (default 10 min).

## Helper functions added

- `fetchProgress(progressId)` — GET the progress record
- `waitForProgress(progressId, timeoutMs)` — poll every 10s until final
- `isFinalStatus(status)` — interprets CICD status codes (2=Success, 3=Failed, 4=Cancelled)

Version bumped 1.0.0 → 1.1.0 (minor — backward-compat additions, existing call sites unchanged).

## Test plan
- [x] generate-tools-json: 0 failures, 6 actions verified in manifest
- [x] Manual end-to-end: triggered FSM + On-Call activate, polled progress to completion
- [ ] Live test of repair action (recommended on a non-prod instance)

Fixes #129.