### PR TITLE
feat(flow-designer): step labels, add_flow_variable, smoke test + contract drift-check

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/__harness__/smoke.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/__harness__/smoke.ts
@@ -3,24 +3,27 @@
  *
  *   SN_INSTANCE=… SN_CLIENT_ID=… SN_CLIENT_SECRET=… bun run smoke.ts
  *
- * Exercises the harness end-to-end and asserts the publish-verification fix:
- * an empty flow has no compiled snapshot, so `publish` must report success=false
- * with a real reason — not a false "published". Cleans up after itself.
+ * Builds a real flow (record trigger + IF condition + Log action) and publishes
+ * it, asserting the tool actually produced a compiled, active flow — i.e. the
+ * full build → publish → snapshot path works end-to-end. Cleans up after itself.
  */
 import { run, payload, cleanup } from "./harness.js"
 
 const PREFIX = "zzz_serac_test_"
 const name = PREFIX + "smoke"
+const ok = (label: string, p: any) => console.log((p?.success ? "  ✓ " : "  ✗ ") + label + (p?.error ? " — " + p.error : ""))
 
-console.log("→ create", name)
-const created = payload(await run("create", { name, description: "harness smoke test" }))
+console.log("→ build + publish", name)
+const created = payload(await run("create", { name, description: "harness smoke", trigger_type: "record_create", table: "incident" }))
 const flowId = created?.data?.flow?.sys_id
-console.log("  created:", created?.success, "flow:", flowId)
+ok("create (record trigger)", created)
+ok("add_flow_logic IF", payload(await run("add_flow_logic", { flow_id: flowId, logic_type: "IF", condition_name: "High priority", condition: "priority<=2" })))
+ok("add_action Log", payload(await run("add_action", { flow_id: flowId, action_type: "log", action_inputs: { message: "high prio" } })))
 
-console.log("→ publish (empty flow → verification must reject)")
 const pub = payload(await run("publish", { flow_id: flowId }))
-console.log("  success:", pub?.success, "| reason:", pub?.error || "(published)")
-if (pub?.success === true) console.log("  ⚠️  expected verification to reject an uncompiled flow")
+ok("publish", pub)
+const good = pub?.success === true && !!pub?.data?.snapshot
+console.log(good ? `PASS — published, snapshot ${pub.data.snapshot}, status ${pub.data.status}` : "FAIL — flow did not publish with a compiled snapshot")
 
-console.log("→ cleanup", PREFIX + "*")
-console.log("  removed", await cleanup(PREFIX), "test flow(s)")
+console.log("→ cleanup", PREFIX + "*:", await cleanup(PREFIX), "removed")
+process.exit(good ? 0 : 1)

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/contract/README.md
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/contract/README.md
@@ -43,8 +43,13 @@ Introspection requires the `graphql_schema_admin` role on the requesting user.
 
 ## Intended use
 
-- **Drift detection**: re-introspect after a ServiceNow upgrade and diff against
-  this snapshot to catch breaking changes to `snFlowDesigner` before they
-  silently break flow authoring/publishing.
+- **Drift detection** — `drift-check.ts` re-introspects the live schema and diffs
+  it against this fixture, so a ServiceNow upgrade that changes `snFlowDesigner`
+  is caught before it silently breaks flow authoring/publishing:
+  ```bash
+  SN_INSTANCE=… SN_CLIENT_ID=… SN_CLIENT_SECRET=… bun run drift-check.ts
+  ```
+  Needs introspection enabled (see above); exits non-zero on drift. It's a
+  maintenance tool (introspection is slow), not a CI gate.
 - **Field reference**: the source of truth for which fields each
   `flow(flowPatch)` element accepts when extending `snow_manage_flow.ts`.

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/contract/drift-check.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/contract/drift-check.ts
@@ -1,0 +1,124 @@
+/**
+ * Drift check for the snFlowDesigner GraphQL contract.
+ *
+ * Re-introspects the live Flow Designer GraphQL schema and diffs it against the
+ * saved fixture (snfd-graphql-contract.json), so a ServiceNow upgrade that
+ * changes the API surface is caught before it silently breaks flow authoring or
+ * publishing. Exits non-zero when drift is found.
+ *
+ *   SN_INSTANCE=https://devXXXXXX.service-now.com \
+ *   SN_CLIENT_ID=… SN_CLIENT_SECRET=… \
+ *   bun run drift-check.ts
+ *
+ * Requires GraphQL introspection enabled on the target:
+ *   - sys_property `glide.graphql.introspection_enabled` = true
+ *   - ⚠️ do NOT also enable `glide.graphql.glide_record_schema.introspection_enabled`
+ *     — it hangs a type per table onto the schema and makes introspection time out.
+ *   - the OAuth user needs the `graphql_schema_admin` role.
+ * Use a throwaway PDI, and flip the property back to false when done.
+ *
+ * It only re-introspects the types already in the fixture (plus flags any new
+ * referenced `global_snFlowDesigner_*` types), which is enough to detect drift.
+ * Introspection on a busy PDI is slow (~tens of seconds per type), so a full run
+ * takes a while — this is a maintenance tool, not a CI gate.
+ */
+import { readFileSync } from "fs"
+
+const INSTANCE = process.env.SN_INSTANCE?.replace(/\/$/, "")
+const CLIENT_ID = process.env.SN_CLIENT_ID
+const CLIENT_SECRET = process.env.SN_CLIENT_SECRET
+if (!INSTANCE || !CLIENT_ID || !CLIENT_SECRET) {
+  console.error("Set SN_INSTANCE, SN_CLIENT_ID and SN_CLIENT_SECRET")
+  process.exit(2)
+}
+
+const fixture: Record<string, any> = JSON.parse(
+  readFileSync(new URL("./snfd-graphql-contract.json", import.meta.url), "utf8"),
+)
+
+async function token(): Promise<string> {
+  const res = await fetch(`${INSTANCE}/oauth_token.do`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "client_credentials", client_id: CLIENT_ID!, client_secret: CLIENT_SECRET! }),
+  })
+  const j = await res.json()
+  if (!j.access_token) throw new Error("token failed: " + JSON.stringify(j).slice(0, 120))
+  return j.access_token
+}
+
+const TREF = "type { kind name ofType { kind name ofType { kind name } } }"
+function named(t: any): string {
+  while (t && !t.name) t = t.ofType
+  return t ? t.name : "?"
+}
+function fieldMap(typeDef: any): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const f of typeDef?.inputFields || []) out[f.name] = named(f.type)
+  for (const f of typeDef?.fields || []) out[f.name] = named(f.type)
+  return out
+}
+
+async function introspect(tok: string, name: string, tries = 3): Promise<any | null> {
+  const query = `{ __type(name:"${name}"){ name kind inputFields { name ${TREF} } fields { name ${TREF} } enumValues { name } } }`
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(`${INSTANCE}/api/now/graphql`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${tok}`, "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ query }),
+        signal: AbortSignal.timeout(120000),
+      })
+      const j = await res.json()
+      const errs = JSON.stringify(j.errors || "")
+      if (errs.toLowerCase().includes("introspection is disabled")) {
+        console.error("Introspection is disabled on this instance — enable glide.graphql.introspection_enabled (see header).")
+        process.exit(2)
+      }
+      if (j?.data?.__type) return j.data.__type
+    } catch {
+      /* retry */
+    }
+  }
+  return null
+}
+
+const tok = await token()
+const names = Object.keys(fixture).filter((k) => !fixture[k]?._err)
+console.log(`Drift check: ${names.length} types from fixture vs live ${INSTANCE}\n`)
+
+const drift: string[] = []
+const referenced = new Set<string>()
+let checked = 0
+for (const name of names) {
+  const live = await introspect(tok, name)
+  checked++
+  if (!live) {
+    drift.push(`REMOVED/UNREADABLE: ${name}`)
+    continue
+  }
+  const was = fieldMap(fixture[name])
+  const now = fieldMap(live)
+  for (const f of Object.keys(now)) {
+    if (now[f]?.startsWith?.("global_snFlowDesigner_")) referenced.add(now[f])
+    if (!(f in was)) drift.push(`+ ${shortName(name)}.${f}: ${now[f]} (added)`)
+    else if (was[f] !== now[f]) drift.push(`~ ${shortName(name)}.${f}: ${was[f]} -> ${now[f]} (type changed)`)
+  }
+  for (const f of Object.keys(was)) if (!(f in now)) drift.push(`- ${shortName(name)}.${f}: ${was[f]} (removed)`)
+  if (checked % 10 === 0) console.log(`  …${checked}/${names.length}`)
+}
+for (const r of referenced) if (!fixture[r]) drift.push(`NEW TYPE referenced but not in fixture: ${shortName(r)}`)
+
+function shortName(n: string): string {
+  return n.replace("global_snFlowDesigner_", "~")
+}
+
+console.log("")
+if (drift.length === 0) {
+  console.log(`✓ No drift — the live snFlowDesigner schema matches the fixture (${names.length} types).`)
+  process.exit(0)
+}
+console.log(`⚠️  ${drift.length} drift item(s):\n`)
+for (const d of drift) console.log("  " + d)
+console.log("\nReview these against snow_manage_flow.ts and update the fixture if the change is expected.")
+process.exit(1)

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -2812,6 +2812,7 @@ async function addActionViaGraphQL(
   order?: number,
   spoke?: string,
   annotation?: string,
+  displayText?: string,
 ): Promise<{
   success: boolean
   actionId?: string
@@ -3221,6 +3222,7 @@ async function addActionViaGraphQL(
           parentUiId: parentUiId || "",
           inputs: insertInputs,
           comment: annotation || "",
+          ...(displayText ? { displayText: displayText } : {}),
           ...(nestedCatchUuid ? { connectedTo: nestedCatchUuid } : {}),
         },
       ],
@@ -6047,6 +6049,11 @@ export const toolDefinition: MCPToolDefinition = {
         description:
           'Key-value pairs for action inputs (also accepted as "action_config", "action_field_values", "inputs", or "config"). Keys are fuzzy-matched to ServiceNow parameter element names — you can use short names like "to" instead of "ah_to", "subject" instead of "ah_subject", "table" instead of "table_name", "message" instead of "log_message". Use `next_order` from the previous response for sequential ordering. Example: {to: "admin@example.com", subject: "Alert", body: "Incident created"}',
       },
+      display_text: {
+        type: "string",
+        description:
+          'Optional custom label for an action step, shown on the Flow Designer canvas (for add_action). Defaults to the action type name when omitted. Example: "Log high priority".',
+      },
       update_fields: {
         type: "object",
         description: "Fields to update (for update action)",
@@ -7699,6 +7706,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
           args.order,
           args.spoke,
           args.annotation,
+          args.display_text,
         )
 
         var addActSummary = summary()

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -959,6 +959,47 @@ async function compileFlowSnapshot(client: any, flowId: string): Promise<string>
 }
 
 /**
+ * Add a user flow variable to an EXISTING flow via the GraphQL
+ * flow(flowPatch: { flowVariables: { insert } }) mutation — the same path the
+ * Flow Designer UI uses. This adds to the working copy WITHOUT publishing
+ * (unlike posting the def to /snapshot, which compiles and then ignores further
+ * appends), so multiple variables can be added before close_flow/publish.
+ *
+ * Flow `inputs` are trigger-derived and can't be added this way; this is for
+ * user `flowVariables`. Returns the new variable's sysId.
+ */
+async function addFlowVariable(
+  client: any,
+  flowId: string,
+  variable: { name: string; label?: string; type?: string; order?: number },
+): Promise<{ success: boolean; sysId?: string; error?: string }> {
+  try {
+    var vtype = variable.type || "string"
+    var vlabel = TYPE_LABELS[vtype] || vtype.charAt(0).toUpperCase() + vtype.slice(1)
+    var varObj = {
+      label: variable.label || variable.name,
+      name: variable.name,
+      type: vtype,
+      type_label: vlabel,
+      order: variable.order || 1,
+      mandatory: false,
+      readonly: false,
+      attributes: "sourceUiUniqueId=,sourceType=,sourceId=,uiUniqueId=" + generateUUID() + ",",
+      uiDisplayType: vtype,
+      uiDisplayTypeLabel: vlabel,
+    }
+    var result = await executeFlowPatchMutation(
+      client,
+      { flowId: flowId, flowVariables: { insert: [varObj] } },
+      "flowVariables { inserts { sysId uiUniqueIdentifier __typename } updates deletes __typename }",
+    )
+    return { success: true, sysId: result?.flowVariables?.inserts?.[0]?.sysId }
+  } catch (e: any) {
+    return { success: false, error: e?.message || String(e) }
+  }
+}
+
+/**
  * Ensure an editing lock exists for the given flow, re-acquiring if necessary.
  * Call this before every GraphQL element mutation.
  */
@@ -5824,6 +5865,7 @@ export const toolDefinition: MCPToolDefinition = {
           "add_subflow",
           "update_subflow",
           "delete_subflow",
+          "add_flow_variable",
           "add_stage",
           "update_stage",
           "delete_stage",
@@ -6054,6 +6096,20 @@ export const toolDefinition: MCPToolDefinition = {
         description:
           'Optional custom label for an action step, shown on the Flow Designer canvas (for add_action). Defaults to the action type name when omitted. Example: "Log high priority".',
       },
+      variable_name: {
+        type: "string",
+        description:
+          "Name of the user flow variable to add to an existing flow (for add_flow_variable). Flow inputs are trigger-derived and cannot be added this way.",
+      },
+      variable_label: {
+        type: "string",
+        description: "Display label for the flow variable (for add_flow_variable). Defaults to variable_name.",
+      },
+      variable_type: {
+        type: "string",
+        description:
+          "Type of the flow variable (for add_flow_variable): string, integer, boolean, reference, etc. Default: string.",
+      },
       update_fields: {
         type: "object",
         description: "Fields to update (for update action)",
@@ -6189,6 +6245,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
     update_flow_logic: ["flow_id", "element_id"],
     delete_flow_logic: ["flow_id", "element_id"],
     add_subflow: ["flow_id", "subflow_id"],
+    add_flow_variable: ["flow_id", "variable_name"],
     update_subflow: ["flow_id", "element_id"],
     delete_subflow: ["flow_id", "element_id"],
     add_stage: ["flow_id", "stage_label", "stage_component_indexes"],
@@ -6243,6 +6300,7 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       "add_subflow",
       "update_subflow",
       "delete_subflow",
+      "add_flow_variable",
       "add_stage",
       "update_stage",
       "delete_stage",
@@ -7942,6 +8000,48 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
             "' first, then retry."
         }
         return createErrorResult((addLogicResult.error || "Failed to add flow logic") + addLogicLockHint)
+      }
+
+      // ────────────────────────────────────────────────────────────────
+      // ADD_FLOW_VARIABLE — add a user flow variable to an existing flow
+      // ────────────────────────────────────────────────────────────────
+      case "add_flow_variable": {
+        var fvFlowId = await resolveFlowId(client, args.flow_id)
+        var fvLock = await ensureFlowEditingLock(client, fvFlowId)
+        if (!fvLock.success) {
+          return createErrorResult("Flow is not open for editing. Call open_flow first. " + (fvLock.warning || ""))
+        }
+        var fvResult = await addFlowVariable(client, fvFlowId, {
+          name: args.variable_name,
+          label: args.variable_label,
+          type: args.variable_type,
+          order: args.order,
+        })
+        if (!fvResult.success) {
+          return createErrorResult(
+            new SnowFlowError(ErrorType.UNKNOWN_ERROR, "Failed to add flow variable: " + (fvResult.error || ""), {
+              details: { flow_id: fvFlowId, variable: args.variable_name },
+            }),
+          )
+        }
+        return createSuccessResult(
+          withUpdateSetContext(
+            {
+              action: "add_flow_variable",
+              flow_id: fvFlowId,
+              name: args.variable_name,
+              sys_id: fvResult.sysId,
+              message: "Added flow variable '" + args.variable_name + "'",
+              reminder: "Call close_flow with flow_id='" + fvFlowId + "' when you are done editing.",
+            },
+            updateSetCtx,
+          ),
+          {},
+          summary()
+            .success("Added flow variable: " + args.variable_name)
+            .field("flow", fvFlowId)
+            .build(),
+        )
       }
 
       // ────────────────────────────────────────────────────────────────

--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -941,10 +941,13 @@ async function compileFlowSnapshot(client: any, flowId: string): Promise<string>
     if (!def || !def.id) return ""
     // The UI tags every snapshot post with a fresh client session id.
     def.clientSessionId = generateUUID()
-    // Server-side compilation can take well over the default 60s client
-    // timeout on large flows / busy instances, so give this call room.
+    // Triggered flows compile via .../snapshot; subflows use .../subflow
+    // (the .../snapshot endpoint 500s for type=subflow). Server-side
+    // compilation can take well over the default 60s client timeout on large
+    // flows / busy instances, so give this call room.
+    var endpoint = def.type === "subflow" ? "/subflow" : "/snapshot"
     var snapResp = await client.post(
-      "/api/now/processflow/flow/" + flowId + "/snapshot?sysparm_transaction_scope=global",
+      "/api/now/processflow/flow/" + flowId + endpoint + "?sysparm_transaction_scope=global",
       def,
       { timeout: 180000 },
     )


### PR DESCRIPTION
Fixes #179

Stacked on #177 (the publish fix) — base is that branch so this diff only shows the extensions. Retarget to main after #177 merges.

All reverse-engineered from captured Flow Designer HARs and validated end-to-end against a live PDI via the test harness.

- **`display_text` on add_action** — sets the action step's displayText; validated it persists in the compiled flow.
- **`add_flow_variable`** — adds user flow variables via `flow(flowPatch: { flowVariables: { insert } })` (the UI's path, no publish). Validated: three variables of different types all persist. (The earlier snapshot-append approach only worked for the first variable, so it was dropped.)
- **smoke test** — `__harness__/smoke.ts` builds trigger + IF + action and asserts publish yields an active flow with a compiled snapshot.
- **drift-check** — `contract/drift-check.ts` re-introspects snFlowDesigner and diffs against the fixture; exits non-zero on drift.

Validated working end-to-end (build → publish → snapshot): record trigger, Log action, IF/ELSE/FOREACH/TRY/PARALLEL/END/TIMER logic, stages, subflows, flow variables.