### PR TITLE
fix(flow-designer): verify real flow state after publish instead of trusting API status

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -779,6 +779,67 @@ async function verifyFlowEditingLock(
 }
 
 /**
+ * Read the committed state of a flow after a publish/activate call and report
+ * whether it is genuinely active AND has a compiled snapshot.
+ *
+ * The publish API can return HTTP 200 while the server-side compilation never
+ * finishes, leaving the flow `active=false`/`status=draft` with an empty
+ * `master_snapshot`. In that state the flow does NOT trigger. This helper is
+ * the source of truth the publish handler uses instead of the API status code.
+ *
+ * A flow is considered publishable-OK only when:
+ *   - active === true, AND
+ *   - status is published/active, AND
+ *   - a snapshot reference exists (master_snapshot OR latest_snapshot).
+ */
+async function verifyFlowActivation(
+  client: any,
+  flowId: string,
+): Promise<{ active: boolean; status: string; hasSnapshot: boolean; snapshot?: string }> {
+  try {
+    var resp = await client.get("/api/now/table/sys_hub_flow/" + flowId, {
+      params: {
+        sysparm_fields: "active,status,master_snapshot,latest_snapshot",
+        sysparm_exclude_reference_link: "true",
+      },
+    })
+    var rec = resp.data?.result || {}
+    var active = rec.active === "true" || rec.active === true
+    var status = (rec.status || "unknown") + ""
+    // Reference fields come back as { value: "..." } unless flattened; handle both.
+    var master = typeof rec.master_snapshot === "object" ? rec.master_snapshot?.value : rec.master_snapshot
+    var latest = typeof rec.latest_snapshot === "object" ? rec.latest_snapshot?.value : rec.latest_snapshot
+    var snapshot = master || latest || ""
+    var hasSnapshot = !!snapshot && snapshot !== ""
+    return { active: active, status: status, hasSnapshot: hasSnapshot, snapshot: snapshot }
+  } catch (e: any) {
+    console.warn("[snow_manage_flow] verifyFlowActivation failed for flow=" + flowId + ": " + (e.message || ""))
+    return { active: false, status: "verify_failed", hasSnapshot: false }
+  }
+}
+
+/**
+ * Best-effort attempt to force the server to compile and publish a flow whose
+ * snapshot did not materialize after the first publish call. Re-issues the
+ * versioning "Activate/Publish" request, which re-runs the compile pipeline.
+ * Returns true if the underlying call did not throw (caller re-verifies state).
+ */
+async function forceFlowCompile(client: any, flowId: string): Promise<boolean> {
+  try {
+    await client.post("/api/now/processflow/versioning/create_version?sysparm_transaction_scope=global", {
+      item_sys_id: flowId,
+      type: "Activate/Publish",
+      annotation: "auto-recompile",
+      favorite: false,
+    })
+    return true
+  } catch (e: any) {
+    console.warn("[snow_manage_flow] forceFlowCompile failed for flow=" + flowId + ": " + (e.message || ""))
+    return false
+  }
+}
+
+/**
  * Ensure an editing lock exists for the given flow, re-acquiring if necessary.
  * Call this before every GraphQL element mutation.
  */
@@ -7030,7 +7091,12 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       case "publish": {
         var activateSysId = await resolveFlowId(client, args.flow_id)
         var activateSummary = summary()
-        var publishSuccess = false
+        // Tracks whether the publish API call returned without throwing.
+        // This is NOT the same as "the flow is actually active" — the
+        // versioning API can return 200 while the server-side compile never
+        // completes, leaving the flow in draft with an empty snapshot. We
+        // verify the real DB state below before claiming success.
+        var apiCallOk = false
 
         // Primary: use processflow versioning API (same as Flow Designer UI).
         // This properly handles the editing lock lifecycle.
@@ -7040,8 +7106,8 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
             { item_sys_id: activateSysId, type: "Activate/Publish", annotation: "", favorite: false },
           )
           var versionResult = versionResp.data?.result || versionResp.data
-          publishSuccess = true
-          activateSummary.success("Flow published via versioning API").field("sys_id", activateSysId)
+          apiCallOk = true
+          activateSummary.field("publish_method", "versioning_api")
           if (versionResult?.version) activateSummary.field("version", versionResult.version)
         } catch (publishErr: any) {
           // Fallback: direct REST PATCH (older instances without processflow versioning)
@@ -7050,10 +7116,8 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
               active: true,
               status: "published",
             })
-            publishSuccess = true
-            activateSummary
-              .warning("Published via REST fallback (versioning API unavailable)")
-              .field("sys_id", activateSysId)
+            apiCallOk = true
+            activateSummary.field("publish_method", "rest_fallback")
           } catch (fallbackErr: any) {
             activateSummary
               .error("Publish failed: " + (fallbackErr.message || fallbackErr))
@@ -7061,21 +7125,73 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
           }
         }
 
-        // Safety: release any lingering editing lock after publish
+        // Safety: release any lingering editing lock so verification reads the
+        // committed state and a later edit isn't blocked.
         await releaseFlowEditingLock(client, activateSysId)
+
+        // ── POST-VERIFICATION ───────────────────────────────────────────
+        // Re-read the flow record and confirm it is genuinely active with a
+        // published snapshot. Without this, a 200 from the versioning API was
+        // reported as success even when the flow stayed draft (empty
+        // master_snapshot) and never triggered.
+        var verifiedActive = false
+        var verifiedStatus = "unknown"
+        var hasSnapshot = false
+        if (apiCallOk) {
+          var verifyOutcome = await verifyFlowActivation(client, activateSysId)
+          verifiedActive = verifyOutcome.active
+          verifiedStatus = verifyOutcome.status
+          hasSnapshot = verifyOutcome.hasSnapshot
+
+          // If the flow is active but no snapshot was compiled, attempt one
+          // corrective republish (the most common transient cause is the
+          // compile BR not having run yet), then re-verify.
+          if (verifiedActive && !hasSnapshot) {
+            activateSummary.warning("Flow active but snapshot missing — forcing recompile")
+            await forceFlowCompile(client, activateSysId)
+            var reVerify = await verifyFlowActivation(client, activateSysId)
+            verifiedActive = reVerify.active
+            verifiedStatus = reVerify.status
+            hasSnapshot = reVerify.hasSnapshot
+          }
+        }
+
+        var publishSuccess = apiCallOk && verifiedActive && hasSnapshot
+
+        if (publishSuccess) {
+          activateSummary.success("Flow activated and published (verified)").field("sys_id", activateSysId)
+        } else if (apiCallOk && verifiedActive && !hasSnapshot) {
+          activateSummary
+            .error("Publish API succeeded but no compiled snapshot exists — flow will NOT trigger")
+            .field("sys_id", activateSysId)
+            .line("Open the flow in Flow Designer and click Save → Activate to compile it.")
+        } else if (apiCallOk && !verifiedActive) {
+          activateSummary
+            .error("Publish API returned OK but flow is still '" + verifiedStatus + "' in the database")
+            .field("sys_id", activateSysId)
+            .line("The server did not commit the activation. Check flow for validation errors.")
+        }
 
         var publishData: any = {
           action: action,
           flow_id: activateSysId,
-          active: publishSuccess,
-          status: publishSuccess ? "published" : "failed",
-          message: publishSuccess ? "Flow activated and published" : "Publish failed",
+          active: verifiedActive,
+          status: publishSuccess ? "published" : verifiedStatus,
+          has_snapshot: hasSnapshot,
+          verified: true,
+          message: publishSuccess
+            ? "Flow activated and published (verified active with compiled snapshot)"
+            : "Publish did not result in an active, compiled flow — see summary",
         }
         if (publishSuccess) {
           publishData.next_step =
             "Use action='check_execution' with flow_id='" + activateSysId + "' to verify execution after trigger."
         }
 
+        // Surface the real failure to the caller instead of a false success.
+        if (!publishSuccess) {
+          return createErrorResult(publishData.message, publishData)
+        }
         return createSuccessResult(publishData, {}, activateSummary.build())
       }
 


### PR DESCRIPTION
The publish/activate handler reported success on any HTTP 200 from the versioning API, even when compilation never completed (flow left in draft with empty master_snapshot, so it never triggered). Now re-reads sys_hub_flow after publish, forces one recompile if active-but-no-snapshot, and only reports success when the flow is genuinely active with a compiled snapshot — otherwise returns an actionable error instead of a false 'published'. Touches only snow_manage_flow.ts; type-clean.