### PR TITLE
fix(e2e): unblock the Windows e2e job (share flag + seed exit)

### DIFF
--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -15,7 +15,11 @@ export namespace ShareNext {
     return Config.get().then((x) => x.enterprise?.url ?? "https://opncd.ai")
   }
 
-  const disabled = process.env["OPENCODE_DISABLE_SHARE"] === "true" || process.env["OPENCODE_DISABLE_SHARE"] === "1"
+  const disabled =
+    process.env["SNOW_CODE_DISABLE_SHARE"] === "true" ||
+    process.env["SNOW_CODE_DISABLE_SHARE"] === "1" ||
+    process.env["OPENCODE_DISABLE_SHARE"] === "true" ||
+    process.env["OPENCODE_DISABLE_SHARE"] === "1"
 
   const shareNextUnsubs: (() => void)[] = []
   export async function init() {


### PR DESCRIPTION
## Summary
Two coupled fixes to get the Windows `bun test:e2e:local` job green again. The second only becomes visible once the first is in place.

### 1. `share-next.ts` — honor `SNOW_CODE_DISABLE_SHARE`
`share-next.ts:18` still checked **only** the legacy `OPENCODE_DISABLE_SHARE`, while CI (and `share.ts:80-83`) moved to `SNOW_CODE_DISABLE_SHARE`. So on CI the share listener stayed enabled, subscribed to `message.updated`, and called `Provider.getModel("opencode", "gpt-5-nano")` on the seeded user message. CI has no `OPENCODE_API_KEY`, so the `opencode` provider filters out paid models (provider.ts:246-251) and `gpt-5-nano` isn't there → `ProviderModelNotFoundError` → seed exits 1. Fix matches the dual-name check already in `share.ts`.

### 2. `seed-e2e.ts` — exit explicitly after seeding
With the crash gone, the job then hung for its full 30-minute budget. `seed-e2e.ts` never called `process.exit`; it relied on the event loop draining. The bootstrapped instance keeps handles open (vcs, scheduler, file-watcher subscriptions) so on Windows it never drains, `bun script/seed-e2e.ts` never exits, and `e2e-local.ts` blocks forever on `await seed.exited`. All storage writes are already awaited/flushed, so we `Instance.disposeAll()` + `process.exit(0)` when done. The crash in #1 had been masking this hang.

## Test plan
- [ ] Windows matrix in `test.yml` gets past seed and runs Playwright (was: ProviderModelNotFoundError, then 30-min hang)
- [ ] Linux matrix stays green — the standalone `Seed opencode data` step now also exits deterministically
- [ ] No behavioral change when `SNOW_CODE_DISABLE_SHARE` is unset (local dev / sharing still works)

> Couldn't run the seed end-to-end locally: this sandbox's network policy blocks `pkg.pr.new`, so workspace deps don't install. Verified against source instead (`Instance.disposeAll` exists; writes are flushed before exit).

Not linked to an existing issue — happy to file one first if the issue-first policy is strict, but these are CI regressions from the rebrand.