### PR TITLE
fix: drop legacy snow-* bin aliases that break npm i -g (EEXIST)

### DIFF
--- a/.github/workflows/publish-npm-test.yml
+++ b/.github/workflows/publish-npm-test.yml
@@ -144,12 +144,10 @@ jobs:
               url: 'https://github.com/serac-labs/serac'
             };
 
-            // Update bin commands - keep legacy names for compatibility
+            // Bin commands - test channel mirrors the published bins.
             pkg.bin = {
               'serac-test': './bin/serac',
-              'serac': './bin/serac',
-              'snow-code': './bin/serac',
-              'snow-flow': './bin/serac'
+              'serac': './bin/serac'
             };
 
             // Helper to resolve workspace/catalog dependencies
@@ -229,9 +227,6 @@ jobs:
             serac-test
             # or
             serac
-            # or (legacy aliases)
-            snow-code
-            snow-flow
             ```
 
             ### Supported Platforms

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -205,17 +205,15 @@ jobs:
             pkg.homepage = 'https://serac.build';
             pkg.bugs = { url: 'https://github.com/serac-labs/serac/issues' };
 
-            // Bin commands - 'serac' is the primary CLI entry; the
-            // legacy snow-flow / snow-code / snowflow / snowcode names
-            // are kept so existing scripts keep working through the
-            // package rename. All names point at the same launcher.
+            // Bin commands - 'serac' is the primary CLI entry. The legacy
+            // snow-flow / snow-code / snowflow / snowcode aliases were
+            // dropped: they collided with the bins of the still-installed,
+            // now-deprecated 'snow-flow' npm package, making
+            // 'npm i -g @serac-labs/core' fail with EEXIST for users
+            // migrating from snow-flow.
             pkg.bin = {
               'serac':      './bin/serac',
-              'serac-code': './bin/serac',
-              'snow-flow':  './bin/serac',
-              'snow-code':  './bin/serac',
-              'snowcode':   './bin/serac',
-              'snowflow':   './bin/serac'
+              'serac-code': './bin/serac'
             };
 
             // Helper to resolve workspace/catalog dependencies
@@ -311,13 +309,12 @@ jobs:
 
             ```bash
             serac
-            # or, if upgrading from snow-flow:
-            snow-flow
             ```
 
-            > Coming from `snow-flow`? The package is now `@serac-labs/core`.
-            > The `snow-flow` and `snow-code` commands keep working as
-            > aliases so existing scripts don't break.
+            > Coming from `snow-flow`? The package is now `@serac-labs/core`
+            > and the command is `serac`. Uninstall the old package first so
+            > the install doesn't collide:
+            > `npm un -g snow-flow && npm i -g @serac-labs/core`.
 
             ## What's New
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -18,11 +18,7 @@
   },
   "bin": {
     "serac": "./bin/serac",
-    "serac-code": "./bin/serac",
-    "snow-flow": "./bin/serac",
-    "snow-code": "./bin/serac",
-    "snowcode": "./bin/serac",
-    "snowflow": "./bin/serac"
+    "serac-code": "./bin/serac"
   },
   "exports": {
     "./*": "./src/*.ts"


### PR DESCRIPTION
Fixes #167.

`@serac-labs/core` declared `snow-flow`/`snow-code`/`snowcode`/`snowflow` bin aliases that collide with the still-installed deprecated `snow-flow` package's bins, so `npm i -g @serac-labs/core` fails with EEXIST for anyone migrating from snow-flow.

Drops the aliases (keeps `serac` + `serac-code`) in the publish workflow, the test-publish workflow, and the source `package.json`, and updates the release-notes upgrade hint. On merge the Release workflow publishes the corrected bins automatically.