### PR TITLE
fix(nix): allow Elastic-2.0 packages so the desktop flake build evaluates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,19 @@
         "aarch64-darwin"
         "x86_64-darwin"
       ];
-      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      # serac's own packages (snow-code, snow-code-desktop) carry the
+      # Elastic-2.0 license, which nixpkgs classifies as unfree — so the
+      # default legacyPackages refuse to evaluate them ("has an unfree
+      # license, refusing to evaluate"). Import nixpkgs per-system with a
+      # SCOPED allowUnfreePredicate that permits only our own packages,
+      # rather than blanket-allowing unfree across the whole package set.
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (
+        system: f (import nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate =
+            pkg: builtins.elem (nixpkgs.lib.getName pkg) [ "snow-code" "snow-code-desktop" ];
+        })
+      );
       rev = self.shortRev or self.dirtyShortRev or "dirty";
     in
     {


### PR DESCRIPTION
`nix build .#desktop` (and the hash-updater) fail at evaluation because `snow-code` / `snow-code-desktop` carry `lib.licenses.elastic20` (unfree per nixpkgs) and the flake used default `legacyPackages` (allowUnfree=false):

```
error: Package 'snow-code-desktop-…' has an unfree license ('elastic20'), refusing to evaluate.
```

Imports nixpkgs per-system with a **scoped** `allowUnfreePredicate` permitting only `snow-code` + `snow-code-desktop` — no blanket allowUnfree.

**Pre-existing**, not from the Actions-pinning PR — `nix-desktop.yml` has been failing on PRs since at least March. (I can't run Nix locally; this PR's own `nix-desktop` check is the validation.)

Fixes #158