### PR TITLE
chore(console): update Discord link to the new community server

### DIFF
--- a/packages/console/app/src/config.ts
+++ b/packages/console/app/src/config.ts
@@ -17,7 +17,7 @@ export const config = {
   // Social links
   social: {
     twitter: "https://x.com/snowflowdev",
-    discord: "https://discord.gg/snow-flow",
+    discord: "https://discord.gg/uGGrWj9KsT",
   },
 
   // Static stats (used on landing page)

--- a/packages/console/app/src/routes/discord.ts
+++ b/packages/console/app/src/routes/discord.ts
@@ -1,5 +1,5 @@
 import { redirect } from "@solidjs/router"
 
 export async function GET() {
-  return redirect("https://discord.gg/snow-flow")
+  return redirect("https://discord.gg/uGGrWj9KsT")
 }


### PR DESCRIPTION
Both `socials.discord` in `packages/console/app/src/config.ts` and the `/discord` redirect route still pointed at the dead `discord.gg/snow-flow` invite. Point them at the new server: `discord.gg/uGGrWj9KsT`.

Fixes #160