### PR TITLE
fix(opencode): correct field assumptions in newly-built tools after live-instance audit

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/snow_approval_chain_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/approvals/snow_approval_chain_manage.ts
@@ -30,7 +30,7 @@ export const toolDefinition: MCPToolDefinition = {
   description: `Unified tool for ServiceNow approval chains across the sysapproval_approver, sysapproval_group, and sysapproval_action tables. Use this when a record needs an ordered, multi-step approval flow rather than a single ad-hoc approver.
 
 Actions:
-- define_chain — write an ordered chain of approval steps for a source record. Each step may target a user (sysapproval_approver) or a group (sysapproval_group). Steps after the first start in 'not_yet_requested' state and are activated as earlier steps complete.
+- define_chain — write an ordered chain of approval steps for a source record. Each step may target a user (sysapproval_approver) or a group (sysapproval_group). Steps after the first start in 'not requested' state and are activated as earlier steps complete.
 - preview_chain — resolve who would be asked at each step (expanding group memberships) without inserting any rows. Useful for showing the caller the chain before firing it.
 - get_approvals — list all pending and historical approval rows for a given source record across both sysapproval_approver and sysapproval_group, plus the recent sysapproval_action verbs applied.
 - cancel — end an active chain. Marks every still-open approver/group row as 'cancelled' and records a sysapproval_action 'cancelled' verb on each.
@@ -78,7 +78,7 @@ Returns: define_chain returns the inserted approval rows in order. preview_chain
       },
       activate_first: {
         type: "boolean",
-        description: "[define_chain] Whether the first step is created in state 'requested' (active) or 'not_yet_requested' (queued). Defaults to true.",
+        description: "[define_chain] Whether the first step is created in state 'requested' (active) or 'not requested' (queued). Defaults to true.",
         default: true,
       },
       // CANCEL
@@ -183,7 +183,7 @@ async function executeDefineChain(args: Record<string, unknown>, context: Servic
     const step = steps[i]
     const order = typeof step.order === "number" ? step.order : (i + 1) * 100
     const isFirst = i === 0
-    const stepState = isFirst && activateFirst ? "requested" : "not_yet_requested"
+    const stepState = isFirst && activateFirst ? "requested" : "not requested"
 
     if (step.approver) {
       const payload: Record<string, unknown> = {
@@ -347,7 +347,7 @@ async function executeGetApprovals(args: Record<string, unknown>, context: Servi
 
   const client = await getAuthenticatedClient(context)
 
-  const stateFilter = include_complete ? "" : "^stateIN requested,not_yet_requested"
+  const stateFilter = include_complete ? "" : "^stateIN requested,not requested"
 
   // Per-user approver rows
   const approverQueryParts = [`sysapproval=${source_sys_id}`]
@@ -436,7 +436,7 @@ async function executeCancel(args: Record<string, unknown>, context: ServiceNowC
   const cancelledGroups: Array<Record<string, unknown>> = []
 
   // Cancel per-user rows that are still open
-  const approverQueryParts = [`sysapproval=${source_sys_id}`, "stateIN requested,not_yet_requested"]
+  const approverQueryParts = [`sysapproval=${source_sys_id}`, "stateIN requested,not requested"]
   if (source_table) approverQueryParts.push(`source_table=${source_table}`)
   const approverResp = await client.get("/api/now/table/sysapproval_approver", {
     params: {
@@ -454,7 +454,7 @@ async function executeCancel(args: Record<string, unknown>, context: ServiceNowC
 
   // Cancel group rows that are still open
   try {
-    const groupQueryParts = [`document_id=${source_sys_id}`, "stateIN requested,not_yet_requested"]
+    const groupQueryParts = [`document_id=${source_sys_id}`, "stateIN requested,not requested"]
     if (source_table) groupQueryParts.push(`source_table=${source_table}`)
     const groupResp = await client.get("/api/now/table/sysapproval_group", {
       params: {

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/snow_catalog_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/catalog/snow_catalog_manage.ts
@@ -107,6 +107,10 @@ Returns: created or queried records with sys_id, name, and the relevant referenc
         type: "string",
         description: "[create_category] Category display title (defaults to name)",
       },
+      homepage_renderer: {
+        type: "string",
+        description: "[create_category] sys_id of the sc_homepage_renderer used to render the category. Mandatory on sc_category — defaults to the OOB Default Renderer if omitted.",
+      },
       // LINK_ITEM_TO_CATEGORY
       cat_item: {
         type: "string",
@@ -432,6 +436,10 @@ async function executeCreateCategory(args: Record<string, unknown>, context: Ser
   }
   if (args.sc_catalogs) payload.sc_catalog = args.sc_catalogs
   if (args.parent) payload.parent = args.parent
+  // sc_category.homepage_renderer is mandatory — pass through when supplied so creates don't
+  // fail on a "Mandatory field" validation. The caller can pre-resolve the OOB default renderer
+  // sys_id (e.g. sc_homepage_renderer where name = 'Default').
+  if (args.homepage_renderer) payload.homepage_renderer = args.homepage_renderer
 
   const response = await client.post("/api/now/table/sc_category", payload)
   const created = response.data.result as Record<string, unknown>

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_communication_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/csm/snow_csm_communication_manage.ts
@@ -178,12 +178,16 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
 
   const client = await getAuthenticatedClient(context)
 
+  // The base interaction table has no `account` or `contact` columns. CSM-specific
+  // attributes typically extend interaction via a child table (sn_customerservice_interaction)
+  // when the plugin is installed. Filter only on the columns guaranteed to exist on
+  // the base interaction table; surface account/contact as-is for callers extending the schema.
   const queryParts: string[] = []
-  if (account) queryParts.push(`account=${account}`)
-  if (contact) queryParts.push(`contact=${contact}`)
   if (channel) queryParts.push(`channel=${channel}`)
   if (state) queryParts.push(`state=${state}`)
   if (from_date) queryParts.push(`opened_at>=${from_date}`)
+  if (account) queryParts.push(`opened_for=${account}`)
+  if (contact) queryParts.push(`opened_for=${contact}`)
 
   const response = await client.get(`/api/now/table/${INTERACTION_TABLE}`, {
     params: {
@@ -192,7 +196,7 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       sysparm_orderby: "opened_at",
       ...(fields
         ? { sysparm_fields: fields }
-        : { sysparm_fields: "sys_id,number,short_description,channel,state,direction,account,contact,opened_for,opened_at" }),
+        : { sysparm_fields: "sys_id,number,short_description,channel,state,direction,opened_for,assignment_group,assigned_to,opened_at" }),
     },
   })
 
@@ -207,9 +211,9 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       channel: r.channel,
       state: r.state,
       direction: r.direction,
-      account: r.account,
-      contact: r.contact,
       opened_for: r.opened_for,
+      assignment_group: r.assignment_group,
+      assigned_to: r.assigned_to,
       opened_at: r.opened_at,
       url: `${context.instanceUrl}/nav_to.do?uri=${INTERACTION_TABLE}.do?sys_id=${r.sys_id}`,
     })),
@@ -229,19 +233,20 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
 
   const interactionSysId = interaction.sys_id as string
 
-  // Pull linked records (best-effort)
+  // Pull linked records (best-effort). interaction_related_record uses
+  // document_table + document_id to point at the parent record.
   let linkedRecords: Array<Record<string, unknown>> = []
   try {
     const linksResponse = await client.get(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
       params: {
         sysparm_query: `interaction=${interactionSysId}`,
-        sysparm_fields: "sys_id,related_record_table,related_record",
+        sysparm_fields: "sys_id,document_table,document_id,type",
         sysparm_limit: 50,
       },
     })
     linkedRecords = (linksResponse.data.result || []) as Array<Record<string, unknown>>
   } catch {
-    // TODO: verify interaction_related_record column names on a live instance.
+    // Best-effort — older releases may not expose interaction_related_record.
   }
 
   return createSuccessResult({
@@ -264,18 +269,31 @@ async function executeLogInteraction(args: Record<string, unknown>, context: Ser
 
   const client = await getAuthenticatedClient(context)
 
-  // Canonical interaction columns; `body` is captured as work_notes since
-  // the interaction table doesn't expose a top-level body in most releases.
-  // TODO: verify if customer has a custom body field on interaction.
+  // Canonical interaction columns. The base interaction table has no `account` or `contact`
+  // columns — those exist only on plugin-extended children. `opened_for` is the closest
+  // base-table analogue. `body` is captured as work_notes (the journal column).
+  // interaction.type is mandatory and uses a constrained choice list (phone/chat/messaging/video);
+  // map our broader `channel` value onto it where possible.
+  const channelToType: Record<string, string> = {
+    phone: "phone",
+    chat: "chat",
+    sms: "messaging",
+    email: "messaging",
+    social: "messaging",
+    web: "messaging",
+    "walk-in": "phone",
+  }
   const payload: Record<string, unknown> = {
     channel,
-    short_description,
+    type: channelToType[channel] || "phone",
     state: "new",
+    short_description,
   }
   if (args.direction) payload.direction = args.direction
-  if (args.account) payload.account = args.account
-  if (args.contact) payload.contact = args.contact
+  // Map account/contact onto opened_for as a best-effort base-table fallback.
   if (args.opened_for) payload.opened_for = args.opened_for
+  else if (args.account) payload.opened_for = args.account
+  else if (args.contact) payload.opened_for = args.contact
   if (args.assigned_to) payload.assigned_to = args.assigned_to
   if (args.body) payload.work_notes = args.body
 
@@ -289,8 +307,8 @@ async function executeLogInteraction(args: Record<string, unknown>, context: Ser
     try {
       const linkResponse = await client.post(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
         interaction: created.sys_id,
-        related_record_table: "sn_customerservice_case",
-        related_record: case_sys_id,
+        document_table: "sn_customerservice_case",
+        document_id: case_sys_id,
       })
       linkSysId = linkResponse.data.result.sys_id
     } catch {
@@ -320,11 +338,11 @@ async function executeLinkToCase(args: Record<string, unknown>, context: Service
 
   const client = await getAuthenticatedClient(context)
 
-  // TODO: verify interaction_related_record column names on a live instance.
+  // interaction_related_record uses document_table + document_id (not related_record_*)
   const response = await client.post(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
     interaction: sys_id,
-    related_record_table: "sn_customerservice_case",
-    related_record: case_sys_id,
+    document_table: "sn_customerservice_case",
+    document_id: case_sys_id,
   })
   const created = response.data.result as Record<string, unknown>
 
@@ -349,10 +367,10 @@ async function executeListForCase(args: Record<string, unknown>, context: Servic
 
   const client = await getAuthenticatedClient(context)
 
-  // TODO: verify interaction_related_record links use related_record_table = sn_customerservice_case.
+  // interaction_related_record links use document_table + document_id (not related_record_*)
   const linksResponse = await client.get(`/api/now/table/${INTERACTION_RELATED_TABLE}`, {
     params: {
-      sysparm_query: `related_record=${case_sys_id}^related_record_table=sn_customerservice_case`,
+      sysparm_query: `document_id=${case_sys_id}^document_table=sn_customerservice_case`,
       sysparm_fields: "sys_id,interaction",
       sysparm_limit: limit,
     },

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/dashboards/snow_dashboard_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/dashboards/snow_dashboard_manage.ts
@@ -161,9 +161,10 @@ async function findDashboard(
     }
   }
   if (title) {
+    // sys_dashboard exposes the display label as `name` (no `title` column).
     const search = await client.get("/api/now/table/sys_dashboard", {
       params: {
-        sysparm_query: `name=${title}^ORtitle=${title}`,
+        sysparm_query: `name=${title}`,
         sysparm_limit: 1,
       },
     })
@@ -183,9 +184,30 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
 
   const client = await getAuthenticatedClient(context)
 
+  // sys_dashboard has no owner or description columns — only name, columns, rows,
+  // cell_height, cell_width, roles, active. Drop the owner filter (left in args for
+  // forward-compat) and project just the real fields.
   const queryParts: string[] = []
-  if (owner) queryParts.push(`owner=${owner}`)
   if (active_only) queryParts.push("active=true")
+  if (owner) {
+    // Best-effort: sys_dashboard_admin holds dashboard ownership/sharing on most releases.
+    try {
+      const adminResp = await client.get("/api/now/table/sys_dashboard_admin", {
+        params: { sysparm_query: `user=${owner}`, sysparm_fields: "dashboard", sysparm_limit: 200 },
+      })
+      const dashIds = ((adminResp.data.result || []) as Array<Record<string, unknown>>)
+        .map((r) => {
+          const ref = r.dashboard
+          if (typeof ref === "string") return ref
+          if (ref && typeof ref === "object" && "value" in ref) return (ref as { value: string }).value
+          return null
+        })
+        .filter((v): v is string => typeof v === "string" && v.length > 0)
+      if (dashIds.length > 0) queryParts.push(`sys_idIN${dashIds.join(",")}`)
+    } catch {
+      // sys_dashboard_admin may not be queryable on every release — drop the owner filter.
+    }
+  }
 
   const response = await client.get("/api/now/table/sys_dashboard", {
     params: {
@@ -194,7 +216,7 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       sysparm_orderby: "name",
       ...(fields
         ? { sysparm_fields: fields }
-        : { sysparm_fields: "sys_id,name,title,description,active,owner,sys_updated_on" }),
+        : { sysparm_fields: "sys_id,name,roles,active,columns,rows,sys_updated_on" }),
     },
   })
 
@@ -205,10 +227,11 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
     count: results.length,
     dashboards: results.map((r) => ({
       sys_id: r.sys_id,
-      title: r.title || r.name,
-      description: r.description,
+      name: r.name,
+      roles: r.roles,
       active: r.active,
-      owner: r.owner,
+      columns: r.columns,
+      rows: r.rows,
       updated_at: r.sys_updated_on,
       url: `${context.instanceUrl}/$pa_dashboard.do?sysparm_dashboard=${r.sys_id}`,
     })),

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/email/snow_email_template_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/email/snow_email_template_manage.ts
@@ -204,7 +204,9 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
 
   const queryParts: string[] = []
   if (table) queryParts.push(`collection=${table}`)
-  if (active_only) queryParts.push("active=true")
+  // sysevent_email_template has no `active` column on this platform — drop the filter.
+  // active_only is accepted in the schema for forward compatibility but ignored here.
+  void active_only
 
   const response = await client.get("/api/now/table/sysevent_email_template", {
     params: {
@@ -213,7 +215,7 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       sysparm_orderby: "name",
       ...(fields
         ? { sysparm_fields: fields }
-        : { sysparm_fields: "sys_id,name,subject,collection,content_type,active,sys_updated_on" }),
+        : { sysparm_fields: "sys_id,name,subject,collection,email_layout,sys_updated_on" }),
     },
   })
 
@@ -227,8 +229,7 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       name: r.name,
       subject: r.subject,
       table: r.collection,
-      content_type: r.content_type,
-      active: r.active,
+      email_layout: r.email_layout,
       updated_at: r.sys_updated_on,
       url: `${context.instanceUrl}/nav_to.do?uri=sysevent_email_template.do?sys_id=${r.sys_id}`,
     })),

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_work_order_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/fsm/snow_fsm_work_order_manage.ts
@@ -347,7 +347,7 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
   let historyCount = 0
   try {
     const tasks = await client.get(`/api/now/table/${WORK_TASK_TABLE}`, {
-      params: { sysparm_query: `parent=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+      params: { sysparm_query: `work_order=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
     })
     taskCount = ((tasks.data.result || []) as Array<unknown>).length
   } catch {
@@ -355,12 +355,11 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
   }
   try {
     const history = await client.get(`/api/now/table/${WORK_ORDER_HISTORY_TABLE}`, {
-      params: { sysparm_query: `order=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
+      params: { sysparm_query: `work_order=${workOrderSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
     })
     historyCount = ((history.data.result || []) as Array<unknown>).length
   } catch {
-    // TODO: verify wm_order_history join column on a live instance — some
-    // variants use `work_order` rather than `order`.
+    // wm_order_history is optional — not present on every FSM install.
   }
 
   return createSuccessResult({
@@ -545,7 +544,7 @@ async function executeListTasks(args: Record<string, unknown>, context: ServiceN
   const sys_id = args.sys_id as string | undefined
   const number = args.number as string | undefined
   const limit = (args.limit as number) || 50
-  const fields = (args.fields as string) || "sys_id,number,short_description,state,assigned_to,parent,sys_updated_on"
+  const fields = (args.fields as string) || "sys_id,number,short_description,state,assigned_to,work_order,sys_updated_on"
 
   if (!sys_id && !number) {
     return createErrorResult("sys_id or number is required for list_tasks action")
@@ -558,9 +557,10 @@ async function executeListTasks(args: Record<string, unknown>, context: ServiceN
   }
 
   const workOrderSysId = workOrder.sys_id as string
+  // wm_task has a direct `work_order` reference column to wm_order — preferred over inherited task.parent.
   const response = await client.get(`/api/now/table/${WORK_TASK_TABLE}`, {
     params: {
-      sysparm_query: `parent=${workOrderSysId}`,
+      sysparm_query: `work_order=${workOrderSysId}`,
       sysparm_limit: limit,
       sysparm_orderby: "sys_created_on",
       sysparm_fields: fields,

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/snow_pa_indicator_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/performance-analytics/snow_pa_indicator_manage.ts
@@ -17,20 +17,20 @@ import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_pa_indicator_manage",
-  description: `Unified tool for ServiceNow Performance Analytics indicator definitions and their dimensional breakdowns. Wraps the pa_indicators, pa_breakdowns, pa_widgets, and pa_scores tables on the platform.
+  description: `Unified tool for ServiceNow Performance Analytics indicator definitions and their dimensional breakdowns. Wraps the pa_indicators, pa_breakdowns, pa_indicator_breakdowns (join), pa_widgets, and pa_scores tables on the platform.
 
 Actions:
-- list — list indicators, optionally filtered by facts_table or active flag
+- list — list indicators, optionally filtered by cube
 - get — retrieve a single indicator by sys_id or name (includes related widget and breakdown counts)
-- create — create a new indicator (name, facts_table, aggregate, field required)
+- create — create a new indicator (name, aggregate, precision, forecast_base_periods, forecast_periods required; cube optional but typical)
 - update — patch indicator fields
-- delete — remove an indicator (and optionally its dependent breakdowns)
-- add_breakdown — attach a dimensional breakdown to an indicator (writes pa_breakdowns)
-- list_breakdowns — list breakdowns for a given indicator or globally
+- delete — remove an indicator (and optionally its dependent pa_indicator_breakdowns links)
+- add_breakdown — attach a dimensional breakdown to an indicator (writes pa_breakdowns + pa_indicator_breakdowns join)
+- list_breakdowns — list breakdowns for a given indicator (via pa_indicator_breakdowns) or globally
 
-Use when: the agent needs to manage KPI/indicator definitions, attach dimensional slicers (assignment_group, priority, location, etc.) to existing indicators, or audit which indicators a facts table feeds.
+Use when: the agent needs to manage KPI/indicator definitions, attach dimensional slicers (assignment_group, priority, location, etc.) to existing indicators, or audit which indicators a cube feeds.
 
-Returns: indicator records with sys_id, name, facts_table, aggregate, field, frequency, unit, and active flag. For breakdowns, returns sys_id, name, table, field, and matrix_source. Companion tools: snow_pa_create for full PA artifact creation (widgets, thresholds, scheduled reports) and snow_pa_operate for collecting and querying PA scores.`,
+Returns: indicator records with sys_id, name, label, cube, aggregate, field, frequency, unit, precision. For breakdowns, returns sys_id, name, facts_table, field, and matrix_source. Companion tools: snow_pa_create for full PA artifact creation (widgets, thresholds, scheduled reports) and snow_pa_operate for collecting and querying PA scores.`,
   category: "performance-analytics",
   subcategory: "performance-analytics",
   use_cases: ["performance-analytics", "kpi", "indicators", "breakdowns", "reporting"],
@@ -64,22 +64,26 @@ Returns: indicator records with sys_id, name, facts_table, aggregate, field, fre
         type: "string",
         description: "[create/update] Indicator description",
       },
-      facts_table: {
+      cube: {
         type: "string",
-        description: "[create/update] Source/facts table the indicator measures (e.g. incident, sc_task)",
+        description: "[create/update] pa_cubes sys_id that defines the indicator's facts table and conditions (the cube is the source/facts wrapper on pa_indicators; use snow_pa_create to author cubes)",
+      },
+      script: {
+        type: "string",
+        description: "[create/update] pa_scripts sys_id when the indicator is scripted",
       },
       aggregate: {
         type: "string",
-        description: "[create/update] Aggregation function",
+        description: "[create/update] Aggregation function (inherited from pa_indicators_definition)",
         enum: ["COUNT", "SUM", "AVG", "MIN", "MAX", "COUNT_DISTINCT"],
       },
       field: {
         type: "string",
-        description: "[create/update] Field on facts_table to aggregate (omit for COUNT)",
+        description: "[create/update] Field on the cube's facts table to aggregate (omit for COUNT)",
       },
       conditions: {
         type: "string",
-        description: "[create/update] Encoded query that filters the facts_table rows",
+        description: "[create/update] Encoded query that filters the facts table rows (inherited from pa_indicators_definition)",
       },
       unit: {
         type: "string",
@@ -95,14 +99,24 @@ Returns: indicator records with sys_id, name, facts_table, aggregate, field, fre
         description: "[create/update] Whether higher or lower is better",
         enum: ["maximize", "minimize"],
       },
+      formula: {
+        type: "string",
+        description: "[create/update] Formula expression for derived indicators",
+      },
       precision: {
         type: "number",
-        description: "[create/update] Decimal precision",
+        description: "[create] Decimal precision (mandatory on pa_indicators)",
+        default: 0,
       },
-      active: {
-        type: "boolean",
-        description: "[create/update] Whether the indicator is active",
-        default: true,
+      forecast_base_periods: {
+        type: "number",
+        description: "[create] Number of base periods used for forecasting (mandatory on pa_indicators)",
+        default: 12,
+      },
+      forecast_periods: {
+        type: "number",
+        description: "[create] Number of periods to forecast (mandatory on pa_indicators)",
+        default: 6,
       },
       // BREAKDOWN fields (for add_breakdown)
       breakdown_name: {
@@ -217,23 +231,21 @@ async function findIndicator(
 // ==================== LIST ====================
 
 async function executeList(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
-  const facts_table = args.facts_table as string | undefined
-  const active_only = args.active_only === true
+  const cube = args.cube as string | undefined
   const limit = (args.limit as number) || 50
   const fields = args.fields as string | undefined
 
   const client = await getAuthenticatedClient(context)
 
   const queryParts: string[] = []
-  if (facts_table) queryParts.push(`facts_table=${facts_table}`)
-  if (active_only) queryParts.push("active=true")
+  if (cube) queryParts.push(`cube=${cube}`)
 
   const response = await client.get("/api/now/table/pa_indicators", {
     params: {
       sysparm_query: queryParts.join("^"),
       sysparm_limit: limit,
       sysparm_orderby: "name",
-      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,name,label,facts_table,aggregate,field,frequency,unit,active,sys_updated_on" }),
+      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,name,label,cube,aggregate,field,frequency,unit,precision,sys_updated_on" }),
     },
   })
 
@@ -246,12 +258,12 @@ async function executeList(args: Record<string, unknown>, context: ServiceNowCon
       sys_id: r.sys_id,
       name: r.name,
       label: r.label,
-      facts_table: r.facts_table,
+      cube: r.cube,
       aggregate: r.aggregate,
       field: r.field,
       frequency: r.frequency,
       unit: r.unit,
-      active: r.active,
+      precision: r.precision,
       updated_at: r.sys_updated_on,
       url: `${context.instanceUrl}/nav_to.do?uri=pa_indicators.do?sys_id=${r.sys_id}`,
     })),
@@ -280,12 +292,12 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
   let breakdownCount = 0
   let widgetCount = 0
   try {
-    const breakdowns = await client.get("/api/now/table/pa_breakdowns_indicator", {
+    const breakdowns = await client.get("/api/now/table/pa_indicator_breakdowns", {
       params: { sysparm_query: `indicator=${indicatorSysId}`, sysparm_fields: "sys_id", sysparm_limit: 200 },
     })
     breakdownCount = (breakdowns.data.result || []).length
   } catch {
-    // TODO: verify pa_breakdowns_indicator join table name on a live instance
+    // pa_indicator_breakdowns may not be reachable on every instance variant
   }
   try {
     const widgets = await client.get("/api/now/table/pa_widgets", {
@@ -313,12 +325,10 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
 
 async function executeCreate(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
   const name = args.name as string | undefined
-  const facts_table = args.facts_table as string | undefined
   const aggregate = args.aggregate as string | undefined
   const field = args.field as string | undefined
 
   if (!name) return createErrorResult("name is required for create action")
-  if (!facts_table) return createErrorResult("facts_table is required for create action")
   if (!aggregate) return createErrorResult("aggregate is required for create action")
   if (aggregate !== "COUNT" && !field) {
     return createErrorResult("field is required when aggregate is not COUNT")
@@ -334,20 +344,25 @@ async function executeCreate(args: Record<string, unknown>, context: ServiceNowC
     return createErrorResult(`Indicator '${name}' already exists. Use action='update' to modify it.`)
   }
 
+  // pa_indicators has three mandatory integer fields: precision, forecast_base_periods,
+  // forecast_periods. Default them when the caller omits values so simple create calls succeed.
   const payload: Record<string, unknown> = {
     name,
     label: (args.label as string) || name,
     description: (args.description as string) || "",
-    facts_table,
     aggregate: aggregate.toUpperCase(),
-    active: args.active === undefined ? true : args.active,
+    precision: args.precision !== undefined ? args.precision : 0,
+    forecast_base_periods: args.forecast_base_periods !== undefined ? args.forecast_base_periods : 12,
+    forecast_periods: args.forecast_periods !== undefined ? args.forecast_periods : 6,
   }
   if (field) payload.field = field
+  if (args.cube) payload.cube = args.cube
+  if (args.script) payload.script = args.script
+  if (args.formula) payload.formula = args.formula
   if (args.conditions) payload.conditions = args.conditions
   if (args.unit) payload.unit = args.unit
   if (args.frequency) payload.frequency = args.frequency
   if (args.direction) payload.direction = args.direction
-  if (args.precision !== undefined) payload.precision = args.precision
 
   const response = await client.post("/api/now/table/pa_indicators", payload)
   const created = response.data.result as Record<string, unknown>
@@ -381,15 +396,18 @@ async function executeUpdate(args: Record<string, unknown>, context: ServiceNowC
   const updatableFields = [
     "label",
     "description",
-    "facts_table",
+    "cube",
+    "script",
     "aggregate",
     "field",
+    "formula",
     "conditions",
     "unit",
     "frequency",
     "direction",
     "precision",
-    "active",
+    "forecast_base_periods",
+    "forecast_periods",
   ]
   const patch: Record<string, unknown> = {}
   for (const key of updatableFields) {
@@ -438,12 +456,11 @@ async function executeDelete(args: Record<string, unknown>, context: ServiceNowC
   const removedBreakdowns: string[] = []
 
   if (cascade) {
-    // TODO: verify pa_breakdowns_indicator join table name on a live instance
-    const breakdownLinks = await client.get("/api/now/table/pa_breakdowns_indicator", {
+    const breakdownLinks = await client.get("/api/now/table/pa_indicator_breakdowns", {
       params: { sysparm_query: `indicator=${targetSysId}`, sysparm_fields: "sys_id", sysparm_limit: 500 },
     })
     for (const row of (breakdownLinks.data.result || []) as Array<Record<string, unknown>>) {
-      await client.delete(`/api/now/table/pa_breakdowns_indicator/${row.sys_id}`)
+      await client.delete(`/api/now/table/pa_indicator_breakdowns/${row.sys_id}`)
       removedBreakdowns.push(row.sys_id as string)
     }
   }
@@ -483,10 +500,11 @@ async function executeAddBreakdown(args: Record<string, unknown>, context: Servi
     return createErrorResult(`Indicator not found: ${sys_id || indicatorName}`)
   }
 
-  // Create the breakdown definition
+  // Create the breakdown definition. pa_breakdowns uses `facts_table` (not `table`)
+  // for the source the breakdown evaluates against.
   const breakdownPayload: Record<string, unknown> = {
     name: breakdown_name,
-    table: breakdown_table,
+    facts_table: breakdown_table,
     field: breakdown_field,
     matrix_source,
   }
@@ -495,11 +513,10 @@ async function executeAddBreakdown(args: Record<string, unknown>, context: Servi
   const breakdownResponse = await client.post("/api/now/table/pa_breakdowns", breakdownPayload)
   const breakdown = breakdownResponse.data.result as Record<string, unknown>
 
-  // Attach the breakdown to the indicator via the join table.
-  // TODO: verify pa_breakdowns_indicator is the correct join table on a live instance.
+  // Attach the breakdown to the indicator via the join table pa_indicator_breakdowns.
   let linkSysId: string | null = null
   try {
-    const linkResponse = await client.post("/api/now/table/pa_breakdowns_indicator", {
+    const linkResponse = await client.post("/api/now/table/pa_indicator_breakdowns", {
       indicator: indicator.sys_id,
       breakdown: breakdown.sys_id,
     })
@@ -546,8 +563,7 @@ async function executeListBreakdowns(args: Record<string, unknown>, context: Ser
       return createErrorResult(`Indicator not found: ${sys_id || indicatorName}`)
     }
 
-    // TODO: verify pa_breakdowns_indicator join table name on a live instance
-    const linkResponse = await client.get("/api/now/table/pa_breakdowns_indicator", {
+    const linkResponse = await client.get("/api/now/table/pa_indicator_breakdowns", {
       params: {
         sysparm_query: `indicator=${indicator.sys_id}`,
         sysparm_limit: limit,

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/reporting/snow_report_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/reporting/snow_report_manage.ts
@@ -18,14 +18,14 @@ import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_report_manage",
-  description: `Unified tool for ServiceNow report lifecycle beyond creation: list, get, run, schedule, share, and export. Wraps sys_report, sys_report_schedule, and sys_report_users_view.
+  description: `Unified tool for ServiceNow report lifecycle beyond creation: list, get, run, schedule, share, and export. Wraps sys_report, sysauto_report, and sys_report_users_groups.
 
 Actions:
 - list — list sys_report definitions, optionally filtered by table or owner
 - get — retrieve a single report (sys_id or title)
 - run — execute the report ad-hoc and return rows from the configured table using the report filter
-- schedule — create or update a sys_report_schedule row (recurrence, time, recipients)
-- share — share a report with users or groups via sys_report_users_view
+- schedule — create or update a sysauto_report row (recurrence, time, recipients)
+- share — share a report with users or groups via sys_report_users_groups
 - export — export the report's underlying rows as JSON or CSV (server-side rendered PDF/XLSX is out of scope; use schedule for delivery)
 
 Use when: the agent needs to manage reports after they exist — running them on demand, scheduling delivery, or controlling who can view them. For authoring a new sys_report row, use snow_create_report instead.
@@ -100,7 +100,7 @@ Returns: report records with sys_id, title, table, type, filter; schedule rows w
       },
       schedule_sys_id: {
         type: "string",
-        description: "[schedule] Existing sys_report_schedule sys_id to update; omit to create a new row",
+        description: "[schedule] Existing sysauto_report sys_id to update; omit to create a new row",
       },
       schedule_active: {
         type: "boolean",
@@ -254,12 +254,12 @@ async function executeGet(args: Record<string, unknown>, context: ServiceNowCont
   // Best-effort schedule lookup
   let scheduleCount = 0
   try {
-    const schedules = await client.get("/api/now/table/sys_report_schedule", {
+    const schedules = await client.get("/api/now/table/sysauto_report", {
       params: { sysparm_query: `report=${reportSysId}`, sysparm_fields: "sys_id", sysparm_limit: 50 },
     })
     scheduleCount = (schedules.data.result || []).length
   } catch {
-    // TODO: verify sys_report_schedule schema on a live instance
+    // TODO: verify sysauto_report schema on a live instance
   }
 
   return createSuccessResult({
@@ -348,16 +348,27 @@ async function executeSchedule(args: Record<string, unknown>, context: ServiceNo
   if (args.run_time) payload.run_time = args.run_time
   if (args.run_dayofmonth !== undefined) payload.run_dayofmonth = args.run_dayofmonth
   if (args.run_dayofweek !== undefined) payload.run_dayofweek = args.run_dayofweek
-  if (recipients.length > 0) payload.email_list = recipients.join(",")
+  // sysauto_report uses user_list (sys_user references), group_list (sys_user_group references),
+  // and address_list (free-form email addresses) — not email_list. Split the recipients by shape:
+  // 32-hex sys_ids go to user_list, plain addresses go to address_list.
+  if (recipients.length > 0) {
+    const userIds: string[] = []
+    const addresses: string[] = []
+    for (const r of recipients) {
+      if (/^[0-9a-f]{32}$/i.test(r)) userIds.push(r)
+      else addresses.push(r)
+    }
+    if (userIds.length > 0) payload.user_list = userIds.join(",")
+    if (addresses.length > 0) payload.address_list = addresses.join(",")
+  }
 
   let response
   let mode: "created" | "updated"
   if (schedule_sys_id) {
-    // TODO: verify sys_report_schedule field set on a live instance
-    response = await client.patch(`/api/now/table/sys_report_schedule/${schedule_sys_id}`, payload)
+    response = await client.patch(`/api/now/table/sysauto_report/${schedule_sys_id}`, payload)
     mode = "updated"
   } else {
-    response = await client.post("/api/now/table/sys_report_schedule", payload)
+    response = await client.post("/api/now/table/sysauto_report", payload)
     mode = "created"
   }
 
@@ -369,7 +380,7 @@ async function executeSchedule(args: Record<string, unknown>, context: ServiceNo
     sys_id: result.sys_id,
     report: { sys_id: report.sys_id, title: report.title },
     schedule: result,
-    url: `${context.instanceUrl}/nav_to.do?uri=sys_report_schedule.do?sys_id=${result.sys_id}`,
+    url: `${context.instanceUrl}/nav_to.do?uri=sysauto_report.do?sys_id=${result.sys_id}`,
   })
 }
 
@@ -394,17 +405,15 @@ async function executeShare(args: Record<string, unknown>, context: ServiceNowCo
     return createErrorResult(`Report not found: ${sys_id || title}`)
   }
 
-  // TODO: verify sys_report_users_view field set on a live instance.
-  // ServiceNow stores share entries with a `report` reference and a target
-  // (user or group). The exact field names vary by version; the patterns
-  // below cover the documented surface.
+  // sys_report_users_groups uses report_id (ref sys_report), user_id (ref sys_user),
+  // and group_id (ref sys_user_group).
   const payload: Record<string, unknown> = {
-    report: report.sys_id,
+    report_id: report.sys_id,
   }
-  if (user) payload.user = user
-  if (group) payload.group = group
+  if (user) payload.user_id = user
+  if (group) payload.group_id = group
 
-  const response = await client.post("/api/now/table/sys_report_users_view", payload)
+  const response = await client.post("/api/now/table/sys_report_users_groups", payload)
   const result = response.data.result as Record<string, unknown>
 
   return createSuccessResult({

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/snow_job_status.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/scheduled-jobs/snow_job_status.ts
@@ -157,22 +157,28 @@ function normalizeRecord(source: SourceKey, raw: Record<string, unknown>): Recor
         document: raw.document,
       }
     case "worker":
+      // sys_progress_worker exposes message, error_message, output_summary, state_code,
+      // total_execute_time, total_run_time, queued_time. It has no start_time/end_time/progress_percent.
       return {
         ...common,
-        progress: raw.progress,
-        progress_percent: raw.progress_percent,
-        started_at: raw.start_time,
-        completed_at: raw.end_time,
+        state_code: raw.state_code,
+        queued_time: raw.queued_time,
+        total_run_time: raw.total_run_time,
+        total_execute_time: raw.total_execute_time,
         message: raw.message,
+        error_message: raw.error_message,
+        output_summary: raw.output_summary,
       }
     case "tracker":
+      // sys_execution_tracker uses start_time, completion_time, percent_complete (not end_time/progress).
       return {
         ...common,
-        progress: raw.progress,
+        percent_complete: raw.percent_complete,
         started_at: raw.start_time,
-        completed_at: raw.end_time,
+        completed_at: raw.completion_time,
         result: raw.result,
         message: raw.message,
+        detail_message: raw.detail_message,
       }
   }
 }
@@ -341,8 +347,9 @@ async function executeGetErrors(args: Record<string, unknown>, context: ServiceN
       } else if (s === "tracker") {
         query = `stateIN5,6^${sinceClause}`
       } else {
-        // trigger: best-effort — look at next_action set in the past with last_action containing an error message
-        query = `last_action_messageLIKEerror^${sinceClause}`
+        // trigger: sys_trigger has `last_error` (text) and `error_count` (int) — surface rows
+        // whose error_count is non-zero or whose last_error is set.
+        query = `error_count>0^ORlast_errorISNOTEMPTY^${sinceClause}`
       }
 
       const response = await client.get(`/api/now/table/${table}`, {

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/snow_oncall_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/schedules/snow_oncall_manage.ts
@@ -72,19 +72,19 @@ Returns: action-specific structures. list_rotations returns rotation records wit
       // SWAP_SHIFT parameters
       roster_sys_id: {
         type: "string",
-        description: "[swap_shift] sys_id of the cmn_rota_roster row to reassign",
+        description: "[swap_shift] sys_id of the cmn_rota_member row whose member assignment is being swapped (the per-window assignment record)",
       },
       from_member_sys_id: {
         type: "string",
-        description: "[swap_shift] sys_id of the cmn_rota_member currently assigned (used as a guard)",
+        description: "[swap_shift] sys_user sys_id currently assigned in the member row (used as a guard)",
       },
       to_member_sys_id: {
         type: "string",
-        description: "[swap_shift] sys_id of the cmn_rota_member taking the shift",
+        description: "[swap_shift] sys_user sys_id taking the shift",
       },
       reason: {
         type: "string",
-        description: "[swap_shift] Optional reason recorded on the roster row",
+        description: "[swap_shift] Optional reason; not persisted on cmn_rota_member (the table has no override/reason columns) but echoed in the response",
       },
       // Common
       limit: {
@@ -186,7 +186,7 @@ async function executeListRotations(args: Record<string, unknown>, context: Serv
       sysparm_query: queryParts.join("^"),
       sysparm_limit: limit,
       sysparm_orderby: "name",
-      sysparm_fields: "sys_id,name,group,schedule,active,time_zone,start_date,end_date,sys_updated_on",
+      sysparm_fields: "sys_id,name,group,schedule,active,coverage_interval,coverage_lead_type,sys_updated_on",
     },
   })
 
@@ -195,10 +195,9 @@ async function executeListRotations(args: Record<string, unknown>, context: Serv
     name: r.name,
     group: r.group,
     schedule: r.schedule,
-    time_zone: r.time_zone,
+    coverage_interval: r.coverage_interval,
+    coverage_lead_type: r.coverage_lead_type,
     active: r.active,
-    start_date: r.start_date,
-    end_date: r.end_date,
     updated_at: r.sys_updated_on,
     url: `${context.instanceUrl}/nav_to.do?uri=cmn_rota.do?sys_id=${r.sys_id}`,
   }))
@@ -228,16 +227,16 @@ async function executeGetCurrentOncall(args: Record<string, unknown>, context: S
 
   const rotationSysId = rotation.sys_id as string
 
-  // Find the roster row whose window covers "now" and that points at an active member.
-  // Use an encoded query that combines start_date_time <= now and end_date_time >= now.
-  // The platform's exact column names on cmn_rota_roster vary slightly across releases;
-  // we use the documented start_date_time / end_date_time pair.
-  // TODO: verify column names against a live instance.
+  // The cmn_rota_roster table holds the rotation pattern (rotation_interval_count,
+  // rotation_start_date, dow_for_rotate, ...) — it does not store per-shift datetime
+  // ranges. Individual member windows live on cmn_rota_member.from / .to (glide_date).
+  // We look up the active member of the rotation's roster whose window covers today.
+  // Resolve every roster on the rotation, then find the member row currently in window.
   const rosterResponse = await client.get("/api/now/table/cmn_rota_roster", {
     params: {
-      sysparm_query: `rota=${rotationSysId}^start_date_time<=javascript:gs.nowDateTime()^end_date_time>=javascript:gs.nowDateTime()`,
-      sysparm_limit: 5,
-      sysparm_orderby: "start_date_time",
+      sysparm_query: `rota=${rotationSysId}^active=true`,
+      sysparm_limit: 50,
+      sysparm_fields: "sys_id,name,active,rotation_interval_type,rotation_start_date",
     },
   })
 
@@ -247,13 +246,33 @@ async function executeGetCurrentOncall(args: Record<string, unknown>, context: S
       action: "get_current_oncall",
       rotation: { sys_id: rotationSysId, name: rotation.name },
       on_call: null,
-      message: "No active roster entry covers the current time for this rotation.",
+      message: "No active rosters defined on this rotation.",
     })
   }
 
-  // The roster row references a cmn_rota_member; the member references a sys_user.
-  // Resolve them in turn for a useful payload.
-  const primary = rosterRows[0]
+  const rosterIds = rosterRows.map((r) => r.sys_id as string)
+  // Find any cmn_rota_member whose [from..to] window covers today and which belongs
+  // to one of the rotation's rosters. cmn_rota_member.from / .to are glide_date.
+  const memberResponse = await client.get("/api/now/table/cmn_rota_member", {
+    params: {
+      sysparm_query: `rosterIN${rosterIds.join(",")}^from<=javascript:gs.beginningOfToday()^to>=javascript:gs.beginningOfToday()`,
+      sysparm_orderby: "order",
+      sysparm_limit: 5,
+    },
+  })
+
+  const memberRows = (memberResponse.data.result || []) as Array<Record<string, unknown>>
+  if (memberRows.length === 0) {
+    return createSuccessResult({
+      action: "get_current_oncall",
+      rotation: { sys_id: rotationSysId, name: rotation.name },
+      on_call: null,
+      message:
+        "No cmn_rota_member row covers the current date for this rotation. Note: full on-call resolution requires the OnCallRotation script include on the platform.",
+    })
+  }
+
+  const primary = memberRows[0]
   const memberRef = primary.member
   const memberSysId =
     typeof memberRef === "string"
@@ -262,45 +281,32 @@ async function executeGetCurrentOncall(args: Record<string, unknown>, context: S
         ? (memberRef as { value: string }).value
         : null
 
-  let member: Record<string, unknown> | null = null
+  // cmn_rota_member.member is the sys_user reference. Resolve the user record.
   let user: Record<string, unknown> | null = null
   if (memberSysId) {
-    const memberResponse = await client.get(`/api/now/table/cmn_rota_member/${memberSysId}`)
-    member = (memberResponse.data.result as Record<string, unknown>) ?? null
-
-    const userRef = member?.user
-    const userSysId =
-      typeof userRef === "string"
-        ? userRef
-        : userRef && typeof userRef === "object" && "value" in userRef
-          ? (userRef as { value: string }).value
-          : null
-    if (userSysId) {
-      const userResponse = await client.get(`/api/now/table/sys_user/${userSysId}`, {
-        params: { sysparm_fields: "sys_id,user_name,name,email,phone,active" },
-      })
-      user = (userResponse.data.result as Record<string, unknown>) ?? null
-    }
+    const userResponse = await client.get(`/api/now/table/sys_user/${memberSysId}`, {
+      params: { sysparm_fields: "sys_id,user_name,name,email,phone,active" },
+    })
+    user = (userResponse.data.result as Record<string, unknown>) ?? null
   }
 
   return createSuccessResult({
     action: "get_current_oncall",
     rotation: { sys_id: rotationSysId, name: rotation.name },
     on_call: {
-      roster_sys_id: primary.sys_id,
-      member: member
-        ? { sys_id: member.sys_id, order: member.order, escalation_step: member.escalation_step }
-        : null,
+      member_sys_id: primary.sys_id,
+      roster: primary.roster,
       user,
       window: {
-        start: primary.start_date_time,
-        end: primary.end_date_time,
+        from: primary.from,
+        to: primary.to,
       },
+      order: primary.order,
     },
-    additional_rosters: rosterRows.slice(1).map((r) => ({
-      roster_sys_id: r.sys_id,
-      start: r.start_date_time,
-      end: r.end_date_time,
+    additional_members: memberRows.slice(1).map((r) => ({
+      member_sys_id: r.sys_id,
+      from: r.from,
+      to: r.to,
     })),
   })
 }
@@ -322,29 +328,46 @@ async function executeListShifts(args: Record<string, unknown>, context: Service
 
   const rotationSysId = rotation.sys_id as string
 
-  // Default window: from now to now+7d, expressed as javascript: clauses so the
-  // server evaluates them in the instance's timezone.
-  const startClause = start_time ? `start_date_time>=${start_time}` : `start_date_time>=javascript:gs.nowDateTime()`
-  const endClause = end_time
-    ? `end_date_time<=${end_time}`
-    : `end_date_time<=javascript:gs.daysAgoEnd(-7)`
-
-  const response = await client.get("/api/now/table/cmn_rota_roster", {
+  // Per-shift coverage on cmn_rota lives on cmn_rota_member.from/.to (glide_date).
+  // First find the rotation's rosters, then list members whose window overlaps the requested range.
+  const rosterResp = await client.get("/api/now/table/cmn_rota_roster", {
     params: {
-      sysparm_query: `rota=${rotationSysId}^${startClause}^${endClause}`,
+      sysparm_query: `rota=${rotationSysId}^active=true`,
+      sysparm_limit: 50,
+      sysparm_fields: "sys_id",
+    },
+  })
+  const rosterIds = ((rosterResp.data.result || []) as Array<Record<string, unknown>>).map((r) => r.sys_id as string)
+  if (rosterIds.length === 0) {
+    return createSuccessResult({
+      action: "list_shifts",
+      rotation: { sys_id: rotationSysId, name: rotation.name },
+      window: { start: start_time || "now", end: end_time || "now + 7 days" },
+      count: 0,
+      shifts: [],
+    })
+  }
+
+  // Default window: from now to now+7d. Use beginningOfToday / daysAgoEnd(-7) for date semantics.
+  const fromClause = start_time ? `to>=${start_time}` : `to>=javascript:gs.beginningOfToday()`
+  const toClause = end_time ? `from<=${end_time}` : `from<=javascript:gs.daysAgoEnd(-7)`
+
+  const response = await client.get("/api/now/table/cmn_rota_member", {
+    params: {
+      sysparm_query: `rosterIN${rosterIds.join(",")}^${fromClause}^${toClause}`,
       sysparm_limit: limit,
-      sysparm_orderby: "start_date_time",
-      sysparm_fields: "sys_id,member,start_date_time,end_date_time,override,override_reason",
+      sysparm_orderby: "from",
+      sysparm_fields: "sys_id,member,roster,from,to,order",
     },
   })
 
   const shifts = ((response.data.result || []) as Array<Record<string, unknown>>).map((r) => ({
     sys_id: r.sys_id,
     member: r.member,
-    start_date_time: r.start_date_time,
-    end_date_time: r.end_date_time,
-    override: r.override,
-    override_reason: r.override_reason,
+    roster: r.roster,
+    from: r.from,
+    to: r.to,
+    order: r.order,
   }))
 
   return createSuccessResult({
@@ -372,11 +395,12 @@ async function executeSwapShift(args: Record<string, unknown>, context: ServiceN
 
   const client = await getAuthenticatedClient(context)
 
-  // Optional safety check: confirm the current member matches from_member_sys_id when provided.
-  const currentResponse = await client.get(`/api/now/table/cmn_rota_roster/${roster_sys_id}`)
+  // The swap target is a cmn_rota_member row (per-member window record), not cmn_rota_roster
+  // (which only holds rotation pattern data on this platform).
+  const currentResponse = await client.get(`/api/now/table/cmn_rota_member/${roster_sys_id}`)
   const current = currentResponse.data.result as Record<string, unknown> | undefined
   if (!current || !current.sys_id) {
-    return createErrorResult(`Roster row ${roster_sys_id} not found`)
+    return createErrorResult(`cmn_rota_member row ${roster_sys_id} not found`)
   }
 
   if (from_member_sys_id) {
@@ -389,30 +413,27 @@ async function executeSwapShift(args: Record<string, unknown>, context: ServiceN
           : null
     if (currentMemberId !== from_member_sys_id) {
       return createErrorResult(
-        `Current roster member (${currentMemberId}) does not match expected from_member_sys_id (${from_member_sys_id})`,
+        `Current member (${currentMemberId}) does not match expected from_member_sys_id (${from_member_sys_id})`,
       )
     }
   }
 
-  // Apply the swap. We mark the roster row as an override and record the reason.
-  // TODO: verify override/override_reason field names against a live instance.
-  const patchPayload: Record<string, unknown> = {
-    member: to_member_sys_id,
-    override: true,
-  }
-  if (reason) patchPayload.override_reason = reason
+  // cmn_rota_member only holds member, roster, from, to, order — there is no
+  // override or override_reason column. Just reassign the member.
+  const patchPayload: Record<string, unknown> = { member: to_member_sys_id }
 
-  const updateResponse = await client.patch(`/api/now/table/cmn_rota_roster/${roster_sys_id}`, patchPayload)
+  const updateResponse = await client.patch(`/api/now/table/cmn_rota_member/${roster_sys_id}`, patchPayload)
   const updated = updateResponse.data.result as Record<string, unknown>
 
   return createSuccessResult({
     action: "swap_shift",
     swapped: true,
-    roster_sys_id,
+    member_row_sys_id: roster_sys_id,
     previous_member: from_member_sys_id || current.member,
     new_member: to_member_sys_id,
-    roster: updated,
-    url: `${context.instanceUrl}/nav_to.do?uri=cmn_rota_roster.do?sys_id=${roster_sys_id}`,
+    reason: reason || null,
+    member_row: updated,
+    url: `${context.instanceUrl}/nav_to.do?uri=cmn_rota_member.do?sys_id=${roster_sys_id}`,
   })
 }
 

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_page_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_page_manage.ts
@@ -2,7 +2,7 @@
  * snow_sp_page_manage - Unified Service Portal page lifecycle management
  *
  * Manages sp_page records beyond initial creation: listing, updating, deleting,
- * cloning, and placing widget instances onto a page via sp_widget_instance.
+ * cloning, and placing widget instances onto a page via sp_instance.
  *
  * Companion to snow_create_sp_page (authoring) and snow_create_sp_widget
  * (widget authoring). This tool covers everything around an existing page.
@@ -14,14 +14,14 @@ import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_sp_page_manage",
-  description: `Unified tool for ServiceNow Service Portal page lifecycle beyond creation: list, update, delete, clone, add_widget_instance. Wraps sp_page and sp_widget_instance.
+  description: `Unified tool for ServiceNow Service Portal page lifecycle beyond creation: list, update, delete, clone, add_widget_instance. Wraps sp_page and sp_instance.
 
 Actions:
 - list — list sp_page rows, optionally filtered by portal id, public flag, or title fragment
 - update — patch sp_page fields (title, public, draft, css, internal)
 - delete — delete an sp_page row (does not cascade widget instances)
 - clone — duplicate an sp_page with a new id and title (optionally copying widget instances)
-- add_widget_instance — place an sp_widget on the page by creating an sp_widget_instance row
+- add_widget_instance — place an sp_widget on the page by creating an sp_instance row
 
 Use when: the agent needs to maintain Service Portal pages — renaming, retiring, duplicating layouts, or wiring widgets onto a page. For authoring a new sp_page, use snow_create_sp_page; for authoring a new sp_widget, use snow_create_sp_widget.
 
@@ -102,7 +102,7 @@ Returns: sp_page rows with sys_id, id, title, public, draft; widget instance row
       },
       copy_widget_instances: {
         type: "boolean",
-        description: "[clone] Also copy sp_widget_instance rows attached to the source page",
+        description: "[clone] Also copy sp_instance rows attached to the source page",
         default: true,
       },
       // ADD_WIDGET_INSTANCE
@@ -359,24 +359,56 @@ async function executeClone(args: Record<string, unknown>, context: ServiceNowCo
 
   const copiedInstances: string[] = []
   if (copy_widget_instances) {
-    // TODO: verify sp_widget_instance.sp_page column name on a live instance.
-    // Older Glide releases sometimes route widget instances through sp_column;
-    // we attempt the direct sp_page query first and fall through quietly on error.
+    // sp_instance has no sp_page reference — instances belong to sp_column rows
+    // which in turn belong to sp_row → sp_page. Walk the layout tree and clone
+    // rows + columns + instances under the new page.
     try {
-      const instances = await client.get("/api/now/table/sp_widget_instance", {
+      const sourceRows = await client.get("/api/now/table/sp_row", {
         params: { sysparm_query: `sp_page=${sourceSysId}`, sysparm_limit: 200 },
       })
-      for (const inst of (instances.data.result || []) as Array<Record<string, unknown>>) {
-        const copy: Record<string, unknown> = { ...inst }
-        delete copy.sys_id
-        delete copy.sys_created_on
-        delete copy.sys_created_by
-        delete copy.sys_updated_on
-        delete copy.sys_updated_by
-        delete copy.sys_mod_count
-        copy.sp_page = clonedSysId
-        const created = await client.post("/api/now/table/sp_widget_instance", copy)
-        copiedInstances.push(created.data.result.sys_id)
+      for (const row of (sourceRows.data.result || []) as Array<Record<string, unknown>>) {
+        const rowCopy: Record<string, unknown> = { ...row }
+        delete rowCopy.sys_id
+        delete rowCopy.sys_created_on
+        delete rowCopy.sys_created_by
+        delete rowCopy.sys_updated_on
+        delete rowCopy.sys_updated_by
+        delete rowCopy.sys_mod_count
+        rowCopy.sp_page = clonedSysId
+        const newRow = await client.post("/api/now/table/sp_row", rowCopy)
+        const newRowSysId = newRow.data.result.sys_id as string
+
+        const cols = await client.get("/api/now/table/sp_column", {
+          params: { sysparm_query: `sp_row=${row.sys_id}`, sysparm_limit: 50 },
+        })
+        for (const col of (cols.data.result || []) as Array<Record<string, unknown>>) {
+          const colCopy: Record<string, unknown> = { ...col }
+          delete colCopy.sys_id
+          delete colCopy.sys_created_on
+          delete colCopy.sys_created_by
+          delete colCopy.sys_updated_on
+          delete colCopy.sys_updated_by
+          delete colCopy.sys_mod_count
+          colCopy.sp_row = newRowSysId
+          const newCol = await client.post("/api/now/table/sp_column", colCopy)
+          const newColSysId = newCol.data.result.sys_id as string
+
+          const instances = await client.get("/api/now/table/sp_instance", {
+            params: { sysparm_query: `sp_column=${col.sys_id}`, sysparm_limit: 50 },
+          })
+          for (const inst of (instances.data.result || []) as Array<Record<string, unknown>>) {
+            const instCopy: Record<string, unknown> = { ...inst }
+            delete instCopy.sys_id
+            delete instCopy.sys_created_on
+            delete instCopy.sys_created_by
+            delete instCopy.sys_updated_on
+            delete instCopy.sys_updated_by
+            delete instCopy.sys_mod_count
+            instCopy.sp_column = newColSysId
+            const created = await client.post("/api/now/table/sp_instance", instCopy)
+            copiedInstances.push(created.data.result.sys_id)
+          }
+        }
       }
     } catch {
       // Best-effort — fall through. Caller still gets the cloned page.
@@ -426,20 +458,22 @@ async function executeAddWidgetInstance(
     return createErrorResult(`sp_widget not found: ${widget_id}`)
   }
 
-  // TODO: verify sp_widget_instance field set on a live instance. The
-  // canonical fields are sp_widget (reference) and sp_column (reference).
-  // If column_sys_id is omitted the instance is attached directly to the
-  // page via sp_page; whether that column-less placement is supported on
-  // older Glide releases varies.
+  // sp_instance has no sp_page column — widget instances are placed on a
+  // sp_column (which belongs to a sp_row, which belongs to the sp_page).
+  // column_sys_id is therefore required to attach the instance correctly.
+  if (!column_sys_id) {
+    return createErrorResult(
+      "column_sys_id is required for add_widget_instance — widget instances live on sp_column rows, not directly on sp_page",
+    )
+  }
   const payload: Record<string, unknown> = {
     sp_widget: widget.sys_id,
-    sp_page: page.sys_id,
+    sp_column: column_sys_id,
   }
-  if (column_sys_id) payload.sp_column = column_sys_id
   if (instance_title) payload.title = instance_title
   if (order !== undefined) payload.order = order
 
-  const response = await client.post("/api/now/table/sp_widget_instance", payload)
+  const response = await client.post("/api/now/table/sp_instance", payload)
   const result = response.data.result as Record<string, unknown>
 
   return createSuccessResult({

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_theme_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/service-portal/snow_sp_theme_manage.ts
@@ -216,17 +216,18 @@ async function executeListThemes(args: Record<string, unknown>, context: Service
 
   const themes = (response.data.result || []) as Array<Record<string, unknown>>
 
-  // Annotate each theme with its sp_css child count (best-effort)
+  // Annotate each theme with its sp_css child count (best-effort).
+  // sp_css has no direct theme reference; the link goes via the m2m_sp_theme_css_include table.
   const enriched: Array<Record<string, unknown>> = []
   for (const theme of themes) {
     let cssCount = 0
     try {
-      const cssResp = await client.get("/api/now/table/sp_css", {
-        params: { sysparm_query: `theme=${theme.sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 100 },
+      const cssResp = await client.get("/api/now/table/m2m_sp_theme_css_include", {
+        params: { sysparm_query: `sp_theme=${theme.sys_id}`, sysparm_fields: "sys_id", sysparm_limit: 100 },
       })
       cssCount = (cssResp.data.result || []).length
     } catch {
-      // best-effort
+      // best-effort — older releases may name the m2m table or columns differently
     }
     enriched.push({
       sys_id: theme.sys_id,
@@ -234,7 +235,7 @@ async function executeListThemes(args: Record<string, unknown>, context: Service
       header: theme.header,
       footer: theme.footer,
       css_variables: theme.css_variables,
-      sp_css_count: cssCount,
+      css_include_count: cssCount,
       updated_at: theme.sys_updated_on,
       url: `${context.instanceUrl}/nav_to.do?uri=sp_theme.do?sys_id=${theme.sys_id}`,
     })
@@ -293,43 +294,38 @@ async function executeUpdateBranding(args: Record<string, unknown>, context: Ser
 
   const portalSysId = portal.sys_id as string
 
-  // TODO: verify against live instance — sp_brand carries portal-specific
-  // branding overrides. The link column is commonly `portal`; on some
-  // releases it is `sp_portal`. We attempt to read the existing row and
-  // patch it; otherwise we insert.
-  const brandPayload: Record<string, unknown> = { portal: portalSysId }
-  if (args.logo !== undefined) brandPayload.logo = args.logo
-  if (args.favicon !== undefined) brandPayload.favicon = args.favicon
-  if (args.primary_color !== undefined) brandPayload.primary_color = args.primary_color
-  if (args.secondary_color !== undefined) brandPayload.secondary_color = args.secondary_color
-  if (args.brand_name !== undefined) brandPayload.name = args.brand_name
-
-  const existingBrand = await client.get("/api/now/table/sp_brand", {
-    params: { sysparm_query: `portal=${portalSysId}`, sysparm_limit: 1, sysparm_fields: "sys_id" },
-  })
-  const existingRows = (existingBrand.data.result || []) as Array<Record<string, unknown>>
-
-  let brand: Record<string, unknown>
-  let mode: "inserted" | "patched"
-
-  if (existingRows.length > 0) {
-    mode = "patched"
-    const brandSysId = existingRows[0].sys_id as string
-    const updResp = await client.patch(`/api/now/table/sp_brand/${brandSysId}`, brandPayload)
-    brand = updResp.data.result
-  } else {
-    mode = "inserted"
-    const insResp = await client.post("/api/now/table/sp_brand", brandPayload)
-    brand = insResp.data.result
+  // sp_brand is not present on most ServiceNow releases — branding fields live
+  // directly on sp_portal (logo, css_variables, title, ...). Patch the portal row
+  // with the supplied branding overrides.
+  const portalPatch: Record<string, unknown> = {}
+  if (args.logo !== undefined) portalPatch.logo = args.logo
+  if (args.brand_name !== undefined) portalPatch.title = args.brand_name
+  // Roll primary/secondary color hints into css_variables when supplied alongside
+  // any existing tokens, so theme stylesheets can pick them up.
+  const colorTokens: string[] = []
+  if (args.primary_color !== undefined) colorTokens.push(`--brand-primary: ${args.primary_color};`)
+  if (args.secondary_color !== undefined) colorTokens.push(`--brand-secondary: ${args.secondary_color};`)
+  if (args.favicon !== undefined) colorTokens.push(`/* favicon: ${args.favicon} */`)
+  if (colorTokens.length > 0) {
+    const existing = (portal.css_variables as string) || ""
+    portalPatch.css_variables = existing ? `${existing}\n${colorTokens.join("\n")}` : colorTokens.join("\n")
   }
+
+  if (Object.keys(portalPatch).length === 0) {
+    return createErrorResult("No branding fields supplied (logo, favicon, primary_color, secondary_color, brand_name)")
+  }
+
+  const updResp = await client.patch(`/api/now/table/sp_portal/${portalSysId}`, portalPatch)
+  const updatedPortal = updResp.data.result as Record<string, unknown>
 
   return createSuccessResult({
     action: "update_branding",
-    mode,
-    portal: { sys_id: portalSysId, title: portal.title, url_suffix: portal.url_suffix },
-    sys_id: brand.sys_id,
-    brand,
-    url: `${context.instanceUrl}/nav_to.do?uri=sp_brand.do?sys_id=${brand.sys_id}`,
+    mode: "patched",
+    portal: { sys_id: portalSysId, title: updatedPortal.title, url_suffix: updatedPortal.url_suffix },
+    sys_id: portalSysId,
+    portal_record: updatedPortal,
+    note: "Branding written to sp_portal (sp_brand is not a standard ServiceNow table). favicon is recorded as a comment in css_variables only.",
+    url: `${context.instanceUrl}/nav_to.do?uri=sp_portal.do?sys_id=${portalSysId}`,
   })
 }
 
@@ -371,14 +367,16 @@ async function executeCloneTheme(args: Record<string, unknown>, context: Service
   const newThemeResp = await client.post("/api/now/table/sp_theme", themePayload)
   const newTheme = newThemeResp.data.result as Record<string, unknown>
 
-  // Copy sp_css children if requested
+  // Copy sp_css includes if requested. The link from sp_theme to sp_css is the
+  // m2m_sp_theme_css_include join table — copy the join rows (pointing at the same
+  // sp_css rows) instead of duplicating the CSS rows themselves.
   const copiedCss: Array<Record<string, unknown>> = []
   if (copyCss) {
     try {
-      const cssResp = await client.get("/api/now/table/sp_css", {
-        params: { sysparm_query: `theme=${source.sys_id}`, sysparm_limit: 200 },
+      const linkResp = await client.get("/api/now/table/m2m_sp_theme_css_include", {
+        params: { sysparm_query: `sp_theme=${source.sys_id}`, sysparm_limit: 200 },
       })
-      const rows = (cssResp.data.result || []) as Array<Record<string, unknown>>
+      const rows = (linkResp.data.result || []) as Array<Record<string, unknown>>
       for (const row of rows) {
         const payload: Record<string, unknown> = {}
         for (const [key, value] of Object.entries(row)) {
@@ -386,12 +384,12 @@ async function executeCloneTheme(args: Record<string, unknown>, context: Service
           if (value === null || value === undefined) continue
           payload[key] = value
         }
-        payload.theme = newTheme.sys_id
-        const inserted = await client.post("/api/now/table/sp_css", payload)
-        copiedCss.push({ sys_id: inserted.data.result.sys_id, name: inserted.data.result.name })
+        payload.sp_theme = newTheme.sys_id
+        const inserted = await client.post("/api/now/table/m2m_sp_theme_css_include", payload)
+        copiedCss.push({ sys_id: inserted.data.result.sys_id })
       }
     } catch {
-      // sp_css copy is best-effort; the new theme still exists even if children fail
+      // m2m copy is best-effort; the new theme still exists even if includes fail
     }
   }
 


### PR DESCRIPTION
## Summary

Audited 15 newly-built MCP tools against a live ServiceNow PDI by reading
`sys_dictionary` for each primary table. Fixed schema misassumptions where
the correct ServiceNow column had an obvious replacement.

## Per-tool changes

- `snow_pa_indicator_manage` (pa_indicators) — replaced fabricated
  `facts_table`/`active` with the real `cube`/`script`/`formula`; added the
  three mandatory integers (`precision`, `forecast_base_periods`,
  `forecast_periods`) with sensible defaults so create succeeds; fixed
  the join from non-existent `pa_breakdowns_indicator` to the real
  `pa_indicator_breakdowns`; fixed `pa_breakdowns.table` → `facts_table`.
- `snow_oncall_manage` — removed cmn_rota fields that don't exist
  (`time_zone`, `start_date`, `end_date`); fixed `cmn_rota_member.user` →
  `.member` (the real sys_user reference); reworked
  current-oncall/list-shifts/swap-shift to read per-member windows from
  `cmn_rota_member.from`/`.to` instead of the non-existent
  `cmn_rota_roster.start_date_time`/`.end_date_time`.
- `snow_fsm_work_order_manage` — switched the wm_task join from inherited
  `parent` to the direct `wm_task.work_order` reference; updated the
  history join to the standard `work_order` column.
- `snow_job_status` — fixed sys_trigger error query from non-existent
  `last_action_message` to the real `last_error`/`error_count`; remapped
  sys_progress_worker and sys_execution_tracker to their real columns
  (state_code/message/error_message/output_summary/queued_time/total_run_time
  on worker; start_time/completion_time/percent_complete/detail_message on
  tracker) instead of fabricated start_time/end_time/progress_percent.
- `snow_catalog_manage` — added `homepage_renderer` schema field with a
  clear "mandatory on sc_category" description so create_category succeeds.
- `snow_approval_chain_manage` — fixed the state value `not_yet_requested`
  → `not requested` (with space) in every payload and stateIN filter,
  matching the real sys_choice value.
- `snow_sp_theme_manage` — removed the assumption that `sp_brand` exists
  (it isn't a stock ServiceNow table) and rewrote `update_branding` to
  write logo/brand_name/colour tokens directly to `sp_portal`; fixed
  clone_theme and the css count lookup to walk `m2m_sp_theme_css_include`
  instead of the non-existent `sp_css.theme` reference.
- `snow_report_manage` — replaced non-existent `sys_report_schedule` with
  the real `sysauto_report`; replaced `sys_report_users_view` with the
  real `sys_report_users_groups` (using its `report_id`/`user_id`/`group_id`
  columns); fixed sysauto_report recipient handling — the real columns are
  `user_list`/`group_list`/`address_list`, not `email_list`. The tool now
  splits supplied recipients into user sys_ids vs plain addresses.
- `snow_dashboard_manage` — dropped the non-existent
  `owner`/`title`/`description` projection (sys_dashboard only has
  name/columns/rows/cell_*/roles/active); rewired the owner filter through
  sys_dashboard_admin where ownership actually lives; fixed find by title
  to query `name`.
- `snow_sp_page_manage` — fixed the non-existent `sp_widget_instance` table
  to the real `sp_instance` everywhere; `add_widget_instance` now requires
  `column_sys_id` because sp_instance has no sp_page reference; clone now
  walks sp_row → sp_column → sp_instance to reproduce the layout.
- `snow_email_template_manage` — removed the non-existent `active` and
  `content_type` fields from the default field projection and from the
  list filter (sysevent_email_template has neither).
- `snow_csm_communication_manage` — removed the non-existent
  `interaction.account` and `interaction.contact` filters (those columns
  exist only on plugin-extended children) and folded them into `opened_for`
  as a base-table fallback; fixed interaction_related_record column names
  from `related_record_table`/`related_record` to the real
  `document_table`/`document_id`; added the mandatory `interaction.type`
  field with a channel→type mapping so log_interaction passes server
  validation.

The three tools whose primary tables aren't on this PDI
(`snow_fsm_dispatch_manage` / wm_agent, `snow_fsm_parts_manage` / pc_part,
`snow_csm_contract_manage` / service_contract) were not audited beyond
table-existence and are unchanged. `snow_fsm_work_order_manage` was the
one tool whose core schema turned out to be already accurate (the
fixes above are minor join-column adjustments, not column renames).

## Test plan

- [x] `bun packages/opencode/script/generate-tools-json.ts` — 0 failed imports, 428 tools, 133 subcategories
- [x] Each rewritten field name verified against `sys_dictionary` on dev380262.service-now.com
- [x] State value `not requested` confirmed against live `sys_choice` for sysapproval_approver
- [x] Mandatory-field defaults verified by reading `mandatory=true` rows on each primary table
- [ ] Manual smoke test of each fixed tool against an instance with the relevant plugin (deferred — depends on plugin availability per instance)

Audited against dev380262.service-now.com via OAuth client_credentials;
1 tool confirmed accurate, 12 tools fixed, 3 tools required plugins not installed.

Fixes #132