### PR TITLE
feat(opencode): empirical SN role manifest for MCP tools

### DIFF
--- a/packages/opencode/script/probe-sn-roles/README.md
+++ b/packages/opencode/script/probe-sn-roles/README.md
@@ -1,0 +1,119 @@
+# sn-role-probe
+
+Resolves the minimum ServiceNow role required to invoke each MCP tool by
+reading the live instance's ACL definitions directly. Output:
+`packages/opencode/sn-roles.manifest.json`, consumed by `generate-tools-json.ts`
+to produce the canonical `tools.json` that `docs.serac.build` renders.
+
+## Why ACL-based, not empirical?
+
+The harness queries `sys_security_acl` + `sys_security_acl_role` for each
+`(table, operation)` primitive that the tools use. This is SN's own source of
+truth — the same data SN's auth engine consults at request time. It's faster
+than probing as a low-role user (one GET per primitive vs. N probe attempts),
+deterministic, and doesn't require provisioning a test user or creating any
+artifacts on the instance.
+
+What it doesn't capture: ACL condition scripts and advanced ACL scripts. The
+manifest flags those (`scriptAcls > 0`) so consumers can show "additional
+runtime checks may apply" next to the role list.
+
+## Requirements
+
+- A SN instance with an OAuth REST API entity that has `client_credentials`
+  grant enabled, bound to a user with `admin` role.
+- A local env file at `~/.config/serac/sn-probe.env`:
+
+  ```sh
+  SN_INSTANCE_URL='https://dev123456.service-now.com'
+  SN_OAUTH_CLIENT_ID='...'
+  SN_OAUTH_CLIENT_SECRET='...'
+  ```
+
+  Lock it down: `chmod 600 ~/.config/serac/sn-probe.env`.
+
+## Run
+
+```sh
+bun packages/opencode/script/probe-sn-roles/index.ts
+```
+
+Output:
+- Live progress to stdout (per-batch resolution count).
+- Manifest written to `packages/opencode/sn-roles.manifest.json`.
+- No state files needed — full run takes 1–3 minutes.
+
+## Resolution algorithm
+
+For each `(table, operation)`:
+
+1. **Direct**: ACLs where `name == <table>` and matching `operation`, active.
+2. **Inherited**: walk `sys_db_object.super_class` up the table hierarchy.
+3. **Wildcard**: ACLs where `name == "*"` and matching operation.
+4. **None**: fall back to `["admin"]` (SN's implicit deny rule for tables with
+   no ACL coverage at any level).
+
+Multiple ACLs matching the same `(table, operation)` are OR-combined: any role
+in any matching ACL grants access, subject to that ACL's condition/script.
+
+## Output shape
+
+```json
+{
+  "version": 1,
+  "validatedOn": "glide-australia-02-11-2026__patch1-...",
+  "testedAt": "2026-05-14T...",
+  "stats": {
+    "tools": 428,
+    "untestable": 128,
+    "primitivesTotal": 462,
+    "primitivesResolved": 462,
+    "sourceDistribution": { "direct": 380, "inherited": 60, "wildcard": 22 },
+    "topRoles": [ { "role": "admin", "tools": 462 }, ... ]
+  },
+  "tools": {
+    "snow_change_manage": {
+      "snRoles": {
+        "anyOf": ["admin"],
+        "minimumBundle": ["itil", "snc_internal"]
+      },
+      "primitives": [
+        { "table": "change_request", "operation": "create", "roles": ["itil", "sn_change_write"], "source": "direct", "scriptAcls": 0 },
+        { "table": "sysapproval_approver", "operation": "create", "roles": ["snc_internal"], "source": "direct", "scriptAcls": 1 }
+      ]
+    },
+    "snow_check_health": {
+      "snRoles": {
+        "anyOf": ["admin", "public", "snc_internal"],
+        "minimumBundle": []
+      },
+      "primitives": [...]
+    },
+    "snow_date_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    }
+  }
+}
+```
+
+Two rollup fields per tool:
+
+- **`anyOf`** — single roles that ALONE suffice for the entire tool (intersection
+  of primitive role sets, plus `admin` since admin bypasses ACLs). When this is
+  just `["admin"]`, no non-admin role works on its own.
+- **`minimumBundle`** — smallest set of roles the user needs **together** to
+  unlock every primitive. Computed via greedy set-cover.
+  - `[]` (empty) = entire tool is publicly accessible (no auth required)
+  - `["foo"]` = single role suffices
+  - `["foo", "bar"]` = user needs BOTH roles
+  - `["admin"]` = some primitive is admin-only, no non-admin bundle works
+
+`admin` is always an implicit alternative regardless of `minimumBundle` value —
+it bypasses ACLs entirely in SN's auth engine.
+
+## Re-running across SN releases
+
+When SN ships a new release (Yokohama → Australia → next), re-run and diff
+the manifest. Role renames or new plugin-specific roles show up as deltas.

--- a/packages/opencode/script/probe-sn-roles/acl-resolve.ts
+++ b/packages/opencode/script/probe-sn-roles/acl-resolve.ts
@@ -1,0 +1,147 @@
+/**
+ * Resolve the minimum SN roles per (table, operation) by reading SN's actual
+ * ACL definitions directly. This is more accurate than empirical probing
+ * because we read SN's source of truth — the `sys_security_acl` table and its
+ * `sys_security_acl_role` join — exactly the rules SN's auth engine evaluates.
+ *
+ * Resolution order per (table, op):
+ *   1. Direct: ACLs where `name == <table>` and `operation == <op>`, active=true
+ *   2. Inherited: walk up `sys_db_object.super_class` and re-resolve
+ *   3. Wildcard: ACLs where `name == "*"` and matching op
+ *   4. None: fall back to `["admin"]` (SN's implicit deny rule)
+ *
+ * Multiple ACLs are OR-combined: any role in any matching ACL grants access
+ * (modulo conditions and scripts, which we don't evaluate — see `scriptAcls`).
+ */
+
+import { adminHeaders, snFetch, type Env } from "./sn.ts"
+
+export interface Resolved {
+  table: string
+  operation: string
+  roles: string[]                    // sorted, deduped, excludes empty strings
+  source: "direct" | "inherited" | "wildcard" | "none"
+  inheritedFrom?: string             // when source === "inherited", the parent table that supplied the roles
+  scriptAcls: number                 // count of script-bearing ACLs (extra gating beyond role check)
+  totalAcls: number
+}
+
+const parentCache = new Map<string, string | null>()
+const resolveCache = new Map<string, Resolved>()
+
+async function getHeader(env: Env): Promise<string> {
+  const h = await adminHeaders(env)
+  return (h as Record<string, string>).Authorization
+}
+
+async function parentOf(env: Env, table: string): Promise<string | null> {
+  if (parentCache.has(table)) return parentCache.get(table)!
+  const hdr = await getHeader(env)
+  const r = await snFetch<{ result: { super_class: { value: string } | string | null }[] }>(
+    env,
+    "GET",
+    `/api/now/table/sys_db_object?sysparm_query=name=${encodeURIComponent(table)}&sysparm_fields=super_class&sysparm_display_value=all&sysparm_limit=1`,
+    hdr,
+  )
+  const sup = r.data?.result?.[0]?.super_class
+  const id = typeof sup === "object" && sup ? sup.value : (typeof sup === "string" ? sup : null)
+  if (!id) {
+    parentCache.set(table, null)
+    return null
+  }
+  // super_class is itself a sys_id pointing back to sys_db_object — resolve to the table name
+  const r2 = await snFetch<{ result: { name: string }[] }>(
+    env,
+    "GET",
+    `/api/now/table/sys_db_object?sysparm_query=sys_id=${id}&sysparm_fields=name&sysparm_limit=1`,
+    hdr,
+  )
+  const parent = r2.data?.result?.[0]?.name ?? null
+  parentCache.set(table, parent)
+  return parent
+}
+
+async function aclsFor(env: Env, table: string, op: string): Promise<{ roles: string[]; total: number; scripts: number }> {
+  const hdr = await getHeader(env)
+  const tableEnc = encodeURIComponent(table)
+  // Two queries — kept simple, parallelised:
+  const [aclResp, roleResp] = await Promise.all([
+    snFetch<{ result: { sys_id: string; script: string }[] }>(
+      env,
+      "GET",
+      `/api/now/table/sys_security_acl?sysparm_query=name=${tableEnc}^operation=${op}^active=true&sysparm_fields=sys_id,script&sysparm_limit=100`,
+      hdr,
+    ),
+    snFetch<{ result: { sys_user_role: { display_value: string } | null }[] }>(
+      env,
+      "GET",
+      `/api/now/table/sys_security_acl_role?sysparm_query=sys_security_acl.name=${tableEnc}^sys_security_acl.operation=${op}^sys_security_acl.active=true&sysparm_fields=sys_user_role&sysparm_display_value=all&sysparm_limit=200`,
+      hdr,
+    ),
+  ])
+  const acls = aclResp.data?.result ?? []
+  const roles = [
+    ...new Set(
+      (roleResp.data?.result ?? [])
+        .map((r) => r.sys_user_role?.display_value ?? "")
+        .filter(Boolean),
+    ),
+  ]
+  return {
+    roles,
+    total: acls.length,
+    scripts: acls.filter((a) => a.script && a.script.trim()).length,
+  }
+}
+
+export async function resolve(env: Env, table: string, op: string): Promise<Resolved> {
+  const key = `${table}:${op}`
+  if (resolveCache.has(key)) return resolveCache.get(key)!
+
+  const direct = await aclsFor(env, table, op)
+  if (direct.total > 0) {
+    const out: Resolved = {
+      table,
+      operation: op,
+      roles: direct.roles.sort(),
+      source: "direct",
+      scriptAcls: direct.scripts,
+      totalAcls: direct.total,
+    }
+    resolveCache.set(key, out)
+    return out
+  }
+
+  const parent = await parentOf(env, table)
+  if (parent && parent !== table) {
+    const inherited = await resolve(env, parent, op)
+    if (inherited.source !== "none") {
+      const out: Resolved = {
+        ...inherited,
+        table,
+        source: "inherited",
+        inheritedFrom: parent,
+      }
+      resolveCache.set(key, out)
+      return out
+    }
+  }
+
+  const wild = await aclsFor(env, "*", op)
+  if (wild.total > 0) {
+    const out: Resolved = {
+      table,
+      operation: op,
+      roles: wild.roles.sort(),
+      source: "wildcard",
+      scriptAcls: wild.scripts,
+      totalAcls: wild.total,
+    }
+    resolveCache.set(key, out)
+    return out
+  }
+
+  const fallback: Resolved = { table, operation: op, roles: ["admin"], source: "none", scriptAcls: 0, totalAcls: 0 }
+  resolveCache.set(key, fallback)
+  return fallback
+}

--- a/packages/opencode/script/probe-sn-roles/extract.ts
+++ b/packages/opencode/script/probe-sn-roles/extract.ts
@@ -1,0 +1,139 @@
+/**
+ * Static analysis: extract (table, operation) primitives from every MCP tool
+ * file in `src/servicenow/servicenow-mcp-unified/tools/`.
+ *
+ * Output shape per tool:
+ *   { name, file, subcategory, calls: [{ method, table, endpoint }] }
+ *
+ * Tools that issue no `/api/now/table/<table>` calls are marked `untestable`
+ * with a reason — they likely use non-table endpoints (catalog API, attachment,
+ * scripted REST) or are pure client-side utilities.
+ */
+
+import { readdir, stat } from "fs/promises"
+import { join, dirname, basename } from "path"
+import { fileURLToPath } from "url"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const TOOLS_DIR = join(HERE, "..", "..", "src", "servicenow", "servicenow-mcp-unified", "tools")
+
+export interface Call {
+  method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE"
+  table: string | null
+  endpoint: string
+}
+
+export interface Tool {
+  name: string
+  file: string
+  subcategory: string
+  permission?: string
+  calls: Call[]
+}
+
+export interface Primitive {
+  table: string
+  operation: "read" | "create" | "write" | "delete"
+  usedBy: string[]
+}
+
+export interface Extraction {
+  tools: Record<string, Tool>
+  primitives: Record<string, Primitive>
+  untestable: { name: string; file: string; subcategory: string; reason: string }[]
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = []
+  for (const e of await readdir(dir)) {
+    const p = join(dir, e)
+    const s = await stat(p)
+    if (s.isDirectory()) {
+      if (e === "__tests__" || e === "shared") continue
+      out.push(...(await walk(p)))
+      continue
+    }
+    if (s.isFile() && p.endsWith(".ts") && e !== "index.ts") out.push(p)
+  }
+  return out
+}
+
+const METHOD_TO_OP: Record<Call["method"], Primitive["operation"]> = {
+  GET: "read",
+  POST: "create",
+  PATCH: "write",
+  PUT: "write",
+  DELETE: "delete",
+}
+
+export async function extract(): Promise<Extraction> {
+  const files = await walk(TOOLS_DIR)
+  const tools: Record<string, Tool> = {}
+  const primitives: Record<string, Primitive> = {}
+  const untestable: Extraction["untestable"] = []
+
+  for (const file of files) {
+    const src = await Bun.file(file).text()
+
+    const nameMatch = src.match(/name:\s*"(snow_[a-z_0-9]+)"/)
+    if (!nameMatch) continue
+    const name = nameMatch[1]
+
+    const subMatch = src.match(/subcategory:\s*"([^"]+)"/)
+    const subcategory = subMatch?.[1] ?? basename(dirname(file))
+
+    const permMatch = src.match(/permission:\s*"([^"]+)"/)
+    const permission = permMatch?.[1]
+
+    const callRe = /client\.(get|post|patch|delete|put)\(\s*[`"']([^`"'${?]+)/gi
+    const calls: Call[] = []
+    for (const m of src.matchAll(callRe)) {
+      const method = m[1].toUpperCase() as Call["method"]
+      const endpoint = m[2].trim()
+      const tableMatch = endpoint.match(/\/api\/now\/table\/([a-z_0-9]+)/)
+      const table = tableMatch?.[1] ?? null
+      calls.push({ method, table, endpoint })
+    }
+
+    const tool: Tool = {
+      name,
+      file: file.replace(TOOLS_DIR, "tools"),
+      subcategory,
+      permission,
+      calls,
+    }
+    tools[name] = tool
+
+    const tableCalls = calls.filter((c) => c.table)
+    if (tableCalls.length === 0) {
+      untestable.push({
+        name,
+        file: tool.file,
+        subcategory,
+        reason: "no /api/now/table/<table> calls in static analysis",
+      })
+      continue
+    }
+
+    for (const c of tableCalls) {
+      const op = METHOD_TO_OP[c.method]
+      const key = `${c.table}:${op}`
+      const existing = primitives[key]
+      if (existing) {
+        if (!existing.usedBy.includes(name)) existing.usedBy.push(name)
+        continue
+      }
+      primitives[key] = { table: c.table!, operation: op, usedBy: [name] }
+    }
+  }
+
+  return { tools, primitives, untestable }
+}
+
+if (import.meta.main) {
+  const result = await extract()
+  console.log(`tools:        ${Object.keys(result.tools).length}`)
+  console.log(`primitives:   ${Object.keys(result.primitives).length}`)
+  console.log(`untestable:   ${result.untestable.length}`)
+  console.log(`unique tables: ${new Set(Object.values(result.primitives).map((p) => p.table)).size}`)
+}

--- a/packages/opencode/script/probe-sn-roles/index.ts
+++ b/packages/opencode/script/probe-sn-roles/index.ts
@@ -1,0 +1,242 @@
+#!/usr/bin/env bun
+/**
+ * sn-role-probe orchestrator.
+ *
+ * For every MCP tool, resolves the minimum SN role(s) required to invoke it by
+ * reading the live instance's ACL definitions (`sys_security_acl` +
+ * `sys_security_acl_role`). Emits `packages/opencode/sn-roles.manifest.json`
+ * which the `generate-tools-json.ts` workflow merges into `tools.json`.
+ *
+ * Run from repo root:
+ *   bun packages/opencode/script/probe-sn-roles/index.ts
+ *
+ * See ./README.md for env setup.
+ */
+
+import { join, dirname } from "path"
+import { fileURLToPath } from "url"
+import { extract, type Extraction } from "./extract.ts"
+import { resolve, type Resolved } from "./acl-resolve.ts"
+import { loadEnv, adminToken, detectRelease, type Env } from "./sn.ts"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const MANIFEST_PATH = join(HERE, "..", "..", "sn-roles.manifest.json")
+const BATCH = 8 // parallel ACL queries per batch
+
+interface ManifestTool {
+  snRoles: {
+    /** Single roles that alone suffice for the entire tool. Always includes `admin`. */
+    anyOf: string[]
+    /** Smallest role-bundle that together grants access to every primitive. User
+     *  needs ALL roles in this array. Computed via greedy set-cover.
+     *  `admin` is implicitly always a working alternative, regardless of bundle. */
+    minimumBundle: string[]
+  } | null
+  untestable?: boolean
+  reason?: string
+  primitives?: {
+    table: string
+    operation: string
+    roles: string[]
+    source: Resolved["source"]
+    inheritedFrom?: string
+    scriptAcls: number
+  }[]
+}
+
+interface Manifest {
+  version: number
+  validatedOn: string
+  testedAt: string
+  stats: {
+    tools: number
+    untestable: number
+    primitivesTotal: number
+    primitivesResolved: number
+    sourceDistribution: Record<string, number>
+    topRoles: { role: string; tools: number }[]
+  }
+  tools: Record<string, ManifestTool>
+}
+
+function chunks<T>(arr: T[], n: number): T[][] {
+  return Array.from({ length: Math.ceil(arr.length / n) }, (_, i) => arr.slice(i * n, i * n + n))
+}
+
+/**
+ * Greedy set-cover: smallest list of roles such that for every input role-set,
+ * the chosen list contains at least one of its roles. Deterministic via
+ * alphabetical tie-breaking.
+ */
+function greedyCover(roleSets: string[][]): string[] {
+  const remaining = new Set(roleSets.map((_, i) => i).filter((i) => roleSets[i].length > 0))
+  const picked: string[] = []
+  while (remaining.size > 0) {
+    const count = new Map<string, number>()
+    for (const i of remaining) {
+      for (const r of roleSets[i]) count.set(r, (count.get(r) ?? 0) + 1)
+    }
+    if (count.size === 0) break
+    const best = [...count.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0]
+    picked.push(best)
+    for (const i of [...remaining]) {
+      if (roleSets[i].includes(best)) remaining.delete(i)
+    }
+  }
+  return picked.sort()
+}
+
+/**
+ * Compute the lowest-privilege role bundle that grants access to all primitives.
+ *
+ * Two ACL-side roles get special treatment:
+ *  - `public` is SN's "no auth required" marker, not a role users hold. A primitive
+ *    with `public` in its role list is satisfied by any caller (including
+ *    unauthenticated), so we drop those primitives from the cover problem.
+ *  - `admin` bypasses every ACL implicitly. Listing it explicitly in a bundle is
+ *    redundant unless a primitive's ACL has admin-only — in that case we can't
+ *    avoid admin and return `["admin"]` alone.
+ *
+ * Returns `[]` when the entire tool is publicly accessible.
+ */
+function minimumBundle(roleSets: string[][]): string[] {
+  if (roleSets.length === 0) return ["admin"]
+  const needsAuth = roleSets.filter((rs) => !rs.includes("public"))
+  if (needsAuth.length === 0) return []
+  const nonAdmin = needsAuth.map((rs) => rs.filter((r) => r !== "admin"))
+  if (nonAdmin.some((rs) => rs.length === 0)) return ["admin"]
+  const cover = greedyCover(nonAdmin)
+  return cover.length > 0 ? cover : ["admin"]
+}
+
+async function resolveAll(env: Env, primitives: { table: string; operation: string }[]): Promise<Map<string, Resolved>> {
+  const out = new Map<string, Resolved>()
+  const total = primitives.length
+  const progress = { done: 0 }
+  for (const batch of chunks(primitives, BATCH)) {
+    const results = await Promise.all(batch.map((p) => resolve(env, p.table, p.operation)))
+    batch.forEach((p, i) => {
+      out.set(`${p.table}:${p.operation}`, results[i])
+      progress.done += 1
+    })
+    if (progress.done % 40 === 0 || progress.done === total) {
+      console.log(`  resolved ${progress.done} / ${total}`)
+    }
+  }
+  return out
+}
+
+function topRoles(resolved: Map<string, Resolved>, n: number): { role: string; tools: number }[] {
+  const counts = new Map<string, number>()
+  for (const r of resolved.values()) {
+    for (const role of r.roles) counts.set(role, (counts.get(role) ?? 0) + 1)
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, n).map(([role, tools]) => ({ role, tools }))
+}
+
+function buildManifest(extraction: Extraction, resolved: Map<string, Resolved>, release: string): Manifest {
+  const tools: Record<string, ManifestTool> = {}
+  const sourceDist: Record<string, number> = {}
+
+  for (const [name, tool] of Object.entries(extraction.tools)) {
+    const tableCalls = tool.calls.filter((c) => c.table)
+    if (tableCalls.length === 0) {
+      tools[name] = {
+        snRoles: null,
+        untestable: true,
+        reason: "no /api/now/table/<table> calls detected in static analysis",
+      }
+      continue
+    }
+    const perPrim = tableCalls.map((c) => {
+      const r = resolved.get(`${c.table}:${methodOp(c.method)}`)
+      if (!r) return null
+      sourceDist[r.source] = (sourceDist[r.source] ?? 0) + 1
+      return {
+        table: c.table!,
+        operation: methodOp(c.method),
+        roles: r.roles,
+        source: r.source,
+        inheritedFrom: r.inheritedFrom,
+        scriptAcls: r.scriptAcls,
+      }
+    }).filter((p): p is NonNullable<typeof p> => p !== null)
+
+    // `anyOf` — single roles that alone suffice for the WHOLE tool. This is the
+    // intersection across all primitive role sets, plus `admin` (which bypasses
+    // ACLs and therefore always works regardless of per-ACL role lists).
+    const sets = perPrim.map((p) => new Set(p.roles))
+    const intersection = sets.length === 0
+      ? []
+      : [...sets[0]].filter((r) => sets.every((s) => s.has(r)))
+    const anyOf = [...new Set([...intersection, "admin"])].sort()
+
+    // `minimumBundle` — smallest set of roles that together cover every primitive.
+    // Useful for tools where no single non-admin role suffices, e.g. multi-table
+    // tools that need ITIL + a write role on a separate table. Admin bypasses
+    // ACLs so it's always an implicit alternative regardless of bundle.
+    tools[name] = {
+      snRoles: { anyOf, minimumBundle: minimumBundle(perPrim.map((p) => p.roles)) },
+      primitives: perPrim,
+    }
+  }
+
+  const stats = {
+    tools: Object.keys(extraction.tools).length,
+    untestable: extraction.untestable.length,
+    primitivesTotal: Object.keys(extraction.primitives).length,
+    primitivesResolved: resolved.size,
+    sourceDistribution: sourceDist,
+    topRoles: topRoles(resolved, 15),
+  }
+
+  return {
+    version: 1,
+    validatedOn: release,
+    testedAt: new Date().toISOString(),
+    stats,
+    tools,
+  }
+}
+
+function methodOp(method: string): string {
+  if (method === "GET") return "read"
+  if (method === "POST") return "create"
+  if (method === "PATCH" || method === "PUT") return "write"
+  if (method === "DELETE") return "delete"
+  return "unknown"
+}
+
+async function main() {
+  console.log("=== sn-role-probe (ACL-based) ===")
+  const env = await loadEnv()
+  console.log(`instance: ${env.url}`)
+
+  await adminToken(env)
+  console.log("admin auth: ok")
+
+  const release = await detectRelease(env)
+  console.log(`release:   ${release}`)
+
+  console.log("extracting primitives from tool sources…")
+  const extraction = await extract()
+  const primitives = Object.values(extraction.primitives)
+  console.log(`  tools:      ${Object.keys(extraction.tools).length}`)
+  console.log(`  primitives: ${primitives.length}`)
+  console.log(`  untestable: ${extraction.untestable.length}`)
+  console.log("")
+
+  console.log("resolving ACLs…")
+  const resolved = await resolveAll(env, primitives)
+  console.log(`  ${resolved.size} primitives resolved`)
+  console.log("")
+
+  const manifest = buildManifest(extraction, resolved, release)
+  await Bun.write(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n")
+  console.log(`manifest:  ${MANIFEST_PATH}`)
+  console.log("")
+  console.log("stats:")
+  console.log(JSON.stringify(manifest.stats, null, 2))
+}
+
+await main()

--- a/packages/opencode/script/probe-sn-roles/sn.ts
+++ b/packages/opencode/script/probe-sn-roles/sn.ts
@@ -1,0 +1,105 @@
+/**
+ * Minimal SN HTTP client for the probe harness.
+ *
+ * Only uses admin OAuth `client_credentials` grant — no test-user provisioning,
+ * because the harness reads ACL definitions directly rather than empirically
+ * probing as a low-role user. See `acl-resolve.ts` for the resolution strategy.
+ */
+
+import { homedir } from "os"
+import { join } from "path"
+
+export interface Env {
+  url: string
+  clientId: string
+  clientSecret: string
+}
+
+export interface Outcome<T = unknown> {
+  ok: boolean
+  status: number
+  data?: T
+  errorBody?: string
+}
+
+const auth = { token: "", expiry: 0 }
+
+export async function loadEnv(): Promise<Env> {
+  const path = join(homedir(), ".config", "serac", "sn-probe.env")
+  const text = await Bun.file(path).text()
+  const parsed: Record<string, string> = {}
+  for (const line of text.split("\n")) {
+    if (!line || line.trim().startsWith("#")) continue
+    const m = line.match(/^([A-Z_]+)\s*=\s*['"]?([^'"]*?)['"]?\s*$/)
+    if (m) parsed[m[1]] = m[2]
+  }
+  if (!parsed.SN_INSTANCE_URL || !parsed.SN_OAUTH_CLIENT_ID || !parsed.SN_OAUTH_CLIENT_SECRET) {
+    throw new Error(`Missing required vars in ${path}`)
+  }
+  return {
+    url: parsed.SN_INSTANCE_URL.replace(/\/$/, ""),
+    clientId: parsed.SN_OAUTH_CLIENT_ID,
+    clientSecret: parsed.SN_OAUTH_CLIENT_SECRET,
+  }
+}
+
+export async function adminToken(env: Env): Promise<string> {
+  if (auth.token && Date.now() < auth.expiry) return auth.token
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: env.clientId,
+    client_secret: env.clientSecret,
+  })
+  const r = await fetch(`${env.url}/oauth_token.do`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  })
+  if (!r.ok) throw new Error(`OAuth failed: HTTP ${r.status} — ${await r.text()}`)
+  const data = (await r.json()) as { access_token: string; expires_in: number }
+  auth.token = data.access_token
+  auth.expiry = Date.now() + data.expires_in * 1000 - 60_000
+  return auth.token
+}
+
+export async function adminHeaders(env: Env): Promise<HeadersInit> {
+  const t = await adminToken(env)
+  return { Authorization: `Bearer ${t}`, "Content-Type": "application/json", Accept: "application/json" }
+}
+
+export async function snFetch<T = unknown>(
+  env: Env,
+  method: string,
+  path: string,
+  authHeader: string,
+  body?: unknown,
+): Promise<Outcome<T>> {
+  const init: RequestInit = {
+    method,
+    headers: { Authorization: authHeader, "Content-Type": "application/json", Accept: "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }
+  const r = await fetch(`${env.url}${path}`, init).catch((err) => ({
+    ok: false,
+    status: 0,
+    text: () => Promise.resolve(String(err)),
+    json: () => Promise.reject(err),
+  }) as unknown as Response)
+  if (!r.ok) {
+    const errorBody = await r.text().catch(() => "")
+    return { ok: false, status: r.status, errorBody }
+  }
+  const data = (await r.json().catch(() => null)) as T | null
+  return { ok: true, status: r.status, data: data ?? undefined }
+}
+
+export async function detectRelease(env: Env): Promise<string> {
+  const hdr = (await adminHeaders(env)) as Record<string, string>
+  const r = await snFetch<{ result: { value: string }[] }>(
+    env,
+    "GET",
+    `/api/now/table/sys_properties?sysparm_query=name=glide.war&sysparm_fields=value&sysparm_limit=1`,
+    hdr.Authorization,
+  )
+  return r.data?.result?.[0]?.value ?? "unknown"
+}

--- a/packages/opencode/sn-roles.manifest.json
+++ b/packages/opencode/sn-roles.manifest.json
@@ -1,0 +1,17719 @@
+{
+  "version": 1,
+  "validatedOn": "glide-australia-02-11-2026__patch1-03-23-2026_03-31-2026_1137.zip",
+  "testedAt": "2026-05-14T10:16:56.949Z",
+  "stats": {
+    "tools": 428,
+    "untestable": 128,
+    "primitivesTotal": 462,
+    "primitivesResolved": 462,
+    "sourceDistribution": {
+      "direct": 870,
+      "wildcard": 189,
+      "inherited": 42
+    },
+    "topRoles": [
+      {
+        "role": "snc_internal",
+        "tools": 207
+      },
+      {
+        "role": "admin",
+        "tools": 149
+      },
+      {
+        "role": "public",
+        "tools": 130
+      },
+      {
+        "role": "delegated_developer",
+        "tools": 47
+      },
+      {
+        "role": "canvas_user",
+        "tools": 41
+      },
+      {
+        "role": "sn_app_eng_studio.admin",
+        "tools": 41
+      },
+      {
+        "role": "sn_app_eng_studio.user",
+        "tools": 41
+      },
+      {
+        "role": "ui_builder_admin",
+        "tools": 29
+      },
+      {
+        "role": "itil",
+        "tools": 26
+      },
+      {
+        "role": "catalog_admin",
+        "tools": 26
+      },
+      {
+        "role": "web_service_admin",
+        "tools": 23
+      },
+      {
+        "role": "workflow_creator",
+        "tools": 23
+      },
+      {
+        "role": "catalog_editor",
+        "tools": 22
+      },
+      {
+        "role": "catalog_manager",
+        "tools": 22
+      },
+      {
+        "role": "atf_test_admin",
+        "tools": 21
+      }
+    ]
+  },
+  "tools": {
+    "snow_scheduled_job_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "syslog_viewer",
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "write",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "delete",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "write",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_job_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "assessment_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_execution_tracker",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_trigger_scheduled_job": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_sp_widget": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sp_admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_sp_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sp_admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_page",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_sp_page_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "write",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "delete",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_sp_theme_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_brand",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sp_brand",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_brand",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "write",
+          "roles": [
+            "maint",
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_date_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_query_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_field_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_saved_filter": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "filter_admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "filter_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_filter",
+          "operation": "create",
+          "roles": [
+            "filter_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 4
+        }
+      ]
+    },
+    "snow_configure_connection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_check_health": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_instance_info": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "knowledge_manager",
+          "mid_server",
+          "password_reset_admin",
+          "sn_sub_man.admin",
+          "snc_internal",
+          "ts_admin",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_batch_request": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_test_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_metric": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "metric_admin"
+        ],
+        "minimumBundle": [
+          "metric_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "metric_definition",
+          "operation": "create",
+          "roles": [
+            "metric_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_collect_metric": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_recommendation_engine": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sentiment_analysis": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_ai_classify": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_autocomplete": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_fuzzy_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_duplicate_detection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_ml_predict": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_anomaly_detection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_pa_dashboard": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_dashboards",
+          "operation": "create",
+          "roles": [
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "create",
+          "roles": [
+            "pa_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_data_quality": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "report_admin"
+        ],
+        "minimumBundle": [
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "create",
+          "roles": [
+            "report_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_define_kpi": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "pa_admin",
+          "pa_data_collector",
+          "pa_power_user"
+        ],
+        "minimumBundle": [
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_schedule_report_delivery": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "report_admin",
+          "report_scheduler"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysauto_report",
+          "operation": "create",
+          "roles": [
+            "report_scheduler",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_report_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_users_view",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_change_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_task",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_change_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_task",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "sn_change_task_assigned_user",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_ui_policy_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_policy_admin"
+        ],
+        "minimumBundle": [
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_policy",
+          "operation": "read",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_parse_json": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_track_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_deployment",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_devops_change": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "sn_change_write"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_devops_insights": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_metrics",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_velocity_tracking": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_velocity",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_source_control": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin",
+          "source_control_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_repo_status",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_repo_branch",
+          "operation": "read",
+          "roles": [
+            "source_control_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_repo_stash",
+          "operation": "read",
+          "roles": [
+            "source_control_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_devops_pipeline": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_pipeline",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_add_form_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_element",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_form_section": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_section",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_form": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_form_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_form",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_disable_business_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "business_rule_admin",
+          "maint"
+        ],
+        "minimumBundle": [
+          "business_rule_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script",
+          "operation": "write",
+          "roles": [
+            "business_rule_admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_business_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "business_rule_admin"
+        ],
+        "minimumBundle": [
+          "business_rule_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script",
+          "operation": "create",
+          "roles": [
+            "business_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_asset_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "discovery_schedule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_asset_compliance_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_manage_software_license": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sam",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license",
+          "operation": "write",
+          "roles": [
+            "sam"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license",
+          "operation": "create",
+          "roles": [
+            "sam"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "create",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_retire_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_transfer_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_optimize_licenses": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license_usage",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_track_asset_lifecycle": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "asset",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_audit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_related_list": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_related_list",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_list_view": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_list_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_add_list_column": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list_element",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_aggregate_metrics": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_uib_page_registry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_event": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_event",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_debug_widget_fetch": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_client_state": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_configure_uib_data_broker": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "write",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_uib_page_performance": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_uib_discover": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin",
+          "uxframework_user"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "read",
+          "roles": [
+            "response_header_admin",
+            "response_header_viewer",
+            "sn_cmdb_ws.config_editor",
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "read",
+          "roles": [
+            "response_header_admin",
+            "response_header_viewer",
+            "sn_cmdb_ws.config_editor",
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_uib_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_client_script",
+          "operation": "create",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_uib_page_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "delete",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "delete",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "delete",
+          "roles": [
+            "maint",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_event",
+          "operation": "read",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_uib_component_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_data_broker": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_security_policies": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_threat_intelligence": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_automate_threat_response": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_compliance_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_compliance_control",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_policy_exception",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_policy_exception",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_control",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_run_compliance_scan": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_compliance_scan",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_scan",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_report",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_audit_rule": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_elevate_role": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_issue_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_vulnerability_scan": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_access_control": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_security_risk_assessment": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "risk_assessment",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "risk_assessment",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sn_vul_vulnerable_item",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_escalate_permissions": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_vulnerability_risk_assessment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_compliance_rule": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_vendor_risk_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_audit_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_evidence_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_audit_trail_analysis": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_security_dashboard": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_playbook_orchestrate": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_execute_security_playbook": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_policy_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_discover_security_frameworks": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_incident_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_risk_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_kms_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_module",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_crypto_module",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_security_incident": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_security_policy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_indicator_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_scan_vulnerabilities": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_vul_scan",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_blast_radius_table_configs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "delegated_developer",
+          "mobile_analytics_viewer",
+          "now_experience_analytics_viewer",
+          "portal_analytics_viewer",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_field_references": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_filter",
+          "operation": "read",
+          "roles": [
+            "filter_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_artifact_dependencies": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "api_service_admin",
+          "oauth_admin",
+          "script_include_admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_blast_radius_dependents": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "api_service_admin",
+          "oauth_admin",
+          "script_include_admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_blast_radius_apps": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "data_mgmt_tools_admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_update_sets": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin",
+          "update_set_previewer",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_code_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_dev_test_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_validate_live_connection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_requirements": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_edit_by_sysid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_memory_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_data_consistency": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_orchestrate_development": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_plugin_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_plugins",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_package",
+          "scriptAcls": 2
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "function_field_admin",
+          "personalize_dictionary"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dictionary",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "atf_test_admin",
+            "atf_test_designer",
+            "function_field_admin",
+            "personalize_dictionary"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_bulk_update": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_data_export": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_choice": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "personalize",
+          "personalize_choices",
+          "personalize_decision_table_input",
+          "personalize_responses"
+        ],
+        "minimumBundle": [
+          "personalize"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_choice",
+          "operation": "create",
+          "roles": [
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_table": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "personalize_dictionary",
+          "sn_cmdb_admin"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "personalize_dictionary",
+            "sn_cmdb_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_field_map": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "import_admin",
+          "import_transformer"
+        ],
+        "minimumBundle": [
+          "import_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_transform_map",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_entry",
+          "operation": "create",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_generate_docs": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_connection_alias": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_connection",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_rest_message_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "write",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "write",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_schedule_job": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_integration_endpoints": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "email_account_admin",
+          "mid_server",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_web_service",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ldap_server_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "mid_server",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_email_account",
+          "operation": "read",
+          "roles": [
+            "email_account_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_db_index",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_credential_alias": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "basic_auth_credentials",
+          "operation": "create",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "api_key_credentials",
+          "operation": "create",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_alias",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_manage_mid_capabilities": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "agent_admin"
+        ],
+        "minimumBundle": [
+          "agent_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "create",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "delete",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_workflow_analyze": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_configure_mid_server": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "agent_admin",
+          "soap_ecc"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_queue",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "soap_ecc"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "write",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "write",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "create",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_oauth_profile": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "external_app_install_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "oauth_entity",
+          "operation": "create",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "create",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_flow_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "action_designer",
+          "connection_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "create",
+          "roles": [
+            "action_designer",
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_action_input",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_action_output",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_step_ext",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_step_ext",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_manage_oauth_tokens": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "oauth_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_credential",
+          "operation": "read",
+          "roles": [
+            "oauth_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_credential",
+          "operation": "read",
+          "roles": [
+            "oauth_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_web_service": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_web_service",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_detect_code_patterns": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_email_config": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "email_account_admin"
+        ],
+        "minimumBundle": [
+          "email_account_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_email_account",
+          "operation": "create",
+          "roles": [
+            "email_account_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_test_integration": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "import_admin",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_web_service",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_data_source",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_scheduler",
+            "import_transformer",
+            "mid_server",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_test_rest_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_test_mid_connectivity": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "agent_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_manage_spoke_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin",
+          "credential_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "discovery_credentials",
+          "operation": "read",
+          "roles": [
+            "credential_admin",
+            "discovery_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_alias",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_data_sources": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "import_admin",
+          "mid_server",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_import_set_table_list",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_data_source",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_scheduler",
+            "import_transformer",
+            "mid_server",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ldap_server_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "mid_server",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_map",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_rest_message": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_install_spoke": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin",
+          "sn_help_setup_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_catalog_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_category",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_category",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_catalogs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager",
+          "itil",
+          "sn_change_write",
+          "sn_request_write"
+        ],
+        "minimumBundle": [
+          "catalog"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_catalog",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_change_write",
+            "sn_request_write",
+            "workspace_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_catalog_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "catalog_script_client",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_search_catalog": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_option",
+          "operation": "read",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_catalog_item_details": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "catalog_ui_policy",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "catalog_script_client",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_catalog_ui_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "catalog_ui_policy",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "catalog_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_order_catalog_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "catalog_admin",
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_request",
+          "operation": "create",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_item_option",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_item_option_mtom",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_request_comments_write",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_request_comments_write",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "client_script_admin"
+        ],
+        "minimumBundle": [
+          "client_script_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_client",
+          "operation": "create",
+          "roles": [
+            "client_script_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ui_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_page_admin"
+        ],
+        "minimumBundle": [
+          "ui_page_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_page",
+          "operation": "create",
+          "roles": [
+            "ui_page_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ui_action": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_discover_platform_tables": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_url_doctor": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_ui_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_policy_admin"
+        ],
+        "minimumBundle": [
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_policy",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_session_context": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_table_schema_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "analytics_admin",
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "business_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy",
+          "operation": "read",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_script_include": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "script_include_admin"
+        ],
+        "minimumBundle": [
+          "script_include_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_include",
+          "operation": "write",
+          "roles": [
+            "script_include_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_include",
+          "operation": "create",
+          "roles": [
+            "script_include_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_update_ux_app_config_landing_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_config",
+          "operation": "write",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_page_macroponent": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_macroponent",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_complete_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list_menu_config",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list_category",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_list",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_ux_app_route": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_experience": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_ux_page_registry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_macroponent",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "create",
+          "roles": [
+            "canvas_admin",
+            "maint",
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_workspace_configuration": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_experience",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_property",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_screen_type",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_app_config": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_configurable_agent_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_screen_type",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_all_workspaces": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_clone_instance": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_cicd_deploy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_backup_instance": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_role_group_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "role_admin",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_role",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "role_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "create",
+          "roles": [
+            "ai_user_admin",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "skill_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_user_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ai_user_admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "create",
+          "roles": [
+            "ai_user_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "write",
+          "roles": [
+            "ai_user_admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_impersonate_user": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "business_calendar_admin",
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_plugins",
+          "operation": "read",
+          "roles": [
+            "business_calendar_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "create",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ml_solution_input_field",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_list_pi_solutions": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin",
+          "ml_report_user",
+          "platform_ml_read"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_activate_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "write",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "write",
+          "roles": [
+            "ml_admin",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_monitor_pi_training": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin",
+          "ml_report_user",
+          "platform_ml_read"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_train_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "business_calendar_admin",
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_plugins",
+          "operation": "read",
+          "roles": [
+            "business_calendar_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "write",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_data_convert": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_date": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_text": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_number": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_schedule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "schedule_admin"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "schedule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_oncall_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_member",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_add_schedule_entry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "schedule_admin",
+          "sn_change_cab.cab_manager"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule_span",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "schedule_admin",
+            "sn_change_cab.cab_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_fsm_parts_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_fsm_work_order_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "pa_admin",
+          "personalize",
+          "personalize_choices",
+          "personalize_decision_table_input",
+          "personalize_responses",
+          "playbook.write",
+          "sn_gd_guidance.guidance_manager",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_choice",
+          "operation": "read",
+          "roles": [
+            "pa_admin",
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses",
+            "playbook.write",
+            "sn_gd_guidance.guidance_manager",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_fsm_dispatch_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_record_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "assignment_rule_admin",
+          "cmdb_read",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_department",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_location",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysrule_assignment",
+          "operation": "read",
+          "roles": [
+            "assignment_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_search_artifacts": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_table_fields": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_index",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_manage_group_membership": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "create",
+          "roles": [
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "delete",
+          "roles": [
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_operational_metrics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "problem",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "problem_task_analyst",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_cleanup_test_artifacts": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_assign_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_query_table": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_catalog_item_manager": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "write",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "write",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "delete",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_auto_resolve_incident": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "problem_coordinator",
+            "sn_incident_comments_write",
+            "sn_incident_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_predictive_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_catalog_item_search": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager",
+          "itil",
+          "sn_request_write",
+          "snc_external",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "catalog"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_cmdb_search": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_by_sysid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_pattern_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "problem",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "problem_task_analyst",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_attach_file": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_incident": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_file_upload": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_scripted_rest_api": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_file_download": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_custom_api": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_graphql_query": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_agile_sprint_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_standup_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_release_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_release",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_defect",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_release",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_release",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_retrospective": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_defect",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_capacity_plan": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_epic_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_theme",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_epic",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_epic",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_sprint_board": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_scrum_task",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_sprint_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_backlog_groom": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_team_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_agile_story_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_story",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_backlog_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_sprint_burndown": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_velocity_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_project": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "pm_project",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_project_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "pm_project_task",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_generate_guid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_timestamp": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_merge_objects": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sanitize_input": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_convert_es6_to_es5": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_random_string": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sleep": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_processor": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "maint"
+        ],
+        "minimumBundle": [
+          "maint"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_processor",
+          "operation": "create",
+          "roles": [
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_add_comment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_journal_entries": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "audit_viewer",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "audit_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_journal_field",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_customer_case": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_employee_onboarding": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_le_onboarding",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_hr_case": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_train_va_nlu": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_send_va_message": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_conversation",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_cs_message",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_discover_va_topics": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_va_topic_block": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_topic_block",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_handoff_to_agent": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_handoff",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_cs_conversation",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_va_topic": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "topic",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_va_conversation": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "interaction_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_conversation",
+          "operation": "read",
+          "roles": [
+            "interaction_admin",
+            "interaction_agent"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_cs_message",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_transform_map": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "import_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_map",
+          "operation": "create",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_execute_transform": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_export_to_xml": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_import_set": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_transform_data": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_knowledge_base": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge_base",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_catalog_variable": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_knowledge_article_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_attachment",
+          "operation": "read",
+          "roles": [
+            "public",
+            "sn_glider.ide_git_user",
+            "sn_glider.read_admin",
+            "sn_sub_man.admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 9
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_catalog_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_knowledge_bases": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge_base",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_category",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_add_dashboard_widget": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard_widget",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_dashboard_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "dashboard_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "read",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_contributor",
+            "pa_power_user",
+            "pa_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dashboard_widget",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard_admin",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "create",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_power_user",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "read",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_contributor",
+            "pa_power_user",
+            "pa_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_dashboard": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_list_supported_artifacts": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_pull_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_cleanup": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_status": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_push_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_convert_to_es5": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_mobile_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_layout",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_send_push_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "fsm_skill_user",
+          "push_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_push_notification",
+          "operation": "create",
+          "roles": [
+            "push_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_mobile_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_action",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_mobile_analytics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_analytics",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_discover_mobile_configs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_layout",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_ui_mobile_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_mobile_offline_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_configure_mobile_app": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_app",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_configure_offline_sync": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_offline_config",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_variable": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_variable_set": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new_set",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_approve_procurement": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "proc_request",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_purchase_order": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "proc_po",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_solution_package": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_auth_diagnostics": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "sp_admin",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "delete",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_deployment_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_artifact_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "data_mgmt_tools_admin",
+          "next_experience_admin",
+          "personalize",
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_choice",
+          "operation": "create",
+          "roles": [
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml_backup",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_clone_instance_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_rollback_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_admin",
+          "update_set_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "delete",
+          "roles": [
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_version",
+          "operation": "read",
+          "roles": [
+            "teamdev_code_reviewer",
+            "teamdev_user",
+            "update_set_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_audit",
+          "operation": "create",
+          "roles": [
+            "audit_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_deployment_debug": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "announcement_admin",
+          "syslog_viewer",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_github_deploy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_github_tree": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_validate_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_decode_base64": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_hash_string": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_encode_base64": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_encode_url": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_decode_url": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_workflow": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_start_workflow": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_workflow_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_activity",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "delete",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_history",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_workflow_transition": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "delete",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_calculate_sla_duration": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_customer_account": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_account",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_csm_contract_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_csm_communication_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_entitlement": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_entitlement",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_customer_history": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_case",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_email",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_hr_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_task",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_hr_profile_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_employee_offboarding": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_hr_lifecycle_event": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_jwt_decode": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_property_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "knowledge_manager",
+          "mid_server",
+          "password_reset_admin",
+          "sn_sub_man.admin",
+          "snc_internal",
+          "ts_admin",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_io": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer",
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_bulk": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_application": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user",
+          "upgrade_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "create",
+          "roles": [
+            "upgrade_admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_scope",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_install_application": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "nobody"
+        ],
+        "minimumBundle": [
+          "nobody"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_store_app",
+          "operation": "create",
+          "roles": [
+            "nobody"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_switch_application_scope": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_current_scope": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_list_applications": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_manage_flow": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "flow_admin",
+          "flow_designer",
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_logic_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_logic_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_output",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "create",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "write",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_instance",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_hub_flow_component",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_run",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_flow_context",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_run",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_output",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_menu_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "next_experience_admin"
+        ],
+        "minimumBundle": [
+          "next_experience_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_menu": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "next_experience_admin"
+        ],
+        "minimumBundle": [
+          "next_experience_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_queue": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_queue",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_queue_items": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_queue",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_template",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_apply_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal",
+          "template_editor_global",
+          "template_editor_group"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_template",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "template_editor_global",
+            "template_editor_group"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_sla": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sla_admin",
+          "sla_manager",
+          "sm_admin",
+          "wm_admin"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "contract_sla",
+          "operation": "create",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "sm_admin",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_sla_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_sla_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "service_viewer",
+          "sla_admin",
+          "sla_manager",
+          "sn_change_read",
+          "sn_incident_read",
+          "sn_problem_read",
+          "wm_agent",
+          "wm_dispatcher",
+          "wm_qualifier"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_script_output": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_property_manager": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_automation_jobs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cmdb_admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "sn_cmdb_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_flow_execution_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_flow_context",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_flow_log",
+          "operation": "read",
+          "roles": [
+            "flow_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_workflow_activity": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_email_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_email",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_sla_definition": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sla_admin",
+          "sla_manager"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "contract_sla",
+          "operation": "create",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "sm_admin",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_slow_queries": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_slow_query_log",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_outbound_http_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_outbound_http_log",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_events": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_viewer"
+        ],
+        "minimumBundle": [
+          "events_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_register",
+          "operation": "read",
+          "roles": [
+            "events_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_event_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin",
+          "sysevent_script_action_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_script_action",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "sysevent_script_action_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_execute_script": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_logs": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_trace_execution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "maint"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_rest_message_test_suite": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_inspect_mutations": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "audit_viewer",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_escalation_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_escalation",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_scheduled_job_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "assessment_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_redeploy_script_endpoint": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_inbound_http_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "system_scheduler_admin",
+          "ui_builder_admin",
+          "user_impersonation_history_viewer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_confirm_script_execution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "delete",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_schedules": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "sla_admin",
+          "sla_manager",
+          "sn_cd.content_approver",
+          "sn_change_read",
+          "sn_incident_read",
+          "sn_problem_read",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_data_mapper": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_field_mapper": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_validate_sysid": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin",
+          "update_set_previewer",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_widget_coherence": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cd.content_approver",
+          "sn_hr_sp.admin",
+          "sp_admin",
+          "sp_operator"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_record": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_validate_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "delegated_developer",
+          "function_field_admin",
+          "mobile_analytics_viewer",
+          "nds_admin",
+          "now_experience_analytics_viewer",
+          "personalize_dictionary",
+          "personalize_read_dictionary",
+          "portal_analytics_viewer",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_widget_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cd.content_approver",
+          "sn_hr_sp.admin",
+          "sp_admin",
+          "sp_operator"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_generate_records": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_user_roles": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ai_user_admin",
+          "itil",
+          "role_delegator",
+          "role_delegator_admin",
+          "user_admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_test_acl": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_acl_role": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "security_admin"
+        ],
+        "minimumBundle": [
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_security_acl_role",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_acl": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "security_admin"
+        ],
+        "minimumBundle": [
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_security_acl",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_indicator_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "write",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "delete",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_pa_discover": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_create": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "report_admin",
+          "report_scheduler"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_thresholds",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_power_user",
+            "pa_threshold_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "create",
+          "roles": [
+            "pa_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_report_chart",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysauto_report",
+          "operation": "create",
+          "roles": [
+            "report_scheduler",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_operate": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_collection_jobs",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_scores",
+          "operation": "read",
+          "roles": [
+            "pa_admin",
+            "pa_contributor",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_event_queue": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_dashboard_viewer",
+          "events_viewer",
+          "pa_data_collector"
+        ],
+        "minimumBundle": [
+          "events_dashboard_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent",
+          "operation": "read",
+          "roles": [
+            "events_dashboard_viewer",
+            "events_viewer",
+            "pa_data_collector"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_event": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent",
+          "operation": "create",
+          "roles": [
+            "events_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_monitor_metrics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "metric",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_alert_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert_rule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_alert": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_request_approval": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_approval_chain_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "fsm_skill_user",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "read",
+          "roles": [
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysapproval_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "read",
+          "roles": [
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_action",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_pending_approvals": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_approve_reject": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_attachments": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_delete_attachment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_upload_attachment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_execute_atf_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_suite",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_result",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test_step": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_step",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_atf_results": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_result",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test_suite": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test_suite",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_suite_test",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_atf_tests": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_data_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_data_policy2",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_data_policy_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_data_policy_rule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_run_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "discovery_schedule_item",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_ci": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_ci_relationships": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "cmdb_read",
+          "itil",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_search_cmdb": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_event_correlation": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_event",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_alert",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_alert_rule",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_get_ci_history": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "audit_viewer",
+          "sn_hr_sp.esc_admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_reconcile_ci": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "certification",
+          "itil",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "write",
+          "roles": [
+            "asset",
+            "certification",
+            "itil",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_ci_health_check": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_update_ci": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_impact_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_ci_service",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "cmdb_ci",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_ci_impact": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "cmdb_read",
+          "itil",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ci_relationship": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "itil",
+          "service_editor",
+          "sn_cmdb_editor"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "create",
+          "roles": [
+            "asset",
+            "itil",
+            "service_editor",
+            "sn_cmdb_editor"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_ci_details": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer",
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_event_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin",
+          "sysevent_script_action_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_script_action",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "sysevent_script_action_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_callback_handler": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_error_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_error_handler",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_exception_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "syslog_admin"
+        ],
+        "minimumBundle": [
+          "syslog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog",
+          "operation": "create",
+          "roles": [
+            "syslog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_cache_set": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_cache_get": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_rate_limit": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_paginate": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_retry_operation": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_diff_objects": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_send_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_send_push": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_notification_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_notification_preferences": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_schedule_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_emergency_broadcast": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent",
+          "operation": "create",
+          "roles": [
+            "events_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_notification_analytics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_email_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_send_email": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_player"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_email",
+          "operation": "create",
+          "roles": [
+            "sn_help_setup_player"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_email_template_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_player",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_email",
+          "operation": "create",
+          "roles": [
+            "sn_help_setup_player"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_inbound_email_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "write",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "delete",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "write",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_email_notification_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "delete",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_update_set_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_ensure_active_update_set": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_update_set_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "nobody",
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "create",
+          "roles": [
+            "nobody"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #131

Adds `packages/opencode/script/probe-sn-roles/` — a harness that resolves the minimum ServiceNow role per MCP tool by reading the live instance's `sys_security_acl` definitions directly. Output lands at `packages/opencode/sn-roles.manifest.json` and the existing `generate-tools-json.ts` merges it into `tools.json` so `docs.serac.build` can render "required SN role" per tool.

This is orthogonal to the existing `allowedRoles` field (which is Serac portal RBAC — `admin / developer / stakeholder`).

## What's in tools.json after this PR

```json
"snow_change_manage": {
  "permission": "write",
  "allowedRoles": ["developer", "admin"],   // portal RBAC (unchanged)
  "snRoles": {
    "anyOf": ["admin"],
    "minimumBundle": ["itil", "snc_internal"]
  }
}
```

`anyOf` lists single roles that alone suffice (always includes `admin`). `minimumBundle` is the smallest role set the user needs together — useful for tools that touch multiple tables with disjoint ACLs.

Empty `minimumBundle: []` means publicly accessible (no auth required).

## Why ACL-static, not empirical probing

I started with empirical probing but pivoted: SN's REST `user_password` field doesn't auto-hash, so a no-role test user can't log in via Basic Auth or OAuth password-grant. Reading ACL definitions directly via `sys_security_acl` + `sys_security_acl_role` is faster (1 min for 462 primitives), deterministic, and uses SN's own source of truth.

Tradeoff: doesn't evaluate condition scripts / advanced ACL scripts at runtime. The manifest flags those (`scriptAcls > 0`) so consumers can show "additional runtime checks may apply".

## Run

```sh
bun packages/opencode/script/probe-sn-roles/index.ts
```

Needs `~/.config/serac/sn-probe.env` with `SN_INSTANCE_URL`, `SN_OAUTH_CLIENT_ID`, `SN_OAUTH_CLIENT_SECRET` for a client-credentials OAuth client bound to an admin user.

## First-run results

- 428 tools indexed
- 300 testable via table-CRUD primitives (`/api/now/table/<table>`)
- 128 marked untestable (utilities, ML tools, non-table endpoints)
- 462 unique `(table, operation)` primitives resolved
- Source distribution: 870 direct ACL match, 42 inherited via `super_class`, 189 wildcard fallback
- Bundle sizes: 53 public-only, 187 single-role, 44 two-role, 13 three-role, 8 admin-only

Validated against Australia P1 build `2026-03-31_1137`.