### PR TITLE
feat(servicenow-mcp): block writes to production instances by default

### DIFF
--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
@@ -15,7 +15,7 @@ import { tool_search_exec, tool_execute_exec } from "../tools/meta/index.js"
 import { ToolSearch } from "../shared/tool-search.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 import { formatArgsForLogging, isRetryableOperation } from "../shared/handler-helpers.js"
-import { reportArtifactToInstanceMap } from "../shared/instance-map-hook.js"
+import { reportArtifactToInstanceMap, isWriteTool } from "../shared/instance-map-hook.js"
 import { type HandlerDeps } from "./types.js"
 
 export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any) => {
@@ -128,6 +128,25 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     validateJWTExpiry(ctx.jwtPayload)
     validatePermission(tool.definition, ctx.jwtPayload)
 
+    // Prod-write safety: a write tool against a PRODUCTION-classified instance is
+    // blocked by default, so the agent can't silently change a client's prod.
+    // Reads — and writes to dev/test/uat — are never gated. The caller re-issues
+    // with `__confirmProd: true` only after the user approves the specific change;
+    // the flag is stripped below so the executor never sees it.
+    const prodWrite = context.environmentType === "production" && isWriteTool(tool.definition)
+    if (prodWrite && args?.__confirmProd !== true) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `"${name}" is a write against a PRODUCTION ServiceNow instance and is blocked by default. ` +
+          `Surface this change to the user; only after they approve, re-issue the exact same call with ` +
+          `"__confirmProd": true added to the arguments. Reads, and writes to dev/test/uat, need no confirmation.`,
+      )
+    }
+    const execArgs =
+      args && typeof args === "object" && "__confirmProd" in args
+        ? Object.fromEntries(Object.entries(args).filter(([k]) => k !== "__confirmProd"))
+        : args
+
     // Execute tool with error handling (permission check passed!).
     // Spread `origin` onto the context so tools that branch on transport
     // (snow_pull_artifact: write-to-disk on stdio, return-inline on http)
@@ -136,7 +155,7 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     const result = await executeWithErrorHandling(
       name,
       async () => {
-        return await tool.executor(args, contextWithOrigin)
+        return await tool.executor(execArgs, contextWithOrigin)
       },
       {
         retry: isRetryableOperation(name),

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/context-loader.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/context-loader.ts
@@ -355,6 +355,10 @@ export const loadContext = (): ServiceNowContext => {
   const refreshToken = process.env.SERVICENOW_REFRESH_TOKEN || process.env.SNOW_REFRESH_TOKEN
   const username = process.env.SERVICENOW_USERNAME || process.env.SNOW_USERNAME
   const password = process.env.SERVICENOW_PASSWORD || process.env.SNOW_PASSWORD
+  // OTAP classification (optional). Lets a self-hosted CLI user mark an instance
+  // "production" so the call-tool prod-write guard applies. Invalid/absent ⇒ undefined.
+  const rawEnvironment = (process.env.SERVICENOW_ENVIRONMENT_TYPE || process.env.SNOW_ENVIRONMENT_TYPE || "").toLowerCase()
+  const environmentType = (["production", "development", "test", "uat", "sandbox"] as const).find((v) => v === rawEnvironment)
 
   // Helper: Convert empty strings to undefined (treat empty as missing)
   const normalizeCredential = (val?: string) => (val && val.trim() !== "" ? val : undefined)
@@ -380,6 +384,7 @@ export const loadContext = (): ServiceNowContext => {
       refreshToken: normalizeCredential(refreshToken),
       username: normalizeCredential(username),
       password: normalizeCredential(password),
+      environmentType,
     }
   }
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/types.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/types.ts
@@ -54,6 +54,14 @@ export interface ServiceNowContext {
    * ignore it. Populated by call-tool.ts before the executor runs.
    */
   origin?: "stdio" | "http"
+  /**
+   * OTAP classification of the connected instance. When "production", the
+   * call-tool handler blocks write tools by default (reads stay free) unless the
+   * caller passes `__confirmProd: true` after the user approves the change.
+   * Populated by the transport's context resolver — HTTP from the portal's
+   * instance record, stdio from SNOW_ENVIRONMENT_TYPE. Absent ⇒ not gated.
+   */
+  environmentType?: "production" | "development" | "test" | "uat" | "sandbox"
 }
 
 /**


### PR DESCRIPTION
Fixes #201.

Adds `environmentType` to `ServiceNowContext` and a default prod-write guard at the `call-tool` chokepoint: when the connected instance is classified `production` and the tool is a write (`isWriteTool`), the call is blocked with an instructive error. The caller re-issues with `__confirmProd: true` after the user approves the specific change; the flag is stripped before the executor runs. Reads, and writes to dev/test/uat, are never gated.

`environmentType` is populated by the HTTP context resolver (hosted) or `SNOW_ENVIRONMENT_TYPE` (stdio/self-host). Absent means not gated, so existing setups are unaffected.

Covers the TUI, the web chat, and mobile in one place — the portal routes its write tools through the same chokepoint.