### PR TITLE
ci(servicenow-mcp): publish via OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -355,6 +355,34 @@ jobs:
             npm publish --access public --tag "$NPM_TAG" --provenance
           fi
 
+      - name: Publish @serac-labs/servicenow-mcp to npm (OIDC)
+        # Separate npm package (ServiceNow MCP server). Unlike core (which
+        # ships .ts source), this ships a built dist/, so build + rewrite
+        # exports/bin from ./src/*.ts to ./dist/*.js first. Publishes via the
+        # same OIDC trusted-publisher path as core (the .npmrc above already
+        # put npm in OIDC mode). REQUIRES a Trusted Publisher to be configured
+        # on npm for @serac-labs/servicenow-mcp pointing at this repo +
+        # workflow; the package must already exist (one-time token bootstrap).
+        #
+        # continue-on-error keeps a not-yet-configured trusted publisher (401)
+        # from failing the whole release (and the core publish above) during
+        # bootstrap. REMOVE it in a follow-up once the trusted publisher is
+        # live and the first OIDC publish is confirmed green.
+        continue-on-error: true
+        run: |
+          cd packages/servicenow-mcp
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+          bun run script/build-for-publish.ts
+          test -f dist/index.js || { echo "build produced no dist/index.js — aborting publish"; exit 1; }
+          NPM_TAG="${{ steps.channel.outputs.npm_tag }}"
+          echo "Publishing @serac-labs/servicenow-mcp@$VERSION with tag: $NPM_TAG (OIDC, signed provenance)"
+          if [ "$NPM_TAG" = "latest" ]; then
+            npm publish --access public --provenance
+          else
+            npm publish --access public --tag "$NPM_TAG" --provenance
+          fi
+
       - name: Bump source pkg.json for next publish
         # The "Get version" step publishes source verbatim. To make the
         # *next* push publish a new version (and not 403 with "version

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -4,6 +4,14 @@
   "version": "0.1.0",
   "description": "Unified ServiceNow MCP server (~426 snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/serac-labs/serac.git"
+  },
+  "homepage": "https://serac.build",
+  "bugs": {
+    "url": "https://github.com/serac-labs/serac/issues"
+  },
   "type": "module",
   "private": false,
   "files": ["dist"],

--- a/packages/servicenow-mcp/script/build-for-publish.ts
+++ b/packages/servicenow-mcp/script/build-for-publish.ts
@@ -1,25 +1,25 @@
 #!/usr/bin/env bun
-import { Script } from "@opencode-ai/script"
+// Build the package to dist/ and rewrite package.json exports/bin from
+// ./src/*.ts to ./dist/*.js (+ .d.ts) so the published tarball resolves to
+// the built output. Run right before `npm publish` in CI. The runner is
+// ephemeral (tag-triggered publish), so package.json is intentionally NOT
+// restored afterwards.
 import { $ } from "bun"
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 
 await $`bun tsc --project tsconfig.build.json`
+
 const pkg = await import("../package.json").then((m) => m.default)
-const original = JSON.parse(JSON.stringify(pkg))
+if (!pkg.exports || !pkg.bin) throw new Error("package.json must declare exports and bin to rewrite for publish")
 for (const [key, value] of Object.entries(pkg.exports)) {
   const file = value.replace("./src/", "./dist/").replace(".ts", "")
   // @ts-ignore
-  pkg.exports[key] = {
-    import: file + ".js",
-    types: file + ".d.ts",
-  }
+  pkg.exports[key] = { import: file + ".js", types: file + ".d.ts" }
 }
 for (const [key, value] of Object.entries(pkg.bin)) {
   // @ts-ignore
   pkg.bin[key] = value.replace("./src/", "./dist/").replace(/\.ts$/, ".js")
 }
 await Bun.write("package.json", JSON.stringify(pkg, null, 2))
-await $`bun pm pack && npm publish *.tgz --tag ${Script.channel} --access public`
-await Bun.write("package.json", JSON.stringify(original, null, 2))

--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -74,8 +74,10 @@ await import(`../packages/sdk/js/script/publish.ts`)
 console.log("\n=== plugin ===\n")
 await import(`../packages/plugin/script/publish.ts`)
 
-console.log("\n=== servicenow-mcp ===\n")
-await import(`../packages/servicenow-mcp/script/publish.ts`)
+// NOTE: @serac-labs/servicenow-mcp is published separately via OIDC
+// (signed provenance) in .github/workflows/publish-npm.yml, not here —
+// see that workflow's "Publish @serac-labs/servicenow-mcp to npm (OIDC)"
+// step. Its version is still bumped by the glob loop above.
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)


### PR DESCRIPTION
Fixes #195. Stacked on #191 (base = `feat/extract-servicenow-mcp`; retarget to `main` once #191 merges).

Rewires `@serac-labs/servicenow-mcp` from the token-based `publish-start.ts` path to the **OIDC trusted-publisher** path in `publish-npm.yml` (signed provenance), the same path `@serac-labs/core` uses. The package ships a built `dist/` (not `.ts` source), so the step builds + rewrites `exports`/`bin` to dist before `npm publish`.

### Changes
- `publish-npm.yml`: new OIDC publish step (build → rewrite → `npm publish --provenance`), `continue-on-error: true` (bootstrap-safe), build-output guard.
- `publish-start.ts`: removed servicenow-mcp from the token path (version still bumped by the glob loop).
- `script/publish.ts` → `build-for-publish.ts` (build + exports/bin→dist rewrite only).
- `package.json`: added `repository`/`homepage`/`bugs` (`--provenance` requires `repository.url`).

### ⚠️ Merge preconditions (ordered — do NOT merge until all green)
- [x] `repository` field added (in this PR)
- [x] OIDC step `continue-on-error` (in this PR)
- [ ] **#191 merged** to `main`, then retarget this PR to `main`
- [ ] **Bootstrap publish**: one-time token `npm publish` so `@serac-labs/servicenow-mcp` exists on npm (a Trusted Publisher can't be configured for a non-existent package — confirmed npm E404 today)
- [ ] **Register Trusted Publisher** on npmjs.com → `@serac-labs/servicenow-mcp` → GitHub Actions → repo `serac-labs/serac`, workflow `publish-npm.yml`
- [ ] **Merge**, then verify the first tagged release publishes with signed provenance (green, not just soft-skipped)
- [ ] **Follow-up PR**: remove `continue-on-error` so a future trusted-publisher/registry failure is loud again

Verified locally: `js-yaml` parses the workflow; the build + exports→dist rewrite produce a tarball whose every export resolves to a built `dist` file; turbo typecheck green. Reviewed adversarially across choreography/version, OIDC/npm, packaging, and merge-ordering before opening.