### PR TITLE
fix(flow-designer): create flows in Global scope, not "None"

### DIFF
--- a/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/opencode/src/servicenow/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -5711,9 +5711,13 @@ async function createFlowViaProcessFlowAPI(
         protection: "",
         runAs: params.runAs || "user",
         runWithRoles: { value: "", displayValue: "" },
+        // sys_scope is resolved server-side from scopeName — leaving it empty
+        // (the old behaviour for the default app) created the flow with scope
+        // "None" instead of Global. Mirror what the Flow Designer UI sends for a
+        // Global flow: scope/scopeName = "global", scopeDisplayName = "Global".
         scope: params.scope || "global",
-        scopeDisplayName: "",
-        scopeName: params.scope && params.scope !== "global" ? params.scope : "",
+        scopeName: params.scope || "global",
+        scopeDisplayName: (params.scope || "global") === "global" ? "Global" : "",
         security: { can_read: true, can_write: true },
         status: "draft",
         type: params.isSubflow ? "subflow" : "flow",


### PR DESCRIPTION
Fixes #182

Flows created by `snow_manage_flow` landed with scope **None** instead of **Global**. The create call sent an empty `scopeName` for the default app; ServiceNow resolves `sys_scope` from `scopeName`, so it became None.

The fix mirrors the exact payload the Flow Designer UI sends for a Global flow (from a captured Activate HAR): `scope`/`scopeName` = `global`, `scopeDisplayName` = `Global`. Scoped-app creation was unaffected (it already set `scopeName`). The publish path re-sends the working-copy def unchanged, so the corrected scope carries through Activate.

Type-check clean (the two pre-existing `snow_manage_flow.ts` errors on `main` are unrelated).