### PR TITLE
fix(opencode): verify downloaded binary against provenance-covered checksums

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -271,6 +271,26 @@ jobs:
 
           ls -la *.tar.gz 2>/dev/null || echo "No tarballs created"
 
+      - name: Generate binary checksums (provenance-covered)
+        # SHA-256 of every platform tarball, written INTO the package so
+        # `npm publish --provenance` signs it. postinstall.cjs verifies the
+        # binary it downloads from the GitHub release against this before
+        # extracting — closing the gap between the signed npm package and
+        # the separately-downloaded, otherwise-unverified executable.
+        run: |
+          cd packages/opencode/dist
+          node -e '
+            const fs = require("fs");
+            const crypto = require("crypto");
+            const out = {};
+            for (const f of fs.readdirSync(".").filter((x) => x.endsWith(".tar.gz")).sort()) {
+              out[f] = crypto.createHash("sha256").update(fs.readFileSync(f)).digest("hex");
+            }
+            fs.writeFileSync("../checksums.json", JSON.stringify(out, null, 2) + "\n");
+          '
+          echo "Wrote packages/opencode/checksums.json:"
+          cat ../checksums.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,7 +2,7 @@ name: typecheck
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
   workflow_dispatch:
 
 permissions:

--- a/packages/opencode/scripts/postinstall.cjs
+++ b/packages/opencode/scripts/postinstall.cjs
@@ -3,11 +3,30 @@ const https = require("https")
 const fs = require("fs")
 const path = require("path")
 const os = require("os")
+const crypto = require("crypto")
 const { execSync } = require("child_process")
 
 const pkg = require("../package.json")
 const VERSION = pkg.version
 const REPO = "serac-labs/serac"
+
+// Expected SHA-256 of each platform tarball, generated at publish time and
+// shipped INSIDE this package, so npm's provenance/attestation covers it.
+// The binary itself is downloaded separately from GitHub Releases (below),
+// which provenance does NOT cover — so we verify it against this before
+// trusting it, closing that supply-chain gap. A missing file/entry skips
+// verification (graceful for older/local builds); a tampered package that
+// stripped this file would fail `npm audit signatures`.
+let EXPECTED_CHECKSUMS = {}
+try {
+  EXPECTED_CHECKSUMS = require("../checksums.json")
+} catch (e) {
+  /* no checksums shipped (older package or local build) — skip verification */
+}
+
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex")
+}
 
 const platformMap = { darwin: "darwin", linux: "linux", win32: "windows" }
 const archMap = { x64: "x64", arm64: "arm64" }
@@ -97,6 +116,27 @@ followRedirects(releaseUrl, function (res) {
   res.pipe(file)
   file.on("finish", function () {
     file.close()
+
+    // Integrity gate: verify the downloaded tarball against the
+    // provenance-covered checksum BEFORE extracting or executing anything.
+    var expectedHash = EXPECTED_CHECKSUMS[tarballName]
+    if (expectedHash) {
+      var actualHash = sha256(tarPath)
+      if (actualHash !== expectedHash) {
+        console.error("serac: SECURITY: checksum mismatch for " + tarballName)
+        console.error("serac:   expected " + expectedHash)
+        console.error("serac:   actual   " + actualHash)
+        console.error("serac: refusing to install a tampered binary — aborting.")
+        try {
+          fs.rmSync(tmpDir, { recursive: true })
+        } catch (e) {}
+        process.exit(1)
+      }
+      console.log("serac: binary checksum verified")
+    } else {
+      console.warn("serac: no published checksum for " + tarballName + " — skipping integrity check")
+    }
+
     try {
       execSync('tar -xzf "' + tarPath + '" -C "' + pkgDir + '"', { stdio: "pipe" })
       if (platform !== "windows" && fs.existsSync(binaryPath)) {


### PR DESCRIPTION
`scripts/postinstall.cjs` downloads the platform binary from GitHub Releases and runs it with no integrity check. npm provenance signs the published JS launcher, but not the separately-downloaded executable — so a tampered release asset installs unverified.

This bakes the checksums into the signed package and verifies before trusting:
- **publish-npm.yml**: after building the platform tarballs (and before `npm publish --provenance`), compute SHA-256 of each `dist/serac-*.tar.gz` into `packages/opencode/checksums.json`. No `files` field ⇒ it ships in the tarball ⇒ provenance covers it.
- **postinstall.cjs**: verify the downloaded tarball's SHA-256 against the shipped `checksums.json` before extracting. Mismatch ⇒ abort (`exit 1`, possible tampering). Missing entry/file ⇒ warn + continue (graceful for local/older builds; a stripped checksums.json would fail `npm audit signatures`). Uses the Node `crypto` builtin — no new dependency.
- **typecheck.yml**: also run on PRs to `main` (was `dev`-only) so typecheck can gate the main branch.

Tested locally: generation matches `shasum -a 256`; match ⇒ passes, tampered ⇒ aborts, no-entry ⇒ skips.

Fixes #152