### PR TITLE
fix(opencode): correct snow_hr_profile_manage field assumptions and drop non-existent relation actions

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_profile_manage.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/hr/snow_hr_profile_manage.ts
@@ -1,9 +1,8 @@
 /**
- * snow_hr_profile_manage - Unified HR profile and relation management
+ * snow_hr_profile_manage - Unified HR profile management
  *
- * Wraps the HRSD employee profile surface: sn_hr_core_profile (canonical
- * employee record consumed by every HR case) and sn_hr_core_user_relation
- * (manager/report and other relationships).
+ * Wraps the HRSD employee profile surface: sn_hr_core_profile, the canonical
+ * employee record consumed by every HR case.
  *
  * Companion to snow_create_hr_case and snow_create_hr_task — those tools
  * open work against an employee, and this tool maintains the underlying
@@ -18,13 +17,11 @@ import { createSuccessResult, createErrorResult, SnowFlowError, ErrorType } from
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_hr_profile_manage",
-  description: `Unified tool for ServiceNow HR employee profiles (sn_hr_core_profile) and the user relations that connect them (sn_hr_core_user_relation).
+  description: `Unified tool for ServiceNow HR employee profiles (sn_hr_core_profile). Searches join through profile.user reference for sys_user fields (department, email, active).
 
 Actions:
 - get_profile — fetch a profile by sys_id, user sys_id, or employee_number
-- update_profile — patch profile fields (department, location, manager, employee_number, job_title)
-- list_relations — list relationships for a profile (manager, direct reports, dotted-line, etc.)
-- add_relation — create a relationship between two profiles (e.g. manager -> report)
+- update_profile — patch profile fields (employment_type, position, primary_job, location, personal_email, work_mobile, mobile_phone, im_name)
 - search_employees — search profiles by name, email, department, or employee_number
 
 Use when: the agent needs to read or maintain the canonical employee record used across all HR cases. Companion tools: snow_create_hr_case (opens HR tickets against a profile), snow_create_hr_task (creates task work on a case), snow_hr_lifecycle_event (drives onboarding/offboarding flows).
@@ -32,7 +29,7 @@ Use when: the agent needs to read or maintain the canonical employee record used
 Requires the HR Core plugin (com.sn_hr_core). When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.`,
   category: "itsm",
   subcategory: "hr",
-  use_cases: ["hr-service-delivery", "employee-profile", "hr-relations", "hr-core"],
+  use_cases: ["hr-service-delivery", "employee-profile", "hr-core"],
   complexity: "intermediate",
   frequency: "medium",
   permission: "write",
@@ -43,12 +40,12 @@ Requires the HR Core plugin (com.sn_hr_core). When the plugin is missing the und
       action: {
         type: "string",
         description: "Management action to perform",
-        enum: ["get_profile", "update_profile", "list_relations", "add_relation", "search_employees"],
+        enum: ["get_profile", "update_profile", "search_employees"],
       },
       // Identification
       sys_id: {
         type: "string",
-        description: "[get_profile/update_profile/list_relations/add_relation] Profile sys_id",
+        description: "[get_profile/update_profile] Profile sys_id",
       },
       user: {
         type: "string",
@@ -58,59 +55,66 @@ Requires the HR Core plugin (com.sn_hr_core). When the plugin is missing the und
         type: "string",
         description: "[get_profile/search_employees/update_profile] Employee number (alternative to sys_id)",
       },
-      // UPDATE fields (canonical platform fields only)
-      department: {
+      // UPDATE fields (real columns on sn_hr_core_profile)
+      employment_type: {
         type: "string",
-        description: "[update_profile] cmn_department sys_id",
+        description: "[update_profile] Employment type (e.g. full_time, part_time, contractor)",
+      },
+      position: {
+        type: "string",
+        description: "[update_profile] sn_hr_core_position sys_id",
+      },
+      primary_job: {
+        type: "string",
+        description: "[update_profile] sn_hr_core_job sys_id",
       },
       location: {
         type: "string",
         description: "[update_profile] cmn_location sys_id",
       },
-      manager: {
+      personal_email: {
         type: "string",
-        description: "[update_profile] Manager profile sys_id",
+        description: "[update_profile] Personal email address",
       },
-      job_title: {
+      work_mobile: {
         type: "string",
-        description: "[update_profile] Job title (free-text)",
+        description: "[update_profile] Work mobile phone number",
       },
-      employment_status: {
+      mobile_phone: {
         type: "string",
-        description: "[update_profile] Employment status (e.g. active, leave_of_absence, terminated)",
+        description: "[update_profile] Mobile phone number",
       },
-      // RELATION fields
-      related_profile: {
+      im_name: {
         type: "string",
-        description: "[add_relation] sys_id of the related sn_hr_core_profile",
-      },
-      relation_type: {
-        type: "string",
-        description: "[add_relation/list_relations] Relation type label (manager, direct_report, dotted_line, etc.)",
+        description: "[update_profile] Instant-message / display name",
       },
       // SEARCH fields
       name: {
         type: "string",
-        description: "[search_employees] Substring match against the profile's name/full_name",
+        description: "[search_employees] Substring match against legal_first_name and im_name (OR'd)",
       },
       email: {
         type: "string",
-        description: "[search_employees] Email substring match (joins through sys_user)",
+        description: "[search_employees] Email substring match (dot-walks through user.email on sys_user)",
+      },
+      department: {
+        type: "string",
+        description: "[search_employees] Department substring match (dot-walks through user.department on sys_user)",
       },
       // Listing
       active_only: {
         type: "boolean",
-        description: "[search_employees/list_relations] Only return active records",
+        description: "[search_employees] Only return profiles whose linked sys_user is active",
         default: true,
       },
       limit: {
         type: "number",
-        description: "[search_employees/list_relations] Maximum records to return",
+        description: "[search_employees] Maximum records to return",
         default: 50,
       },
       fields: {
         type: "string",
-        description: "[get_profile/search_employees/list_relations] Comma-separated list of fields to return",
+        description: "[get_profile/search_employees] Comma-separated list of fields to return",
       },
     },
     required: ["action"],
@@ -118,7 +122,6 @@ Requires the HR Core plugin (com.sn_hr_core). When the plugin is missing the und
 }
 
 const PROFILE_TABLE = "sn_hr_core_profile"
-const RELATION_TABLE = "sn_hr_core_user_relation"
 
 export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
   const action = args.action as string
@@ -129,15 +132,11 @@ export async function execute(args: Record<string, unknown>, context: ServiceNow
         return await executeGetProfile(args, context)
       case "update_profile":
         return await executeUpdateProfile(args, context)
-      case "list_relations":
-        return await executeListRelations(args, context)
-      case "add_relation":
-        return await executeAddRelation(args, context)
       case "search_employees":
         return await executeSearchEmployees(args, context)
       default:
         return createErrorResult(
-          `Unknown action: ${action}. Valid actions: get_profile, update_profile, list_relations, add_relation, search_employees`,
+          `Unknown action: ${action}. Valid actions: get_profile, update_profile, search_employees`,
         )
     }
   } catch (error: unknown) {
@@ -225,17 +224,28 @@ async function executeUpdateProfile(args: Record<string, unknown>, context: Serv
     return createErrorResult(`Profile not found: ${args.sys_id || args.user || args.employee_number}`)
   }
 
-  // Canonical platform fields only. Customer-specific custom fields are intentionally
-  // not exposed — agents should add them through a follow-up table-update call.
-  // TODO: verify if customer has custom field overrides for sn_hr_core_profile.
-  const updatable = ["department", "location", "manager", "job_title", "employment_status"]
+  // Real columns on sn_hr_core_profile (verified against sys_dictionary on a live HRSD instance).
+  // Customer-specific custom fields are intentionally not exposed — agents should add them
+  // through a follow-up table-update call.
+  const updatable = [
+    "employment_type",
+    "position",
+    "primary_job",
+    "location",
+    "personal_email",
+    "work_mobile",
+    "mobile_phone",
+    "im_name",
+  ]
   const patch: Record<string, unknown> = {}
   for (const key of updatable) {
     if (args[key] !== undefined) patch[key] = args[key]
   }
 
   if (Object.keys(patch).length === 0) {
-    return createErrorResult("No update fields provided. Valid: department, location, manager, job_title, employment_status")
+    return createErrorResult(
+      "No update fields provided. Valid: employment_type, position, primary_job, location, personal_email, work_mobile, mobile_phone, im_name",
+    )
   }
 
   const targetSysId = profile.sys_id as string
@@ -249,77 +259,6 @@ async function executeUpdateProfile(args: Record<string, unknown>, context: Serv
     updated_fields: Object.keys(patch),
     profile: updated,
     url: `${context.instanceUrl}/nav_to.do?uri=${PROFILE_TABLE}.do?sys_id=${targetSysId}`,
-  })
-}
-
-// ==================== LIST_RELATIONS ====================
-
-async function executeListRelations(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
-  const sys_id = args.sys_id as string | undefined
-  const relation_type = args.relation_type as string | undefined
-  const active_only = args.active_only !== false
-  const limit = (args.limit as number) || 50
-  const fields = args.fields as string | undefined
-
-  if (!sys_id) return createErrorResult("sys_id (profile) is required for list_relations")
-
-  const client = await getAuthenticatedClient(context)
-
-  // Relations are stored bidirectionally — match either side of the relation.
-  // TODO: verify column names on sn_hr_core_user_relation (commonly `user` and `related_user`,
-  // or `profile` and `related_profile` depending on the HRSD release).
-  const queryParts = [`userPROFILE${sys_id}^ORrelated_userPROFILE${sys_id}`.replace(/PROFILE/g, "=")]
-  if (relation_type) queryParts.push(`type=${relation_type}`)
-  if (active_only) queryParts.push("active=true")
-
-  const response = await client.get(`/api/now/table/${RELATION_TABLE}`, {
-    params: {
-      sysparm_query: queryParts.join("^"),
-      sysparm_limit: limit,
-      ...(fields ? { sysparm_fields: fields } : { sysparm_fields: "sys_id,user,related_user,type,active" }),
-    },
-  })
-
-  const results = (response.data.result || []) as Array<Record<string, unknown>>
-  return createSuccessResult({
-    action: "list_relations",
-    profile_sys_id: sys_id,
-    count: results.length,
-    relations: results,
-  })
-}
-
-// ==================== ADD_RELATION ====================
-
-async function executeAddRelation(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
-  const sys_id = args.sys_id as string | undefined
-  const related_profile = args.related_profile as string | undefined
-  const relation_type = args.relation_type as string | undefined
-
-  if (!sys_id) return createErrorResult("sys_id is required for add_relation")
-  if (!related_profile) return createErrorResult("related_profile is required for add_relation")
-  if (!relation_type) return createErrorResult("relation_type is required for add_relation")
-
-  const client = await getAuthenticatedClient(context)
-
-  // TODO: verify exact column names — older HRSD releases use `user` and `related_user`,
-  // newer releases sometimes use `profile`/`related_profile`. Try the canonical pair first.
-  const payload: Record<string, unknown> = {
-    user: sys_id,
-    related_user: related_profile,
-    type: relation_type,
-    active: true,
-  }
-
-  const response = await client.post(`/api/now/table/${RELATION_TABLE}`, payload)
-  const created = response.data.result as Record<string, unknown>
-
-  return createSuccessResult({
-    action: "add_relation",
-    created: true,
-    sys_id: created.sys_id,
-    relation: created,
-    url: `${context.instanceUrl}/nav_to.do?uri=${RELATION_TABLE}.do?sys_id=${created.sys_id}`,
   })
 }
 
@@ -341,11 +280,13 @@ async function executeSearchEmployees(args: Record<string, unknown>, context: Se
   const client = await getAuthenticatedClient(context)
 
   const queryParts: string[] = []
-  if (name) queryParts.push(`nameLIKE${name}`)
+  // sn_hr_core_profile has no `name` column; the tool searches the two real name fields OR'd.
+  if (name) queryParts.push(`legal_first_nameLIKE${name}^ORim_nameLIKE${name}`)
+  // Dot-walk through the user reference for sys_user-side fields (email, department, active).
   if (email) queryParts.push(`user.emailLIKE${email}`)
   if (employee_number) queryParts.push(`employee_number=${employee_number}`)
-  if (department) queryParts.push(`department=${department}`)
-  if (active_only) queryParts.push("active=true")
+  if (department) queryParts.push(`user.departmentLIKE${department}`)
+  if (active_only) queryParts.push("user.active=true")
 
   const response = await client.get(`/api/now/table/${PROFILE_TABLE}`, {
     params: {
@@ -353,7 +294,10 @@ async function executeSearchEmployees(args: Record<string, unknown>, context: Se
       sysparm_limit: limit,
       ...(fields
         ? { sysparm_fields: fields }
-        : { sysparm_fields: "sys_id,user,employee_number,name,department,location,job_title,active" }),
+        : {
+            sysparm_fields:
+              "sys_id,user,employee_number,legal_first_name,im_name,personal_email,location,position,primary_job",
+          }),
     },
   })
 
@@ -365,15 +309,16 @@ async function executeSearchEmployees(args: Record<string, unknown>, context: Se
       sys_id: r.sys_id,
       user: r.user,
       employee_number: r.employee_number,
-      name: r.name,
-      department: r.department,
+      legal_first_name: r.legal_first_name,
+      im_name: r.im_name,
+      personal_email: r.personal_email,
       location: r.location,
-      job_title: r.job_title,
-      active: r.active,
+      position: r.position,
+      primary_job: r.primary_job,
       url: `${context.instanceUrl}/nav_to.do?uri=${PROFILE_TABLE}.do?sys_id=${r.sys_id}`,
     })),
   })
 }
 
-export const version = "1.0.0"
+export const version = "1.1.0"
 export const author = "groeimetai"


### PR DESCRIPTION
Live audit against an HRSD-enabled instance (`com.sn_hr_core` active) found that `snow_hr_profile_manage` was written against assumed `sn_hr_core_profile` columns and a non-existent `sn_hr_core_user_relation` table. Half the columns the tool referenced do not exist; the relation table is fictional (sys_db_object lookup returns nothing).

## Dropped actions

- `list_relations` and `add_relation`: target `sn_hr_core_user_relation`, which does not exist on any HRSD release. HRSD models org structure via `sys_user.manager` and dependents via `sn_hr_core_who_is_covered`.
- Removed `RELATION_TABLE`, both `execute*` functions, and the `related_profile` / `relation_type` input properties.
- Action enum reduced 5 -> 3 (`get_profile`, `update_profile`, `search_employees`).

## search_employees field mapping

Old query returned HTTP 403 "Field(s) present in the query do not have permission to be read" against the live instance — ServiceNow's signal that the columns don't exist on `sn_hr_core_profile`.

| arg | before | after |
| --- | --- | --- |
| `name` | `nameLIKE` | `legal_first_nameLIKE^ORim_nameLIKE` |
| `department` | `department=` | `user.departmentLIKE` (dot-walked) |
| `active_only` | `active=true` | `user.active=true` (dot-walked) |
| `email` | `user.emailLIKE` | unchanged (was correct) |
| `employee_number` | `employee_number=` | unchanged (was correct) |

Default `sysparm_fields` swapped from `sys_id,user,employee_number,name,department,location,job_title,active` to `sys_id,user,employee_number,legal_first_name,im_name,personal_email,location,position,primary_job` (all verified via `sys_dictionary`). The result-mapping in `employees` uses the same set.

## update_profile field mapping

Of the previous `updatable` list, only `location` actually exists; the other four were silently no-ops.

| before | after |
| --- | --- |
| department, location, manager, job_title, employment_status | employment_type, position, primary_job, location, personal_email, work_mobile, mobile_phone, im_name |

Input-schema property descriptions updated to match.

## Other

- Description / `use_cases` drop the relations references; lead paragraph notes that searches dot-walk through `profile.user`.
- Two stale TODO markers removed (resolved live).
- `version` bump 1.0.0 -> 1.1.0 (action enum is technically narrower).

## Live tests

Read-only, against `dev380262.service-now.com`:

- `search_employees` `name=charlie` -> HTTP 200, empty result (no records in dev instance, but query parses).
- `search_employees` `email=@example.com` -> HTTP 200, empty result.
- `get_profile` with bogus `employee_number` -> "Profile not found" (correct).
- `update_profile` validation paths fire on missing identifier / missing fields.
- Old query against `nameLIKE^active=true` -> HTTP 403 (confirms fields are bogus).
- Dropped actions (`list_relations`, `add_relation`) -> "Unknown action" rejection.

`bun packages/opencode/script/generate-tools-json.ts`: 0 failures, action enum reduced to 3.

Fixes #140