### PR TITLE
fix(servicenow): use event name, not sys_id, when creating script actions

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_create_event_rule.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/automation/snow_create_event_rule.ts
@@ -27,7 +27,11 @@ export const toolDefinition: MCPToolDefinition = {
     type: "object",
     properties: {
       name: { type: "string", description: "Event Rule name" },
-      eventName: { type: "string", description: "Event name to listen for" },
+      eventName: {
+        type: "string",
+        description:
+          "Registered event NAME to listen for, e.g. 'incident.commented' or 'x_app.my_event' — the 'event_name' string from sysevent_register. This is NOT the sys_id and NOT a reference: a Script Action matches fired events by name, so a 32-char hex sys_id will store but never fire. Use snow_discover_events to find the name.",
+      },
       condition: { type: "string", description: "Event condition script (ES5 only!)" },
       script: {
         type: "string",
@@ -41,15 +45,47 @@ export const toolDefinition: MCPToolDefinition = {
   },
 }
 
+function isSysId(value: string): boolean {
+  return /^[0-9a-f]{32}$/i.test(value)
+}
+
+// Translate a sysevent_register sys_id into its event_name. Passes plain names
+// through untouched; throws a clear, actionable error when the sys_id has no
+// matching event so the script action is never created against an id that
+// can't fire.
+async function resolveEventName(client: any, eventName: string): Promise<string> {
+  if (!isSysId(eventName)) return eventName
+
+  const response = await client.get(
+    `/api/now/table/sysevent_register?sysparm_query=sys_id=${eventName}&sysparm_fields=event_name&sysparm_limit=1`,
+  )
+  const record = response.data.result?.[0]
+
+  if (!record?.event_name) {
+    throw new SnowFlowError(
+      ErrorType.VALIDATION_ERROR,
+      `eventName "${eventName}" looks like a sys_id but no sysevent_register record matches it. Pass the registered event NAME string (e.g. "incident.commented"), not the sys_id — a Script Action fires on the event name.`,
+    )
+  }
+
+  return record.event_name
+}
+
 export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
   const { name, eventName, condition = "", script, description = "", active = true, order = 100 } = args
 
   try {
     const client = await getAuthenticatedClient(context)
 
+    // A Script Action matches a fired event by its registered NAME, not its
+    // sys_id. Agents frequently pass the sys_id of the sysevent_register record
+    // they just looked up — it saves without error but the rule never fires.
+    // Detect that and resolve the sys_id back to the actual event_name.
+    const resolvedEventName = await resolveEventName(client, eventName)
+
     const eventRuleData: any = {
       name,
-      event_name: eventName,
+      event_name: resolvedEventName,
       script,
       description,
       active,
@@ -68,7 +104,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       event_rule: {
         sys_id: rule.sys_id,
         name: rule.name,
-        event_name: eventName,
+        event_name: resolvedEventName,
         active,
         order,
       },


### PR DESCRIPTION
Script Actions match a fired event by its registered name (`incident.commented`), not by sys_id. The agent kept putting the sys_id of the `sysevent_register` record into `eventName`, so the action saved fine but never fired.

Fix:
- `eventName` description now states it must be the event NAME string (not the sys_id / not a reference), and points at `snow_discover_events`.
- Runtime guard resolves an accidental 32-char sys_id back to its `event_name` via `sysevent_register`, and errors clearly when no event matches.

Refs #154 — leaving the issue open so it can be verified on a deployed build before we close it.