### PR TITLE
fix(docs): commit tools.json + sn-roles manifest to main (Complete Tool Reference 404)

### DIFF
--- a/packages/opencode/sn-roles.manifest.json
+++ b/packages/opencode/sn-roles.manifest.json
@@ -1,0 +1,17719 @@
+{
+  "version": 1,
+  "validatedOn": "glide-australia-02-11-2026__patch1-03-23-2026_03-31-2026_1137.zip",
+  "testedAt": "2026-05-14T10:16:56.949Z",
+  "stats": {
+    "tools": 428,
+    "untestable": 128,
+    "primitivesTotal": 462,
+    "primitivesResolved": 462,
+    "sourceDistribution": {
+      "direct": 870,
+      "wildcard": 189,
+      "inherited": 42
+    },
+    "topRoles": [
+      {
+        "role": "snc_internal",
+        "tools": 207
+      },
+      {
+        "role": "admin",
+        "tools": 149
+      },
+      {
+        "role": "public",
+        "tools": 130
+      },
+      {
+        "role": "delegated_developer",
+        "tools": 47
+      },
+      {
+        "role": "canvas_user",
+        "tools": 41
+      },
+      {
+        "role": "sn_app_eng_studio.admin",
+        "tools": 41
+      },
+      {
+        "role": "sn_app_eng_studio.user",
+        "tools": 41
+      },
+      {
+        "role": "ui_builder_admin",
+        "tools": 29
+      },
+      {
+        "role": "itil",
+        "tools": 26
+      },
+      {
+        "role": "catalog_admin",
+        "tools": 26
+      },
+      {
+        "role": "web_service_admin",
+        "tools": 23
+      },
+      {
+        "role": "workflow_creator",
+        "tools": 23
+      },
+      {
+        "role": "catalog_editor",
+        "tools": 22
+      },
+      {
+        "role": "catalog_manager",
+        "tools": 22
+      },
+      {
+        "role": "atf_test_admin",
+        "tools": 21
+      }
+    ]
+  },
+  "tools": {
+    "snow_scheduled_job_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "syslog_viewer",
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "write",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "delete",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "write",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_job_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "assessment_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_execution_tracker",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_trigger_scheduled_job": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_sp_widget": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sp_admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_sp_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sp_admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_page",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_sp_page_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "write",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "delete",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_page",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "sn_cd.content_approver",
+            "snc_internal",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sp_page",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_widget_instance",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_sp_theme_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sp_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_brand",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sp_brand",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_brand",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sp_theme",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_theme",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "read",
+          "roles": [
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_css",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "write",
+          "roles": [
+            "maint",
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_date_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_query_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_field_filter": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_saved_filter": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "filter_admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "filter_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_filter",
+          "operation": "create",
+          "roles": [
+            "filter_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 4
+        }
+      ]
+    },
+    "snow_configure_connection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_check_health": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_instance_info": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "knowledge_manager",
+          "mid_server",
+          "password_reset_admin",
+          "sn_sub_man.admin",
+          "snc_internal",
+          "ts_admin",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_batch_request": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_test_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_metric": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "metric_admin"
+        ],
+        "minimumBundle": [
+          "metric_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "metric_definition",
+          "operation": "create",
+          "roles": [
+            "metric_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_collect_metric": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_recommendation_engine": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sentiment_analysis": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_ai_classify": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_autocomplete": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_fuzzy_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_duplicate_detection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_ml_predict": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_anomaly_detection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_pa_dashboard": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_dashboards",
+          "operation": "create",
+          "roles": [
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "create",
+          "roles": [
+            "pa_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_data_quality": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "report_admin"
+        ],
+        "minimumBundle": [
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "create",
+          "roles": [
+            "report_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_define_kpi": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "pa_admin",
+          "pa_data_collector",
+          "pa_power_user"
+        ],
+        "minimumBundle": [
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_schedule_report_delivery": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "report_admin",
+          "report_scheduler"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysauto_report",
+          "operation": "create",
+          "roles": [
+            "report_scheduler",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_report_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_schedule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report_users_view",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_change_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_task",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_change_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_task",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "sn_change_task_assigned_user",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "change_request",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_ui_policy_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_policy_admin"
+        ],
+        "minimumBundle": [
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_policy",
+          "operation": "read",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_parse_json": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_track_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_deployment",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_devops_change": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "sn_change_write"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "change_request",
+          "operation": "create",
+          "roles": [
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_devops_insights": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_metrics",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_velocity_tracking": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_velocity",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_source_control": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin",
+          "source_control_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_repo_status",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_repo_branch",
+          "operation": "read",
+          "roles": [
+            "source_control_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_repo_stash",
+          "operation": "read",
+          "roles": [
+            "source_control_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_devops_pipeline": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_devops_pipeline",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_add_form_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_element",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_form_section": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_section",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_form": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_form_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_form",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_disable_business_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "business_rule_admin",
+          "maint"
+        ],
+        "minimumBundle": [
+          "business_rule_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script",
+          "operation": "write",
+          "roles": [
+            "business_rule_admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_business_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "business_rule_admin"
+        ],
+        "minimumBundle": [
+          "business_rule_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script",
+          "operation": "create",
+          "roles": [
+            "business_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_asset_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "discovery_schedule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_asset_compliance_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_manage_software_license": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sam",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license",
+          "operation": "write",
+          "roles": [
+            "sam"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license",
+          "operation": "create",
+          "roles": [
+            "sam"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "create",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_retire_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_transfer_asset": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_optimize_licenses": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_license",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "alm_asset",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_license_usage",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_track_asset_lifecycle": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "asset",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "alm_asset",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_asset",
+          "operation": "write",
+          "roles": [
+            "asset"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "alm_audit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_related_list": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "form_admin"
+        ],
+        "minimumBundle": [
+          "form_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_related_list",
+          "operation": "create",
+          "roles": [
+            "form_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_list_view": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_list_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_add_list_column": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_list_element",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_aggregate_metrics": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_uib_page_registry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_event": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_event",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_debug_widget_fetch": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_client_state": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_configure_uib_data_broker": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "write",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_uib_page_performance": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_uib_discover": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin",
+          "uxframework_user"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "read",
+          "roles": [
+            "response_header_admin",
+            "response_header_viewer",
+            "sn_cmdb_ws.config_editor",
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "read",
+          "roles": [
+            "response_header_admin",
+            "response_header_viewer",
+            "sn_cmdb_ws.config_editor",
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_uib_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_client_script",
+          "operation": "create",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_uib_page_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_client_script",
+          "operation": "delete",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "delete",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "delete",
+          "roles": [
+            "maint",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "delete",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_element",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_event",
+          "operation": "read",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_uib_component_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_lib_component",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_uib_data_broker": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_data_broker",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_security_policies": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_threat_intelligence": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_automate_threat_response": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_compliance_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_compliance_control",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_policy_exception",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_policy_exception",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_evidence",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sn_compliance_control",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_run_compliance_scan": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_compliance_scan",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_scan",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sn_compliance_report",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_audit_rule": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_elevate_role": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_issue_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_vulnerability_scan": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_access_control": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_security_risk_assessment": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "risk_assessment",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "risk_assessment",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sn_vul_vulnerable_item",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_escalate_permissions": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_vulnerability_risk_assessment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_compliance_rule": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_vendor_risk_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_audit_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_evidence_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_audit_trail_analysis": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_security_dashboard": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_playbook_orchestrate": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_execute_security_playbook": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_policy_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_discover_security_frameworks": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_incident_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_grc_risk_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_kms_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_module",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_crypto_module",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_kmf_key",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_security_incident": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_security_policy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sir_indicator_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_scan_vulnerabilities": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_vul_scan",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_blast_radius_table_configs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "delegated_developer",
+          "mobile_analytics_viewer",
+          "now_experience_analytics_viewer",
+          "portal_analytics_viewer",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_field_references": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_filter",
+          "operation": "read",
+          "roles": [
+            "filter_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_artifact_dependencies": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "api_service_admin",
+          "oauth_admin",
+          "script_include_admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_blast_radius_dependents": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "api_service_admin",
+          "oauth_admin",
+          "script_include_admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_blast_radius_apps": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "data_mgmt_tools_admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_blast_radius_update_sets": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin",
+          "update_set_previewer",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_code_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_dev_test_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_validate_live_connection": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_requirements": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_edit_by_sysid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_memory_search": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_data_consistency": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_orchestrate_development": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_plugin_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_plugins",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_package",
+          "scriptAcls": 2
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "function_field_admin",
+          "personalize_dictionary"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dictionary",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "atf_test_admin",
+            "atf_test_designer",
+            "function_field_admin",
+            "personalize_dictionary"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_bulk_update": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_data_export": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_choice": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "personalize",
+          "personalize_choices",
+          "personalize_decision_table_input",
+          "personalize_responses"
+        ],
+        "minimumBundle": [
+          "personalize"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_choice",
+          "operation": "create",
+          "roles": [
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_table": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "personalize_dictionary",
+          "sn_cmdb_admin"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "personalize_dictionary",
+            "sn_cmdb_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_field_map": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "import_admin",
+          "import_transformer"
+        ],
+        "minimumBundle": [
+          "import_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_transform_map",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_entry",
+          "operation": "create",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_generate_docs": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_connection_alias": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_connection",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_rest_message_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "write",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "write",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "delete",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn_parameters",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_schedule_job": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_integration_endpoints": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "email_account_admin",
+          "mid_server",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_web_service",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ldap_server_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "mid_server",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_email_account",
+          "operation": "read",
+          "roles": [
+            "email_account_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_analyze_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_db_index",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_credential_alias": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "basic_auth_credentials",
+          "operation": "create",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "api_key_credentials",
+          "operation": "create",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_alias",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_manage_mid_capabilities": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "agent_admin"
+        ],
+        "minimumBundle": [
+          "agent_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "create",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ecc_agent_capability",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "delete",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_workflow_analyze": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_configure_mid_server": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "agent_admin",
+          "soap_ecc"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_capability_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "read",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_queue",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "soap_ecc"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "write",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "write",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent_application_m2m",
+          "operation": "create",
+          "roles": [
+            "agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_oauth_profile": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "external_app_install_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "oauth_entity",
+          "operation": "create",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "create",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_flow_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "action_designer",
+          "connection_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "create",
+          "roles": [
+            "action_designer",
+            "admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_action_input",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_action_output",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_step_ext",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_step_ext",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_manage_oauth_tokens": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "oauth_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_credential",
+          "operation": "read",
+          "roles": [
+            "oauth_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_entity_profile",
+          "operation": "read",
+          "roles": [
+            "external_app_install_admin",
+            "oauth_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "oauth_credential",
+          "operation": "read",
+          "roles": [
+            "oauth_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_web_service": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_web_service",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_detect_code_patterns": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_email_config": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "email_account_admin"
+        ],
+        "minimumBundle": [
+          "email_account_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_email_account",
+          "operation": "create",
+          "roles": [
+            "email_account_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_test_integration": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "import_admin",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_web_service",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_data_source",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_scheduler",
+            "import_transformer",
+            "mid_server",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_test_rest_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_test_mid_connectivity": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "agent_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ecc_agent",
+          "operation": "read",
+          "roles": [
+            "agent_admin",
+            "agent_security_admin",
+            "export_set_scheduler",
+            "mid_server",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_manage_spoke_connection": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin",
+          "credential_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "discovery_credentials",
+          "operation": "read",
+          "roles": [
+            "credential_admin",
+            "discovery_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_alias",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "write",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "create",
+          "roles": [
+            "connection_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_connection",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_data_sources": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "import_admin",
+          "mid_server",
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_import_set_table_list",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_data_source",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_scheduler",
+            "import_transformer",
+            "mid_server",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ldap_server_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "mid_server",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_map",
+          "operation": "read",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_rest_message": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "create",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_install_spoke": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "connection_admin",
+          "sn_help_setup_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "v_plugin",
+          "operation": "read",
+          "roles": [
+            "sn_help_setup_admin",
+            "upgrade_admin",
+            "usage_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_action_type_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_alias",
+          "operation": "read",
+          "roles": [
+            "connection_admin",
+            "credential_admin",
+            "import_admin",
+            "mid_server"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_spoke",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_catalog_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_guide",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_producer",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sc_cat_item",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_category",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_change_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_category",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_catalogs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager",
+          "itil",
+          "sn_change_write",
+          "sn_request_write"
+        ],
+        "minimumBundle": [
+          "catalog"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_catalog",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_change_write",
+            "sn_request_write",
+            "workspace_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_category",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "model_manager",
+            "sn_change_write",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_catalog_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "catalog_script_client",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_search_catalog": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item_option",
+          "operation": "read",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_catalog_item_details": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "catalog_ui_policy",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "catalog_script_client",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_catalog_ui_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "catalog_ui_policy",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "catalog_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_order_catalog_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "catalog_admin",
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_request",
+          "operation": "create",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_item_option",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_item_option_mtom",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_request_comments_write",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sc_req_item",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "sn_request_comments_write",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_client_script": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "client_script_admin"
+        ],
+        "minimumBundle": [
+          "client_script_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_client",
+          "operation": "create",
+          "roles": [
+            "client_script_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ui_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_page_admin"
+        ],
+        "minimumBundle": [
+          "ui_page_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_page",
+          "operation": "create",
+          "roles": [
+            "ui_page_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ui_action": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_discover_platform_tables": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_url_doctor": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_ui_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_policy_admin"
+        ],
+        "minimumBundle": [
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_policy",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy_action",
+          "operation": "create",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_session_context": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_table_schema_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "analytics_admin",
+          "ui_policy_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "business_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ui_policy",
+          "operation": "read",
+          "roles": [
+            "ui_policy_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_script_include": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "script_include_admin"
+        ],
+        "minimumBundle": [
+          "script_include_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_script_include",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "api_service_admin",
+            "oauth_admin",
+            "script_include_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_include",
+          "operation": "write",
+          "roles": [
+            "script_include_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_script_include",
+          "operation": "create",
+          "roles": [
+            "script_include_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_update_ux_app_config_landing_page": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_config",
+          "operation": "write",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_page_macroponent": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_macroponent",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_complete_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list_menu_config",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_list_category",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_list",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_ux_app_route": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_experience": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_ux_page_registry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_macroponent",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_ux_page_registry",
+          "operation": "create",
+          "roles": [
+            "canvas_admin",
+            "maint",
+            "ui_builder_admin",
+            "uxframework_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_workspace_configuration": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_experience",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_ux_app_config",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_page_property",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_screen_type",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ux_app_config": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "delegated_developer",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "delegated_developer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_config",
+          "operation": "create",
+          "roles": [
+            "delegated_developer",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_configurable_agent_workspace": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_ux_screen_type",
+          "operation": "create",
+          "roles": [
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_all_workspaces": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ui_builder_admin"
+        ],
+        "minimumBundle": [
+          "ui_builder_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_ux_app_route",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "ui_builder_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_ux_page",
+          "operation": "read",
+          "roles": [
+            "ui_builder_admin",
+            "uxframework_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_clone_instance": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_cicd_deploy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_backup_instance": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_role_group_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "role_admin",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_role",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "role_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_has_role",
+          "operation": "create",
+          "roles": [
+            "ai_user_admin",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "skill_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_user_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ai_user_admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "create",
+          "roles": [
+            "ai_user_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "write",
+          "roles": [
+            "ai_user_admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_impersonate_user": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "business_calendar_admin",
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_plugins",
+          "operation": "read",
+          "roles": [
+            "business_calendar_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "create",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "ml_solution_input_field",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_list_pi_solutions": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin",
+          "ml_report_user",
+          "platform_ml_read"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_activate_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "write",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "write",
+          "roles": [
+            "ml_admin",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_write"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_monitor_pi_training": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ml_admin",
+          "ml_report_user",
+          "platform_ml_read"
+        ],
+        "minimumBundle": [
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "nlu_admin",
+            "nlu_editor",
+            "platform_ml_read",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_train_pi_solution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "business_calendar_admin",
+          "ml_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_plugins",
+          "operation": "read",
+          "roles": [
+            "business_calendar_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "read",
+          "roles": [
+            "ml_admin",
+            "ml_report_user",
+            "platform_ml_read"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "ml_solution_definition",
+          "operation": "write",
+          "roles": [
+            "ml_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_data_convert": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_date": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_text": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_format_number": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_schedule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "schedule_admin"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "schedule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_oncall_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_member",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_rota_roster",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_add_schedule_entry": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil_admin",
+          "schedule_admin",
+          "sn_change_cab.cab_manager"
+        ],
+        "minimumBundle": [
+          "itil_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule_span",
+          "operation": "create",
+          "roles": [
+            "itil_admin",
+            "schedule_admin",
+            "sn_change_cab.cab_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_fsm_parts_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_fsm_work_order_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "pa_admin",
+          "personalize",
+          "personalize_choices",
+          "personalize_decision_table_input",
+          "personalize_responses",
+          "playbook.write",
+          "sn_gd_guidance.guidance_manager",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "pa_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_choice",
+          "operation": "read",
+          "roles": [
+            "pa_admin",
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses",
+            "playbook.write",
+            "sn_gd_guidance.guidance_manager",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_fsm_dispatch_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_record_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "assignment_rule_admin",
+          "cmdb_read",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_department",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_location",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysrule_assignment",
+          "operation": "read",
+          "roles": [
+            "assignment_rule_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_search_artifacts": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_table_fields": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "access_control_read_admin",
+            "personalize_dictionary",
+            "sn_kmf.cryptographic_manager",
+            "user_admin",
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_index",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_manage_group_membership": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "create",
+          "roles": [
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "delete",
+          "roles": [
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_operational_metrics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "problem",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "problem_task_analyst",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_cleanup_test_artifacts": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_assign_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_query_table": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_catalog_item_manager": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "write",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "write",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sc_cat_item",
+          "operation": "delete",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_auto_resolve_incident": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "write",
+          "roles": [
+            "itil",
+            "problem_coordinator",
+            "sn_incident_comments_write",
+            "sn_incident_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_predictive_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_catalog_item_search": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog",
+          "catalog_admin",
+          "catalog_builder_editor",
+          "catalog_editor",
+          "catalog_manager",
+          "itil",
+          "sn_request_write",
+          "snc_external",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "catalog"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "itil",
+            "sn_request_write",
+            "snc_external",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_cmdb_search": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_by_sysid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_pattern_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sc_request",
+          "operation": "read",
+          "roles": [
+            "catalog",
+            "itil",
+            "sn_request_approver_read",
+            "sn_request_read",
+            "sn_request_write",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "problem",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "problem_task_analyst",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_attach_file": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_analyze_incident": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "incident",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "ml_admin",
+            "ml_report_user",
+            "sn_incident_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_file_upload": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_scripted_rest_api": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_file_download": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_custom_api": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_graphql_query": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_agile_sprint_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_standup_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_release_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_release",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_defect",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_release",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_release",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_retrospective": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_defect",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_capacity_plan": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_epic_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_theme",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_epic",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_epic",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_sprint_board": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_scrum_task",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_sprint_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_backlog_groom": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_team_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "rm_team_member",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_agile_story_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_epic",
+          "operation": "read",
+          "roles": [],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "rm_story",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_agile_backlog_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_sprint_burndown": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_agile_velocity_report": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "rm_sprint",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "rm_story",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_project": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "pm_project",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_project_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "pm_project_task",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_generate_guid": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_timestamp": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_merge_objects": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sanitize_input": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_convert_es6_to_es5": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_random_string": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sleep": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_processor": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "maint"
+        ],
+        "minimumBundle": [
+          "maint"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_processor",
+          "operation": "create",
+          "roles": [
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_add_comment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_journal_entries": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "audit_viewer",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "audit_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_journal_field",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_customer_case": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_employee_onboarding": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_le_onboarding",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_hr_case": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_train_va_nlu": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_send_va_message": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_conversation",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_cs_message",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_discover_va_topics": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_va_topic_block": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_topic_block",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_handoff_to_agent": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_handoff",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_cs_conversation",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_va_topic": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "topic",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_va_conversation": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "interaction_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_cs_conversation",
+          "operation": "read",
+          "roles": [
+            "interaction_admin",
+            "interaction_agent"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_cs_message",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_transform_map": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin",
+          "import_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_transform_map",
+          "operation": "create",
+          "roles": [
+            "import_admin",
+            "import_transformer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_execute_transform": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_export_to_xml": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_import_set": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_transform_data": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_knowledge_base": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge_base",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_catalog_variable": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_knowledge_article_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_attachment",
+          "operation": "read",
+          "roles": [
+            "public",
+            "sn_glider.ide_git_user",
+            "sn_glider.read_admin",
+            "sn_sub_man.admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 9
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_knowledge",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_catalog_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sc_cat_item",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_knowledge_bases": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "kb_knowledge_base",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "kb_category",
+          "operation": "read",
+          "roles": [
+            "public"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_add_dashboard_widget": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard_widget",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_dashboard_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "dashboard_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "read",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_contributor",
+            "pa_power_user",
+            "pa_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dashboard_widget",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_dashboard_admin",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "create",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_power_user",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_tabs",
+          "operation": "read",
+          "roles": [
+            "dashboard_admin",
+            "pa_admin",
+            "pa_contributor",
+            "pa_power_user",
+            "pa_viewer",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_dashboard": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_dashboard",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_list_supported_artifacts": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_pull_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_cleanup": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_sync_status": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_push_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_convert_to_es5": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_mobile_layout": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_layout",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_send_push_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "fsm_skill_user",
+          "push_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_push_notification",
+          "operation": "create",
+          "roles": [
+            "push_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_mobile_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_action",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_mobile_analytics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_analytics",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_discover_mobile_configs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_ui_mobile_layout",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_ui_mobile_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_mobile_offline_config",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_configure_mobile_app": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_app",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_configure_offline_sync": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_mobile_offline_config",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_variable": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_variable_set": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "catalog_admin",
+          "catalog_editor",
+          "catalog_manager"
+        ],
+        "minimumBundle": [
+          "catalog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "item_option_new_set",
+          "operation": "create",
+          "roles": [
+            "catalog_admin",
+            "catalog_editor",
+            "catalog_manager"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_approve_procurement": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "proc_request",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_purchase_order": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "proc_po",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_solution_package": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_auth_diagnostics": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "sp_admin",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "create",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "delete",
+          "roles": [
+            "sp_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_deployment_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_artifact_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "data_mgmt_tools_admin",
+          "next_experience_admin",
+          "personalize",
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_security_acl",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_choice",
+          "operation": "create",
+          "roles": [
+            "personalize",
+            "personalize_choices",
+            "personalize_decision_table_input",
+            "personalize_responses"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml_backup",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_clone_instance_artifact": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_rollback_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_admin",
+          "update_set_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "delete",
+          "roles": [
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_version",
+          "operation": "read",
+          "roles": [
+            "teamdev_code_reviewer",
+            "teamdev_user",
+            "update_set_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_audit",
+          "operation": "create",
+          "roles": [
+            "audit_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_deployment_debug": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "announcement_admin",
+          "syslog_viewer",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sp_portal",
+          "operation": "read",
+          "roles": [
+            "announcement_admin",
+            "iar_admin",
+            "knowledge",
+            "knowledge_admin",
+            "knowledge_manager",
+            "portal_analytics_admin",
+            "response_header_admin",
+            "response_header_viewer",
+            "sp_admin",
+            "sp_operator",
+            "virtual_agent_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_github_deploy": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_github_tree": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_validate_deployment": {
+      "snRoles": {
+        "anyOf": [
+          "access_analyzer_admin",
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "asset",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "decision_table_admin",
+          "delegated_developer",
+          "itil",
+          "mobile_analytics_viewer",
+          "nlq_admin",
+          "now_experience_analytics_viewer",
+          "pa_analyst",
+          "personalize_decision_table_input",
+          "portal_analytics_viewer",
+          "sn_change_read",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor",
+          "sn_gd_guidance.guidance_manager",
+          "sn_help_setup_admin",
+          "sn_incident_read",
+          "sn_incident_write",
+          "sn_problem_read",
+          "sn_problem_write",
+          "sn_request_read",
+          "sn_sub_man.admin",
+          "usage_admin",
+          "user_admin",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "access_analyzer_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_decode_base64": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_hash_string": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_encode_base64": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_encode_url": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_decode_url": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_workflow": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_start_workflow": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_workflow_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_context",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_context",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_activity",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "delete",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_history",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_workflow_transition": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "read",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_transition",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "write",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "wf_transition",
+          "operation": "delete",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_calculate_sla_duration": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_customer_account": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_account",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_csm_contract_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_csm_communication_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_entitlement": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_entitlement",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_customer_history": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sn_customerservice_case",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_email",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_hr_task": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_task",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_hr_profile_manage": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_employee_offboarding": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sn_hr_core_case",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_hr_lifecycle_event": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_jwt_decode": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_property_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "knowledge_manager",
+          "mid_server",
+          "password_reset_admin",
+          "sn_sub_man.admin",
+          "snc_internal",
+          "ts_admin",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_io": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer",
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_property_bulk": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_application": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user",
+          "upgrade_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "create",
+          "roles": [
+            "upgrade_admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_scope",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_install_application": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "nobody"
+        ],
+        "minimumBundle": [
+          "nobody"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_store_app",
+          "operation": "create",
+          "roles": [
+            "nobody"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_switch_application_scope": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_current_scope": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_list_applications": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_metadata",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_manage_flow": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "flow_admin",
+          "flow_designer",
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_logic_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_logic_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_input",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_output",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_logic_definition",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "create",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "write",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow_version",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_action_instance",
+          "operation": "read",
+          "roles": [
+            "flow_admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_hub_flow_component",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_variable",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_run",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_trigger_instance",
+          "operation": "read",
+          "roles": [
+            "flow_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_flow_context",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_hub_flow_run",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_output",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "connection_admin",
+            "workflow_creator"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "var_dictionary",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_safe_edit",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "flow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sys_hub_flow_lock",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_menu_item": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "next_experience_admin"
+        ],
+        "minimumBundle": [
+          "next_experience_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_menu": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "next_experience_admin"
+        ],
+        "minimumBundle": [
+          "next_experience_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app_module",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "next_experience_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_queue": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_queue",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_queue_items": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_queue",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_template",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_apply_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal",
+          "template_editor_global",
+          "template_editor_group"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_template",
+          "operation": "read",
+          "roles": [
+            "snc_internal",
+            "template_editor_global",
+            "template_editor_group"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_sla": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sla_admin",
+          "sla_manager",
+          "sm_admin",
+          "wm_admin"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "contract_sla",
+          "operation": "create",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "sm_admin",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_sla_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "read",
+          "roles": [
+            "contract_manager",
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "sn_sla_definition_read",
+            "wm_admin",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "contract_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "write",
+          "roles": [
+            "sla_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_sla_status": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "service_viewer",
+          "sla_admin",
+          "sla_manager",
+          "sn_change_read",
+          "sn_incident_read",
+          "sn_problem_read",
+          "wm_agent",
+          "wm_dispatcher",
+          "wm_qualifier"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "task_sla",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "service_viewer",
+            "sla_admin",
+            "sla_manager",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "wm_agent",
+            "wm_dispatcher",
+            "wm_qualifier"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_script_output": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_script_execution_history",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_property_manager": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "maint",
+          "password_reset_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_discover_automation_jobs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cmdb_admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "sn_cmdb_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "read",
+          "roles": [
+            "sn_cmdb_admin",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_flow_execution_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_flow_context",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_flow_log",
+          "operation": "read",
+          "roles": [
+            "flow_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_workflow_activity": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "workflow_creator"
+        ],
+        "minimumBundle": [
+          "workflow_creator"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "wf_workflow",
+          "operation": "read",
+          "roles": [
+            "catalog_admin",
+            "catalog_builder_editor",
+            "catalog_editor",
+            "catalog_manager",
+            "knowledge_admin",
+            "knowledge_manager",
+            "sla_admin",
+            "sla_manager",
+            "workflow_creator",
+            "workflow_publisher"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "wf_activity",
+          "operation": "create",
+          "roles": [
+            "workflow_creator"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_email_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_email",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_sla_definition": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sla_admin",
+          "sla_manager"
+        ],
+        "minimumBundle": [
+          "sla_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        },
+        {
+          "table": "contract_sla",
+          "operation": "create",
+          "roles": [
+            "sla_admin",
+            "sla_manager",
+            "sm_admin",
+            "wm_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_slow_queries": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_slow_query_log",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_outbound_http_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_outbound_http_log",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_events": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_viewer"
+        ],
+        "minimumBundle": [
+          "events_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_register",
+          "operation": "read",
+          "roles": [
+            "events_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_event_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin",
+          "sysevent_script_action_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_script_action",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "sysevent_script_action_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_execute_script": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_logs": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_trace_execution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "knowledge_manager",
+          "maint"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "maint",
+            "password_reset_admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_properties",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "maint"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_rest_message_test_suite": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "web_service_admin"
+        ],
+        "minimumBundle": [
+          "web_service_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_fn",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_rest_message_headers",
+          "operation": "read",
+          "roles": [
+            "web_service_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_inspect_mutations": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "atf_test_admin",
+          "audit_viewer",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_escalation_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_escalation",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_scheduled_job_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "assessment_admin",
+          "syslog_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_trigger",
+          "operation": "read",
+          "roles": [
+            "assessment_admin",
+            "events_dashboard_viewer",
+            "events_viewer",
+            "maint",
+            "pa_data_collector",
+            "scheduler_dashboard_viewer",
+            "survey_admin",
+            "system_scheduler_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "syslog",
+          "operation": "read",
+          "roles": [
+            "syslog_viewer",
+            "wm_admin",
+            "workflow_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_redeploy_script_endpoint": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_inbound_http_logs": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer",
+          "system_scheduler_admin",
+          "ui_builder_admin",
+          "user_impersonation_history_viewer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog_transaction",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer",
+            "system_scheduler_admin",
+            "ui_builder_admin",
+            "user_impersonation_history_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_confirm_script_execution": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "snc_internal",
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_trigger",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "system_scheduler_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_properties",
+          "operation": "read",
+          "roles": [
+            "knowledge_manager",
+            "mid_server",
+            "password_reset_admin",
+            "sn_sub_man.admin",
+            "snc_internal",
+            "ts_admin",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_properties",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "maint",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "delete",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_schedules": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "itil",
+          "sla_admin",
+          "sla_manager",
+          "sn_cd.content_approver",
+          "sn_change_read",
+          "sn_incident_read",
+          "sn_problem_read",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "itil"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmn_schedule",
+          "operation": "read",
+          "roles": [
+            "itil",
+            "sla_admin",
+            "sla_manager",
+            "sn_cd.content_approver",
+            "sn_change_read",
+            "sn_incident_read",
+            "sn_problem_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_data_mapper": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_field_mapper": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_validate_sysid": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin",
+          "update_set_previewer",
+          "upgrade_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_widget_coherence": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cd.content_approver",
+          "sn_hr_sp.admin",
+          "sp_admin",
+          "sp_operator"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_validate_record": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_validate_field": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "analytics_admin",
+          "analytics_viewer",
+          "atf_test_admin",
+          "atf_test_designer",
+          "core_ui_analytics_viewer",
+          "data_classification_auditor",
+          "delegated_developer",
+          "function_field_admin",
+          "mobile_analytics_viewer",
+          "nds_admin",
+          "now_experience_analytics_viewer",
+          "personalize_dictionary",
+          "personalize_read_dictionary",
+          "portal_analytics_viewer",
+          "web_analytics_viewer"
+        ],
+        "minimumBundle": [
+          "analytics_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_widget_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "sn_cd.content_approver",
+          "sn_hr_sp.admin",
+          "sp_admin",
+          "sp_operator"
+        ],
+        "minimumBundle": [
+          "sn_cd.content_approver"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sp_widget",
+          "operation": "read",
+          "roles": [
+            "sn_cd.content_approver",
+            "sn_hr_sp.admin",
+            "sp_admin",
+            "sp_operator"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_generate_records": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_user_roles": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "ai_user_admin",
+          "itil",
+          "role_delegator",
+          "role_delegator_admin",
+          "user_admin"
+        ],
+        "minimumBundle": [
+          "ai_user_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_has_role",
+          "operation": "read",
+          "roles": [
+            "ai_user_admin",
+            "itil",
+            "role_delegator",
+            "role_delegator_admin",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_test_acl": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_script_execution",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_acl_role": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "security_admin"
+        ],
+        "minimumBundle": [
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_security_acl_role",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_acl": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "security_admin"
+        ],
+        "minimumBundle": [
+          "security_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_security_acl",
+          "operation": "create",
+          "roles": [
+            "security_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_indicator_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "write",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "delete",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_indicators",
+          "operation": "delete",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_breakdowns_indicator",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_pa_discover": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "analytics_admin",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_dictionary",
+          "operation": "read",
+          "roles": [
+            "analytics_admin",
+            "analytics_viewer",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "delegated_developer",
+            "function_field_admin",
+            "mobile_analytics_viewer",
+            "nds_admin",
+            "now_experience_analytics_viewer",
+            "personalize_dictionary",
+            "personalize_read_dictionary",
+            "portal_analytics_viewer",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_db_object",
+          "operation": "read",
+          "roles": [
+            "access_analyzer_admin",
+            "analytics_admin",
+            "analytics_viewer",
+            "asset",
+            "atf_test_admin",
+            "atf_test_designer",
+            "core_ui_analytics_viewer",
+            "data_classification_auditor",
+            "decision_table_admin",
+            "delegated_developer",
+            "itil",
+            "mobile_analytics_viewer",
+            "nlq_admin",
+            "now_experience_analytics_viewer",
+            "pa_analyst",
+            "personalize_decision_table_input",
+            "portal_analytics_viewer",
+            "sn_change_read",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor",
+            "sn_gd_guidance.guidance_manager",
+            "sn_help_setup_admin",
+            "sn_incident_read",
+            "sn_incident_write",
+            "sn_problem_read",
+            "sn_problem_write",
+            "sn_request_read",
+            "sn_sub_man.admin",
+            "usage_admin",
+            "user_admin",
+            "web_analytics_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_create": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "report_admin",
+          "report_scheduler"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_indicators",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_breakdowns",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "pa_thresholds",
+          "operation": "create",
+          "roles": [
+            "pa_admin",
+            "pa_power_user",
+            "pa_threshold_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "pa_widgets",
+          "operation": "create",
+          "roles": [
+            "pa_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_report_chart",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysauto_report",
+          "operation": "create",
+          "roles": [
+            "report_scheduler",
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_pa_operate": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "pa_admin",
+          "report_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "pa_collection_jobs",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_report",
+          "operation": "read",
+          "roles": [
+            "report_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "pa_scores",
+          "operation": "read",
+          "roles": [
+            "pa_admin",
+            "pa_contributor",
+            "pa_data_collector",
+            "pa_power_user"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_event_queue": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_dashboard_viewer",
+          "events_viewer",
+          "pa_data_collector"
+        ],
+        "minimumBundle": [
+          "events_dashboard_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent",
+          "operation": "read",
+          "roles": [
+            "events_dashboard_viewer",
+            "events_viewer",
+            "pa_data_collector"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_event": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent",
+          "operation": "create",
+          "roles": [
+            "events_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_monitor_metrics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "metric",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_create_alert_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert_rule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_alert": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_request_approval": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_approval_chain_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "fsm_skill_user",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_grmember",
+          "operation": "read",
+          "roles": [
+            "fsm_skill_user",
+            "group_viewer",
+            "itil",
+            "rota_admin",
+            "rota_manager",
+            "skill_user",
+            "sn_cmdb_user",
+            "user_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_group",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "read",
+          "roles": [
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysapproval_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_approver",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "read",
+          "roles": [
+            "sn_change_read",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sysapproval_group",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysapproval_action",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_get_pending_approvals": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_approve_reject": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysapproval_approver",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_attachments": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_delete_attachment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_upload_attachment": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_execute_atf_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_suite",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_result",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test_step": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_step",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_atf_results": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_result",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_atf_test_suite": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test_suite",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_atf_test_suite_test",
+          "operation": "create",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_discover_atf_tests": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "atf_test_admin",
+          "atf_test_designer"
+        ],
+        "minimumBundle": [
+          "atf_test_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_atf_test",
+          "operation": "read",
+          "roles": [
+            "atf_test_admin",
+            "atf_test_designer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_data_policy": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_data_policy2",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_data_policy_rule": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_data_policy_rule",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sys_metadata",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_run_discovery": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "discovery_schedule_item",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_create_ci": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_ci_relationships": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "cmdb_read",
+          "itil",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_search_cmdb": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_get_event_correlation": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "canvas_user",
+          "delegated_developer",
+          "public",
+          "sn_app_eng_studio.admin",
+          "sn_app_eng_studio.user",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "em_alert",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_event",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_alert",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        },
+        {
+          "table": "em_alert_rule",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "canvas_user",
+            "delegated_developer",
+            "public",
+            "sn_app_eng_studio.admin",
+            "sn_app_eng_studio.user",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 3
+        }
+      ]
+    },
+    "snow_get_ci_history": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "audit_viewer",
+          "sn_hr_sp.esc_admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_reconcile_ci": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "certification",
+          "itil",
+          "sn_change_write",
+          "sn_cmdb_admin",
+          "sn_cmdb_editor"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "write",
+          "roles": [
+            "asset",
+            "certification",
+            "itil",
+            "sn_change_write",
+            "sn_cmdb_admin",
+            "sn_cmdb_editor"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_ci_health_check": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_update_ci": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_impact_analysis": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "cmdb_read",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_ci_service",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "cmdb_ci",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_get_ci_impact": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "cmdb_read",
+          "itil",
+          "service_viewer"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_ci_relationship": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "asset",
+          "itil",
+          "service_editor",
+          "sn_cmdb_editor"
+        ],
+        "minimumBundle": [
+          "asset"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "create",
+          "roles": [
+            "asset",
+            "itil",
+            "service_editor",
+            "sn_cmdb_editor"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_get_ci_details": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "audit_viewer",
+          "cmdb_read"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "cmdb_ci",
+          "operation": "read",
+          "roles": [
+            "cmdb_read",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "cmdb_rel_ci",
+          "operation": "read",
+          "roles": [
+            "asset",
+            "cmdb_read",
+            "itil",
+            "service_viewer"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_audit",
+          "operation": "read",
+          "roles": [
+            "audit_viewer",
+            "sn_hr_sp.esc_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_event_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "events_admin",
+          "sysevent_script_action_admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_script_action",
+          "operation": "create",
+          "roles": [
+            "events_admin",
+            "sysevent_script_action_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_callback_handler": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_error_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "public",
+          "snc_internal"
+        ],
+        "minimumBundle": []
+      },
+      "primitives": [
+        {
+          "table": "sys_error_handler",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_exception_handler": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "syslog_admin"
+        ],
+        "minimumBundle": [
+          "syslog_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "syslog",
+          "operation": "create",
+          "roles": [
+            "syslog_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_cache_set": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_cache_get": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_rate_limit": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_paginate": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_retry_operation": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_diff_objects": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_send_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_send_push": {
+      "snRoles": null,
+      "untestable": true,
+      "reason": "no /api/now/table/<table> calls detected in static analysis"
+    },
+    "snow_create_notification_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_notification_preferences": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_schedule_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "system_scheduler_admin"
+        ],
+        "minimumBundle": [
+          "system_scheduler_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysauto_script",
+          "operation": "create",
+          "roles": [
+            "system_scheduler_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_emergency_broadcast": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "events_admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent",
+          "operation": "create",
+          "roles": [
+            "events_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_notification_analytics": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        }
+      ]
+    },
+    "snow_create_notification": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_create_email_template": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_send_email": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_player"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_email",
+          "operation": "create",
+          "roles": [
+            "sn_help_setup_player"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_email_template_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "sn_help_setup_player",
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_email",
+          "operation": "create",
+          "roles": [
+            "sn_help_setup_player"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "write",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_inbound_email_action": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "admin"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "read",
+          "roles": [
+            "admin",
+            "snc_internal"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "create",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "write",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "delete",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_in_email_action",
+          "operation": "write",
+          "roles": [
+            "admin"
+          ],
+          "source": "inherited",
+          "inheritedFrom": "sysrule",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_email_notification_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "snc_internal"
+        ],
+        "minimumBundle": [
+          "snc_internal"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_template",
+          "operation": "read",
+          "roles": [
+            "sn_publications.author",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "delete",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sysevent_email_action",
+          "operation": "create",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_update_set_query": {
+      "snRoles": {
+        "anyOf": [
+          "admin",
+          "teamdev_user",
+          "update_set_admin"
+        ],
+        "minimumBundle": [
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    },
+    "snow_ensure_active_update_set": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "data_mgmt_tools_admin",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        }
+      ]
+    },
+    "snow_update_set_manage": {
+      "snRoles": {
+        "anyOf": [
+          "admin"
+        ],
+        "minimumBundle": [
+          "nobody",
+          "snc_internal",
+          "teamdev_user"
+        ]
+      },
+      "primitives": [
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_app",
+          "operation": "read",
+          "roles": [
+            "data_mgmt_tools_admin",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "create",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_user",
+          "operation": "read",
+          "roles": [
+            "public",
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "write",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "create",
+          "roles": [
+            "admin",
+            "public",
+            "snc_internal"
+          ],
+          "source": "wildcard",
+          "scriptAcls": 2
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "write",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "create",
+          "roles": [
+            "nobody"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_user_preference",
+          "operation": "read",
+          "roles": [
+            "snc_internal"
+          ],
+          "source": "direct",
+          "scriptAcls": 1
+        },
+        {
+          "table": "sys_update_set",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_picker"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        },
+        {
+          "table": "sys_update_xml",
+          "operation": "read",
+          "roles": [
+            "teamdev_user",
+            "update_set_admin",
+            "update_set_previewer",
+            "upgrade_admin"
+          ],
+          "source": "direct",
+          "scriptAcls": 0
+        }
+      ]
+    }
+  }
+}

--- a/packages/opencode/tools.json
+++ b/packages/opencode/tools.json
@@ -1,0 +1,25855 @@
+{
+  "generatedAt": "2026-06-08T17:14:40.382Z",
+  "count": 429,
+  "groups": [
+    {
+      "name": "access-control",
+      "displayName": "Access Control",
+      "tools": [
+        {
+          "name": "snow_create_access_control",
+          "description": "Create an Access Control List (ACL) entry on a table: grants a role permission to perform an operation (read/write/create/delete) on records, optionally gated by a condition or advanced script. Writes to sys_security_acl.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "configuration",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "table": {
+                "type": "string"
+              },
+              "operation": {
+                "type": "string"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "condition": {
+                "type": "string"
+              },
+              "advanced": {
+                "type": "boolean"
+              },
+              "active": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "operation"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_acl",
+          "description": "Create Access Control List rule",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "acl",
+            "security",
+            "permissions"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "ACL name"
+              },
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write",
+                  "create",
+                  "delete"
+                ],
+                "description": "Operation type"
+              },
+              "type": {
+                "type": "string",
+                "description": "ACL type (record/field)"
+              },
+              "admin_overrides": {
+                "type": "boolean",
+                "default": true
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "operation"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_acl_role",
+          "description": "Link a role (sys_user_role) to an existing ACL by creating a sys_security_acl_role record. After linking, anyone holding that role is granted access under the ACL's table/operation/condition.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "acl",
+            "roles",
+            "security"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "acl": {
+                "type": "string",
+                "description": "ACL sys_id"
+              },
+              "role": {
+                "type": "string",
+                "description": "Role sys_id"
+              }
+            },
+            "required": [
+              "acl",
+              "role"
+            ]
+          }
+        },
+        {
+          "name": "snow_test_acl",
+          "description": "Simulate whether a user would be granted a given operation (read/write/create/delete) on a table or specific record under the current ACL configuration. Runs a server-side script using GlideRecord.canRead/canWrite/canCreate/canDelete.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "acl",
+            "testing",
+            "security"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write",
+                  "create",
+                  "delete"
+                ],
+                "description": "Operation"
+              },
+              "user": {
+                "type": "string",
+                "description": "User sys_id to test"
+              },
+              "record_id": {
+                "type": "string",
+                "description": "Specific record sys_id"
+              }
+            },
+            "required": [
+              "table",
+              "operation"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "administration",
+      "displayName": "Administration",
+      "tools": [
+        {
+          "name": "snow_backup_instance",
+          "description": "Request a snapshot backup of the current ServiceNow instance under a chosen name, optionally including attachments. Returns the backup name and timestamp; the backup itself runs asynchronously.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "backup",
+            "disaster-recovery",
+            "instance-management"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "backup_name": {
+                "type": "string",
+                "description": "Backup name"
+              },
+              "include_attachments": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "backup_name"
+            ]
+          }
+        },
+        {
+          "name": "snow_clone_instance",
+          "description": "Request a sub-prod instance clone from source to target (e.g. prod → test). Optional data_preservers list keeps specified records intact across the clone; cloning runs asynchronously and typically takes hours.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "instance-cloning",
+            "environment-setup",
+            "testing"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "source_instance": {
+                "type": "string",
+                "description": "Source instance name"
+              },
+              "target_instance": {
+                "type": "string",
+                "description": "Target instance name"
+              },
+              "data_preservers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Data preservers"
+              }
+            },
+            "required": [
+              "source_instance",
+              "target_instance"
+            ]
+          }
+        },
+        {
+          "name": "snow_plugin_manage",
+          "description": "Manage ServiceNow plugins: list, check status, activate, deactivate, repair, or poll an async progress.\n\nActions:\n- list — Search and list plugins. Filter by name/ID, show only active.\n- check — Get detailed info on a specific plugin (status, version, dependencies). Pass verify_table to also query sys_db_object for a table the plugin should have created — covers the case where v_plugin reports inactive but the plugin's tables actually exist (known v_plugin staleness after CICD activation).\n- activate — Activate a plugin via CICD API (/api/sn_cicd/plugin) with sys_plugins table-PATCH fallback. Returns the progress_id so callers can poll completion. Pass wait=true to block until the plugin reaches a final state (or timeout_ms elapses, default 10 min).\n- deactivate — Deactivate a plugin via the same dual mechanism.\n- repair — Rollback the plugin then re-activate it (clean reinstall). Returns both progress_ids; pass wait=true to block until the activate phase completes. Requires plugin-activation privileges in ServiceNow.\n- progress — Poll a CICD progress record (/api/sn_cicd/progress/{id}) by progress_id. Use to check status of an earlier activate/repair without blocking.\n\nExamples:\n- { action: \"list\", search: \"incident\" }\n- { action: \"check\", plugin_id: \"com.snc.incident\" }\n- { action: \"activate\", plugin_id: \"com.snc.incident\", wait: true }\n- { action: \"repair\", plugin_id: \"com.snc.incident\" }\n- { action: \"progress\", progress_id: \"1227ba16937083101bf5f99bdd03d60c\" }",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "plugin-discovery",
+            "plugin-management",
+            "plugin-status",
+            "activation",
+            "deactivation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Operation to perform",
+                "enum": [
+                  "list",
+                  "check",
+                  "activate",
+                  "deactivate",
+                  "repair",
+                  "progress"
+                ]
+              },
+              "plugin_id": {
+                "type": "string",
+                "description": "[check/activate/deactivate/repair] Plugin identifier (e.g. \"com.snc.incident\") or sys_id"
+              },
+              "verify_table": {
+                "type": "string",
+                "description": "[check] Optional table name the plugin should have created (e.g. \"wm_order\" for FSM). When provided, the tool also queries sys_db_object — handles the known case where v_plugin reports inactive but the plugin's tables exist (post-activation v_plugin lag)."
+              },
+              "search": {
+                "type": "string",
+                "description": "[list] Filter by plugin name or ID (e.g. \"incident\", \"com.snc\")"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list] Only show active plugins",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Max results to return (default 50)",
+                "default": 50
+              },
+              "progress_id": {
+                "type": "string",
+                "description": "[progress] CICD progress record sys_id, returned by a prior activate/repair call"
+              },
+              "wait": {
+                "type": "boolean",
+                "description": "[activate/repair] Block until the install reaches a final state (Successful/Failed/Cancelled) or timeout_ms elapses. Default false — return progress_id immediately for async polling via the progress action.",
+                "default": false
+              },
+              "timeout_ms": {
+                "type": "number",
+                "description": "[activate/repair when wait=true] Max time to wait in milliseconds. Default 600000 (10 min).",
+                "default": 600000
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "agile",
+      "displayName": "Agile",
+      "tools": [
+        {
+          "name": "snow_agile_backlog_groom",
+          "description": "Backlog grooming operations: reprioritize stories, bulk-update story points, move stories between epics, and assign stories to sprints in batch.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "backlog",
+            "grooming",
+            "refinement"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "reprioritize",
+                  "estimate",
+                  "assign_sprint",
+                  "move_epic"
+                ],
+                "description": "Grooming action: reprioritize (change priority), estimate (set story points), assign_sprint (move to sprint), move_epic (reassign epic)"
+              },
+              "stories": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "sys_id": {
+                      "type": "string",
+                      "description": "Story sys_id"
+                    },
+                    "priority": {
+                      "type": "number",
+                      "description": "New priority (for reprioritize)"
+                    },
+                    "story_points": {
+                      "type": "number",
+                      "description": "Story point estimate (for estimate)"
+                    },
+                    "order": {
+                      "type": "number",
+                      "description": "Backlog order/rank (for reprioritize)"
+                    }
+                  },
+                  "required": [
+                    "sys_id"
+                  ]
+                },
+                "description": "Array of stories to update"
+              },
+              "sprint": {
+                "type": "string",
+                "description": "Target sprint sys_id or number (for assign_sprint action)"
+              },
+              "epic": {
+                "type": "string",
+                "description": "Target epic sys_id or number (for move_epic action)"
+              }
+            },
+            "required": [
+              "action",
+              "stories"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_backlog_query",
+          "description": "Query the product backlog: list stories sorted by priority/rank, filter by epic, theme, state, or assignee. Shows unassigned and upcoming work.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "backlog",
+            "planning",
+            "grooming"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "product": {
+                "type": "string",
+                "description": "Product name or sys_id to scope the backlog"
+              },
+              "epic": {
+                "type": "string",
+                "description": "Filter by epic sys_id or number"
+              },
+              "theme": {
+                "type": "string",
+                "description": "Filter by theme sys_id or name"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "Draft",
+                  "Ready",
+                  "Work In Progress",
+                  "Testing",
+                  "Closed Complete",
+                  "Closed Incomplete"
+                ],
+                "description": "Filter by story state"
+              },
+              "unassigned_only": {
+                "type": "boolean",
+                "description": "Only show stories not assigned to a sprint"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "Filter by assignee username or sys_id"
+              },
+              "priority": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "description": "Filter by priority (1=Critical, 2=High, 3=Moderate, 4=Low)"
+              },
+              "has_points": {
+                "type": "boolean",
+                "description": "Filter for stories that have (true) or lack (false) story point estimates"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results (default 25)"
+              },
+              "offset": {
+                "type": "number",
+                "description": "Pagination offset (default 0)"
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_agile_capacity_plan",
+          "description": "Capacity planning: compare team availability against sprint commitment. Shows member allocation, average velocity, and recommended story point capacity.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "capacity",
+            "planning",
+            "sprint planning"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id"
+              },
+              "sprint": {
+                "type": "string",
+                "description": "Target sprint sys_id or number (defaults to active sprint)"
+              },
+              "velocity_sprints": {
+                "type": "number",
+                "description": "Number of past sprints to calculate average velocity (default 3)"
+              }
+            },
+            "required": [
+              "team"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_epic_manage",
+          "description": "Manage Agile epics: create/update epics, link stories, view progress breakdown. Works with ServiceNow rm_epic table.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "epic",
+            "planning",
+            "portfolio"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update",
+                  "get_progress"
+                ],
+                "description": "Action to perform"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Epic sys_id (required for update/get_progress)"
+              },
+              "title": {
+                "type": "string",
+                "description": "Epic title / short description"
+              },
+              "description": {
+                "type": "string",
+                "description": "Detailed description"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "Draft",
+                  "Open",
+                  "Work In Progress",
+                  "Closed Complete",
+                  "Closed Incomplete",
+                  "Cancelled"
+                ],
+                "description": "Epic state"
+              },
+              "theme": {
+                "type": "string",
+                "description": "Theme sys_id or name to link to"
+              },
+              "product": {
+                "type": "string",
+                "description": "Product sys_id or name"
+              },
+              "priority": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "description": "Priority (1=Critical, 2=High, 3=Moderate, 4=Low)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_release_manage",
+          "description": "Manage Agile releases: create/update releases, link sprints and epics, check release readiness with story completion status.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "release",
+            "planning",
+            "deployment"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update",
+                  "readiness"
+                ],
+                "description": "Action: create/update a release, or check readiness"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Release sys_id (required for update/readiness)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Release name"
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Release start date (YYYY-MM-DD)"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "Release end date (YYYY-MM-DD)"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "Draft",
+                  "Planning",
+                  "In Progress",
+                  "Released",
+                  "Cancelled"
+                ],
+                "description": "Release state"
+              },
+              "description": {
+                "type": "string",
+                "description": "Release description/notes"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_retrospective",
+          "description": "Generate sprint retrospective data: planned vs completed story points, defect rate, velocity trend, carry-over stories, and team performance metrics across sprints.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "retrospective",
+            "retro",
+            "metrics",
+            "improvement"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sprint": {
+                "type": "string",
+                "description": "Sprint sys_id or number to retrospect"
+              },
+              "team": {
+                "type": "string",
+                "description": "Team name or sys_id (uses last closed sprint if sprint not specified)"
+              },
+              "compare_sprints": {
+                "type": "number",
+                "description": "Number of previous sprints to compare against (default 3)"
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_agile_sprint_board",
+          "description": "Get a sprint board view: stories and tasks grouped by state columns (Draft, Ready, Work In Progress, Testing, Closed Complete, Closed Incomplete). Includes task breakdown per story.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "sprint",
+            "board",
+            "kanban"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sprint": {
+                "type": "string",
+                "description": "Sprint sys_id or number"
+              },
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id (uses active sprint if sprint not specified)"
+              },
+              "include_tasks": {
+                "type": "boolean",
+                "description": "Include scrum tasks per story (default false)"
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_agile_sprint_burndown",
+          "description": "Generate burndown and burnup chart data for a sprint. Shows ideal vs actual progress, remaining story points per day, and scope changes.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "sprint",
+            "burndown",
+            "metrics",
+            "chart"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sprint": {
+                "type": "string",
+                "description": "Sprint sys_id or number"
+              },
+              "chart_type": {
+                "type": "string",
+                "enum": [
+                  "burndown",
+                  "burnup",
+                  "both"
+                ],
+                "description": "Chart type (default: both)"
+              }
+            },
+            "required": [
+              "sprint"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_sprint_manage",
+          "description": "Manage Agile sprints: create new sprints, start/close sprints, update sprint details. Works with ServiceNow Agile 2.0 (rm_sprint table).",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "sprint",
+            "planning"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "start",
+                  "close",
+                  "update"
+                ],
+                "description": "Action to perform on the sprint"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Sprint sys_id (required for start/close/update)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Sprint name (for create)"
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Sprint start date (YYYY-MM-DD)"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "Sprint end date (YYYY-MM-DD)"
+              },
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id"
+              },
+              "story_points": {
+                "type": "number",
+                "description": "Sprint story point capacity"
+              },
+              "goal": {
+                "type": "string",
+                "description": "Sprint goal description"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_sprint_query",
+          "description": "Query sprints with burndown data, filter by team/state/date range. Optionally includes story breakdown per sprint.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "sprint",
+            "query",
+            "planning"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "planning",
+                  "active",
+                  "closed"
+                ],
+                "description": "Sprint state filter"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only return active sprints"
+              },
+              "include_stories": {
+                "type": "boolean",
+                "description": "Include story breakdown per sprint"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results (default 10)"
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_agile_standup_report",
+          "description": "Generate a daily standup report: what each team member worked on recently, what they are working on now, and any blockers. Based on story/task state changes.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "standup",
+            "daily",
+            "status"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id"
+              },
+              "sprint": {
+                "type": "string",
+                "description": "Sprint sys_id or number (defaults to active sprint)"
+              },
+              "days_back": {
+                "type": "number",
+                "description": "Number of days to look back for 'done' items (default 1)"
+              }
+            },
+            "required": [
+              "team"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_story_manage",
+          "description": "Create and update user stories in ServiceNow Agile 2.0. Assign story points, link to sprints/epics, manage acceptance criteria, and update state.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "story",
+            "user story",
+            "backlog"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update"
+                ],
+                "description": "Action to perform"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Story sys_id (required for update)"
+              },
+              "title": {
+                "type": "string",
+                "description": "Story title / short description"
+              },
+              "description": {
+                "type": "string",
+                "description": "Detailed description"
+              },
+              "story_points": {
+                "type": "number",
+                "description": "Story point estimate (1, 2, 3, 5, 8, 13, 21)"
+              },
+              "sprint": {
+                "type": "string",
+                "description": "Sprint sys_id or number to assign to"
+              },
+              "epic": {
+                "type": "string",
+                "description": "Epic sys_id or number to link to"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "User sys_id or username to assign"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "Draft",
+                  "Ready",
+                  "Work In Progress",
+                  "Testing",
+                  "Closed Complete",
+                  "Closed Incomplete"
+                ],
+                "description": "Story state"
+              },
+              "priority": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "description": "Priority (1=Critical, 2=High, 3=Moderate, 4=Low)"
+              },
+              "acceptance_criteria": {
+                "type": "string",
+                "description": "Acceptance criteria for the story"
+              },
+              "blocked": {
+                "type": "boolean",
+                "description": "Whether the story is blocked"
+              },
+              "blocked_reason": {
+                "type": "string",
+                "description": "Reason for being blocked"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_team_manage",
+          "description": "Manage Scrum teams: create teams, add/remove members with roles (Scrum Master, Product Owner, Developer), list team composition.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "team",
+            "management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update",
+                  "list_members",
+                  "add_member",
+                  "remove_member"
+                ],
+                "description": "Action to perform"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Team sys_id (required for update/list_members/add_member/remove_member)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Team name (for create/update)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Team description"
+              },
+              "velocity": {
+                "type": "number",
+                "description": "Default velocity (story points per sprint)"
+              },
+              "member": {
+                "type": "string",
+                "description": "User sys_id or username (for add_member/remove_member)"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "scrum_master",
+                  "product_owner",
+                  "developer"
+                ],
+                "description": "Member role (for add_member)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_agile_velocity_report",
+          "description": "Generate velocity report: story points committed vs completed per sprint for a team. Shows trends across multiple sprints for capacity planning.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "agile",
+            "scrum",
+            "velocity",
+            "metrics",
+            "reporting"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "team": {
+                "type": "string",
+                "description": "Scrum team name or sys_id"
+              },
+              "sprint_count": {
+                "type": "number",
+                "description": "Number of past sprints to include (default 6)"
+              },
+              "include_current": {
+                "type": "boolean",
+                "description": "Include the currently active sprint (default true)"
+              }
+            },
+            "required": [
+              "team"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "analysis",
+      "displayName": "Analysis",
+      "tools": [
+        {
+          "name": "snow_analyze_form",
+          "description": "Analyze everything that affects a ServiceNow form for a given table: active UI policies, client scripts, data policies, record + field ACLs, and UI actions. Useful when debugging 'why does this form behave this way?' — consolidates 5+ queries into one structured report.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "debugging",
+            "forms",
+            "acls",
+            "ui-policies",
+            "client-scripts"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name (e.g. 'incident', 'change_request', 'sc_req_item')"
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive policies/scripts/ACLs. Default: false.",
+                "default": false
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_analyze_requirements",
+          "description": "Analyzes development requirements to identify dependencies, suggest reusable components, and create implementation roadmaps.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "requirements",
+            "planning",
+            "roadmap"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "objective": {
+                "type": "string",
+                "description": "Development objective (e.g., \"iPhone provisioning for new users\")"
+              },
+              "auto_discover_dependencies": {
+                "type": "boolean",
+                "description": "Automatically discover required dependencies",
+                "default": true
+              },
+              "suggest_existing_components": {
+                "type": "boolean",
+                "description": "Suggest reuse of existing components",
+                "default": true
+              },
+              "create_dependency_map": {
+                "type": "boolean",
+                "description": "Create visual dependency map",
+                "default": true
+              },
+              "scope_preference": {
+                "type": "string",
+                "enum": [
+                  "global",
+                  "scoped",
+                  "auto"
+                ],
+                "description": "Deployment scope preference",
+                "default": "auto"
+              }
+            },
+            "required": [
+              "objective"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "analytics",
+      "displayName": "Analytics",
+      "tools": [
+        {
+          "name": "snow_aggregate_metrics",
+          "description": "Aggregate over a table via the /api/now/stats endpoint: COUNT, SUM, AVG, MIN, or MAX on a field, optionally grouped by another field. Returns the rolled-up result without fetching individual rows.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "aggregation",
+            "metrics",
+            "reporting"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field to aggregate"
+              },
+              "aggregation": {
+                "type": "string",
+                "enum": [
+                  "COUNT",
+                  "SUM",
+                  "AVG",
+                  "MIN",
+                  "MAX"
+                ],
+                "default": "COUNT"
+              },
+              "group_by": {
+                "type": "string",
+                "description": "Field to group by"
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_analyze_uib_page_performance",
+          "description": "Analyze UI Builder page performance and get optimization recommendations",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "performance",
+            "optimization"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Page sys_id to analyze"
+              },
+              "include_components": {
+                "type": "boolean",
+                "description": "Include component-level performance analysis",
+                "default": true
+              },
+              "include_data_broker_stats": {
+                "type": "boolean",
+                "description": "Include data broker performance metrics",
+                "default": true
+              },
+              "include_client_scripts": {
+                "type": "boolean",
+                "description": "Include client script performance",
+                "default": true
+              },
+              "time_period_days": {
+                "type": "number",
+                "description": "Analysis period in days",
+                "default": 30
+              },
+              "detailed_analysis": {
+                "type": "boolean",
+                "description": "Generate detailed performance report",
+                "default": false
+              }
+            },
+            "required": [
+              "page_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_anomaly_detection",
+          "description": "Detect outliers in a numeric series using a standard-deviation threshold (default 2.0). Returns the points whose deviation from the mean exceeds the threshold.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "anomaly-detection",
+            "data-analysis",
+            "monitoring"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "data_points": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "description": "Data points"
+              },
+              "threshold": {
+                "type": "number",
+                "default": 2,
+                "description": "Anomaly threshold (std dev)"
+              }
+            },
+            "required": [
+              "data_points"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_mobile_analytics",
+          "description": "Retrieves mobile application usage analytics including active users, sessions, and feature usage.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "analytics",
+            "mobile-metrics",
+            "usage-tracking"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "metric_type": {
+                "type": "string",
+                "description": "Metric type: users, sessions, features, performance, errors, all"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "Time range: 24h, 7d, 30d, 90d"
+              },
+              "user_id": {
+                "type": "string",
+                "description": "Filter by specific user"
+              },
+              "platform": {
+                "type": "string",
+                "description": "Filter by platform: ios, android, all"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_pattern_analysis",
+          "description": "Analyzes patterns across incidents, requests, and problems to identify trends, common issues, and improvement opportunities",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "pattern-analysis",
+            "trends",
+            "data-analysis"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "analysis_type": {
+                "type": "string",
+                "description": "Type of pattern analysis",
+                "enum": [
+                  "incident_patterns",
+                  "request_trends",
+                  "problem_root_causes",
+                  "user_behavior"
+                ]
+              },
+              "timeframe": {
+                "type": "string",
+                "description": "Time period for analysis",
+                "enum": [
+                  "day",
+                  "week",
+                  "month",
+                  "quarter"
+                ],
+                "default": "week"
+              }
+            },
+            "required": [
+              "analysis_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_sentiment_analysis",
+          "description": "Score the sentiment of a free-text string as positive/neutral/negative with a confidence value. Useful for triaging case comments, survey responses, or chat transcripts.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "sentiment-analysis",
+            "text-analysis",
+            "ai"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to analyze"
+              }
+            },
+            "required": [
+              "text"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "api",
+      "displayName": "Api",
+      "tools": [
+        {
+          "name": "snow_custom_api",
+          "description": "Make an arbitrary REST call to any ServiceNow endpoint with the chosen method (GET/POST/PUT/PATCH/DELETE), path, query params, and JSON body. Escape hatch for endpoints that don't have a first-class tool yet.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "custom-api",
+            "rest",
+            "integration"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE"
+                ],
+                "default": "GET"
+              },
+              "path": {
+                "type": "string",
+                "description": "API path (relative to instance URL)"
+              },
+              "body": {
+                "type": "object",
+                "description": "Request body"
+              },
+              "params": {
+                "type": "object",
+                "description": "Query parameters"
+              }
+            },
+            "required": [
+              "path"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "applications",
+      "displayName": "Applications",
+      "tools": [
+        {
+          "name": "snow_create_application",
+          "description": "Create a scoped application (sys_app), optionally bootstrapping an Update Set and switching the OAuth service account into the new scope so subsequent artifacts are tracked there.\n\nUse when: building a complete feature set (HR Portal, Customer Onboarding), bundling functionality for single-unit deployment, building external integrations, or developing for multiple instances. Prefer global scope for small fixes, shared utilities, quick POCs, or cross-application work.\n\nDefaults:\n- auto_create_update_set=true — creates a fresh Update Set in the new app scope\n- auto_switch_scope=true — switches the OAuth service account to the new scope so subsequent artifacts track there\n\nSet either to false for manual control.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "app-development",
+            "scoped-apps",
+            "development",
+            "deployment"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Application name (e.g., \"HR Self-Service Portal\")"
+              },
+              "scope": {
+                "type": "string",
+                "description": "Application scope prefix (e.g., \"x_myco_hr_portal\"). Must start with \"x_\" followed by vendor prefix and app name. Use lowercase with underscores."
+              },
+              "version": {
+                "type": "string",
+                "description": "Application version (default: \"1.0.0\")",
+                "default": "1.0.0"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "Brief description of the application purpose"
+              },
+              "vendor": {
+                "type": "string",
+                "description": "Vendor/company name (e.g., \"My Company\")"
+              },
+              "vendor_prefix": {
+                "type": "string",
+                "description": "Vendor prefix for scope (e.g., \"myco\"). Used in scope: x_<vendor_prefix>_<app>"
+              },
+              "auto_create_update_set": {
+                "type": "boolean",
+                "description": "Automatically create an Update Set for this application (default: true). The Update Set will be scoped to this application for proper change tracking.",
+                "default": true
+              },
+              "auto_switch_scope": {
+                "type": "boolean",
+                "description": "Automatically switch to this application scope after creation (default: true). Enables immediate development within the new application.",
+                "default": true
+              },
+              "update_set_name": {
+                "type": "string",
+                "description": "Custom name for the auto-created Update Set. If not provided, defaults to \"Initial Setup: <app_name>\""
+              },
+              "runtime_access_tracking": {
+                "type": "string",
+                "description": "Runtime access tracking level",
+                "enum": [
+                  "none",
+                  "tracking",
+                  "enforcing"
+                ],
+                "default": "tracking"
+              },
+              "licensable": {
+                "type": "boolean",
+                "description": "Whether the application is licensable",
+                "default": false
+              }
+            },
+            "required": [
+              "name",
+              "scope"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_current_scope",
+          "description": "Get the current application scope and active Update Set.\n\n🔍 USE THIS TO:\n- Verify which scope you're currently working in before creating artifacts\n- Check if you have an active Update Set in the current scope\n- Understand the development context before starting work\n\n📋 RETURNS:\n- Current application scope (name, sys_id, scope prefix)\n- Whether it's global or a scoped application\n- Current active Update Set (if any)\n- Recommendations for next steps",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "admin",
+            "stakeholder"
+          ],
+          "useCases": [
+            "app-development",
+            "scoped-apps",
+            "development",
+            "context-check"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "include_update_set": {
+                "type": "boolean",
+                "description": "Include information about the current Update Set (default: true)",
+                "default": true
+              },
+              "include_recent_artifacts": {
+                "type": "boolean",
+                "description": "Include count of recent artifacts created in current scope (default: false)",
+                "default": false
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_install_application",
+          "description": "Install application from store",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "app-install",
+            "store",
+            "deployment"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "app_id": {
+                "type": "string",
+                "description": "Application ID from store"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version to install"
+              }
+            },
+            "required": [
+              "app_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_list_applications",
+          "description": "List all scoped applications (sys_app) in the ServiceNow instance. Use to find available scopes before switching, see which applications are active/inactive, or decide which scope to use for development.\n\nSearch options: filter by name (partial match), scope (partial match, e.g. \"x_myco\"), or vendor. Active-only by default; pass active_only=false to include inactive. include_global controls whether the Global scope appears in the list.\n\nReturns each application with name, scope prefix, version, vendor, sys_id, and an is_current flag for the currently active scope. Optional include_artifact_count adds a per-application sys_metadata count (slower).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "admin",
+            "stakeholder"
+          ],
+          "useCases": [
+            "app-development",
+            "scoped-apps",
+            "development",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "search": {
+                "type": "string",
+                "description": "Search term to filter applications by name or scope (partial match)"
+              },
+              "vendor": {
+                "type": "string",
+                "description": "Filter by vendor name (partial match)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only show active applications (default: true)",
+                "default": true
+              },
+              "include_artifact_count": {
+                "type": "boolean",
+                "description": "Include count of artifacts in each application (slower, default: false)",
+                "default": false
+              },
+              "include_global": {
+                "type": "boolean",
+                "description": "Include \"Global\" scope in the list (default: true)",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of applications to return (default: 50)",
+                "default": 50
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_switch_application_scope",
+          "description": "Switch the current application scope for the OAuth service account by writing to sys_user_preference (name=sys_scope). All NEW artifacts created after the switch belong to that scope; existing artifacts stay in their original scope.\n\nResolves the target by trying, in order: sys_id, scope name (e.g. \"x_myco_hr_portal\"), application name. Pass \"global\" for the cross-application/system-wide scope.\n\nTracking: the active Update Set should match the target scope. Set create_update_set=true to bootstrap a matching one in the same call (named \"Development: <app_name>\" by default), otherwise switch the Update Set separately via snow_update_set_manage.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "app-development",
+            "scoped-apps",
+            "development",
+            "scope-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Target scope to switch to. Can be \"global\", application sys_id, scope name (e.g., \"x_myco_app\"), or application name."
+              },
+              "create_update_set": {
+                "type": "boolean",
+                "description": "Create a new Update Set in the target scope (default: false). Useful when starting new development work.",
+                "default": false
+              },
+              "update_set_name": {
+                "type": "string",
+                "description": "Name for the new Update Set (if create_update_set=true). Defaults to \"Development: <app_name>\""
+              },
+              "update_set_description": {
+                "type": "string",
+                "description": "Description for the new Update Set (if create_update_set=true)"
+              },
+              "servicenow_username": {
+                "type": "string",
+                "description": "Optional: Also switch scope for this ServiceNow user (for UI visibility)"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "approvals",
+      "displayName": "Approvals",
+      "tools": [
+        {
+          "name": "snow_approval_chain_manage",
+          "description": "Unified tool for ServiceNow approval chains across the sysapproval_approver, sysapproval_group, and sysapproval_action tables. Use this when a record needs an ordered, multi-step approval flow rather than a single ad-hoc approver.\n\nActions:\n- define_chain — write an ordered chain of approval steps for a source record. Each step may target a user (sysapproval_approver) or a group (sysapproval_group). Steps after the first start in 'not requested' state and are activated as earlier steps complete.\n- preview_chain — resolve who would be asked at each step (expanding group memberships) without inserting any rows. Useful for showing the caller the chain before firing it.\n- get_approvals — list all pending and historical approval rows for a given source record across both sysapproval_approver and sysapproval_group, plus the recent sysapproval_action verbs applied.\n- cancel — end an active chain. Marks every still-open approver/group row as 'cancelled' and records a sysapproval_action 'cancelled' verb on each.\n\nUse when: an agent needs to wire up a multi-step approval (e.g. peer → manager → director), preview the chain before committing, audit pending approvals on a record, or stop an in-flight chain. For a single ad-hoc approval use snow_request_approval; to act on an individual approval use snow_approve_reject.\n\nReturns: define_chain returns the inserted approval rows in order. preview_chain returns the resolved approver list per step without writing. get_approvals returns pending and complete rows plus the recent action verbs. cancel returns the rows it closed.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "approvals",
+            "workflow",
+            "chain",
+            "multi-step"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Approval chain action to perform",
+                "enum": [
+                  "define_chain",
+                  "preview_chain",
+                  "get_approvals",
+                  "cancel"
+                ]
+              },
+              "source_table": {
+                "type": "string",
+                "description": "[define_chain/preview_chain/get_approvals/cancel] Source table (e.g. change_request, sc_request, problem)"
+              },
+              "source_sys_id": {
+                "type": "string",
+                "description": "[define_chain/preview_chain/get_approvals/cancel] Source record sys_id the chain attaches to"
+              },
+              "steps": {
+                "type": "array",
+                "description": "[define_chain/preview_chain] Ordered chain steps. Each step has approver (user sys_id) OR group (sys_user_group sys_id), optional order (defaults to array index * 100), and optional comments.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "approver": {
+                      "type": "string",
+                      "description": "User sys_id (use for individual approver step)"
+                    },
+                    "group": {
+                      "type": "string",
+                      "description": "Group sys_id (use for group approval step)"
+                    },
+                    "order": {
+                      "type": "number",
+                      "description": "Explicit order/sequence; defaults to (index + 1) * 100"
+                    },
+                    "comments": {
+                      "type": "string",
+                      "description": "Optional comments stored on the approval row"
+                    }
+                  }
+                }
+              },
+              "activate_first": {
+                "type": "boolean",
+                "description": "[define_chain] Whether the first step is created in state 'requested' (active) or 'not requested' (queued). Defaults to true.",
+                "default": true
+              },
+              "cancel_comment": {
+                "type": "string",
+                "description": "[cancel] Comment recorded on each closed approval row and on the matching sysapproval_action verb"
+              },
+              "include_complete": {
+                "type": "boolean",
+                "description": "[get_approvals] Include approver/group rows that are already approved/rejected/cancelled",
+                "default": false
+              },
+              "include_actions": {
+                "type": "boolean",
+                "description": "[get_approvals] Include recent sysapproval_action verb history for the source record",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "[get_approvals] Maximum rows to return per table",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_approve_reject",
+          "description": "Approve or reject approval request",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "approvals",
+            "workflow",
+            "decision"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "approval_sys_id": {
+                "type": "string",
+                "description": "Approval sys_id"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "approved",
+                  "rejected"
+                ],
+                "description": "Action"
+              },
+              "comments": {
+                "type": "string",
+                "description": "Comments"
+              }
+            },
+            "required": [
+              "approval_sys_id",
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_pending_approvals",
+          "description": "Get pending approvals for user",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "approvals",
+            "query",
+            "pending"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "approver_sys_id": {
+                "type": "string",
+                "description": "Approver user sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "default": 100
+              }
+            },
+            "required": [
+              "approver_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_request_approval",
+          "description": "Create a sysapproval_approver record asking a specific user to approve a record on a source table. Sets state to 'requested' and attaches optional comments. Used to kick off approval workflows outside of Flow Designer.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "approvals",
+            "workflow",
+            "requests"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "source_table": {
+                "type": "string",
+                "description": "Source table name"
+              },
+              "source_sys_id": {
+                "type": "string",
+                "description": "Source record sys_id"
+              },
+              "approver": {
+                "type": "string",
+                "description": "Approver user sys_id"
+              },
+              "comments": {
+                "type": "string",
+                "description": "Approval comments"
+              }
+            },
+            "required": [
+              "source_table",
+              "source_sys_id",
+              "approver"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "artifact-analysis",
+      "displayName": "Artifact Analysis",
+      "tools": [
+        {
+          "name": "snow_blast_radius_artifact_dependencies",
+          "description": "Forward dependency analysis for a single artifact: what does it read, write, and depend on?\n\nUse to understand what fields a business rule touches, what tables a script include queries, which script includes an artifact calls, and the artifact's complexity/risk profile.\n\nExample: \"What does this business rule touch?\"\n\nReturns:\n- Fields read and written (with line numbers)\n- Tables queried via GlideRecord\n- Script includes called (deep mode also resolves them to sys_id/scope/active)\n- Glide APIs used\n- Risk assessment: low / medium / high complexity",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "code-review",
+            "dependency-analysis"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_type": {
+                "type": "string",
+                "enum": [
+                  "business_rule",
+                  "client_script",
+                  "ui_action",
+                  "ui_policy",
+                  "script_include",
+                  "acl",
+                  "flow",
+                  "widget"
+                ],
+                "description": "Type of artifact to analyze"
+              },
+              "artifact_sys_id": {
+                "type": "string",
+                "description": "sys_id of the artifact"
+              },
+              "analysis_depth": {
+                "type": "string",
+                "enum": [
+                  "shallow",
+                  "deep"
+                ],
+                "description": "shallow = field refs only; deep = also resolves script include calls (default: deep)",
+                "default": "deep"
+              }
+            },
+            "required": [
+              "artifact_type",
+              "artifact_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "asset-lifecycle",
+      "displayName": "Asset Lifecycle",
+      "tools": [
+        {
+          "name": "snow_create_asset",
+          "description": "Create hardware/software asset",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "asset-management",
+            "creation",
+            "alm"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "asset_tag": {
+                "type": "string"
+              },
+              "ci": {
+                "type": "string"
+              },
+              "model_category": {
+                "type": "string"
+              },
+              "assigned_to": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "asset_tag"
+            ]
+          }
+        },
+        {
+          "name": "snow_retire_asset",
+          "description": "Mark an asset as retired (install_status=7) on alm_asset, optionally recording a retirement date and disposal reason. End-of-lifecycle counterpart to procurement/transfer flows.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "asset-management",
+            "retirement",
+            "lifecycle"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "asset_sys_id": {
+                "type": "string"
+              },
+              "retirement_date": {
+                "type": "string"
+              },
+              "disposal_reason": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "asset_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_track_asset_lifecycle",
+          "description": "Track complete asset lifecycle from procurement to disposal",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "lifecycle",
+            "tracking",
+            "audit-trail"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "asset_sys_id": {
+                "type": "string",
+                "description": "Asset sys_id to track"
+              },
+              "action": {
+                "type": "string",
+                "description": "Lifecycle action",
+                "enum": [
+                  "procure",
+                  "receive",
+                  "deploy",
+                  "transfer",
+                  "retire",
+                  "dispose"
+                ]
+              },
+              "reason": {
+                "type": "string",
+                "description": "Reason for lifecycle change"
+              },
+              "user_sys_id": {
+                "type": "string",
+                "description": "User performing the action"
+              },
+              "notes": {
+                "type": "string",
+                "description": "Additional notes"
+              }
+            },
+            "required": [
+              "asset_sys_id",
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_transfer_asset",
+          "description": "Transfer asset to user/location",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "asset-management",
+            "transfer",
+            "relocation"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "asset_sys_id": {
+                "type": "string"
+              },
+              "to_user": {
+                "type": "string"
+              },
+              "to_location": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "asset_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "attachments",
+      "displayName": "Attachments",
+      "tools": [
+        {
+          "name": "snow_attach_file",
+          "description": "Attach files to ServiceNow records with validation and content type detection",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "attachments",
+            "files"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Record sys_id to attach file to"
+              },
+              "file_path": {
+                "type": "string",
+                "description": "Local file path to attach"
+              },
+              "file_name": {
+                "type": "string",
+                "description": "Name for the attached file (defaults to original filename)"
+              },
+              "content_type": {
+                "type": "string",
+                "description": "MIME type (auto-detected if not provided)"
+              },
+              "max_size_mb": {
+                "type": "number",
+                "description": "Maximum file size in MB",
+                "default": 25
+              }
+            },
+            "required": [
+              "table",
+              "sys_id",
+              "file_path"
+            ]
+          }
+        },
+        {
+          "name": "snow_delete_attachment",
+          "description": "Permanently delete a file attachment by its sys_id via the /api/now/attachment endpoint. Removes the file from its parent record.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "attachments",
+            "deletion",
+            "file-management"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "attachment_sys_id": {
+                "type": "string",
+                "description": "Attachment sys_id"
+              }
+            },
+            "required": [
+              "attachment_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_file_download",
+          "description": "Download an attachment's file content by sys_id and return it as base64 along with its content-type. Use snow_get_attachments first to find the attachment_sys_id for a record.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "files",
+            "download",
+            "attachments"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "attachment_sys_id": {
+                "type": "string",
+                "description": "Attachment sys_id"
+              }
+            },
+            "required": [
+              "attachment_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_file_upload",
+          "description": "Upload a base64-encoded file as an attachment on a specific record (table + sys_id), with file name and MIME type. Equivalent to snow_upload_attachment — pick whichever fits your naming.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "files",
+            "upload",
+            "attachments"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_name": {
+                "type": "string",
+                "description": "File name"
+              },
+              "content_type": {
+                "type": "string",
+                "description": "Content type"
+              },
+              "file_data": {
+                "type": "string",
+                "description": "Base64 encoded file data"
+              },
+              "table": {
+                "type": "string",
+                "description": "Target table"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              }
+            },
+            "required": [
+              "file_name",
+              "file_data",
+              "table",
+              "record_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_attachments",
+          "description": "List all attachments on a single record (table_name + table_sys_id). Returns each attachment's metadata (sys_id, file_name, size, content_type) — use snow_file_download to fetch a file's bytes.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "attachments",
+            "query",
+            "file-management"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "table_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              }
+            },
+            "required": [
+              "table_name",
+              "table_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_upload_attachment",
+          "description": "Attach a base64-encoded file to a specific record (table_name + table_sys_id) with file name and optional MIME type. Returns the new attachment metadata.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "attachments",
+            "upload",
+            "file-management"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "table_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              },
+              "file_name": {
+                "type": "string",
+                "description": "File name"
+              },
+              "content_type": {
+                "type": "string",
+                "description": "MIME type"
+              },
+              "content": {
+                "type": "string",
+                "description": "Base64 encoded content"
+              }
+            },
+            "required": [
+              "table_name",
+              "table_sys_id",
+              "file_name",
+              "content"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "audit",
+      "displayName": "Audit",
+      "tools": [
+        {
+          "name": "snow_get_ci_history",
+          "description": "Get Configuration Item change history",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "audit",
+            "history"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_sys_id": {
+                "type": "string"
+              },
+              "days_back": {
+                "type": "number",
+                "default": 30
+              }
+            },
+            "required": [
+              "ci_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_grc_audit_manage",
+          "description": "Unified tool for ServiceNow GRC Audit Management: engagements, audits, findings, and evidence. Wraps the sn_audit_audit, sn_audit_finding, sn_audit_engagement, and sn_audit_evidence tables that ship with the GRC: Audit Management plugin.\n\nActions:\n- list — list audits, optionally filtered by engagement, state, or auditor\n- get — retrieve a single audit by sys_id\n- create_audit — open a new audit inside an existing engagement\n- update_audit — patch fields on an existing audit (state, scope, lead auditor, dates)\n- add_finding — log a finding against an audit with severity and recommendation\n- list_findings — list findings, optionally filtered by audit, severity, or state\n- attach_evidence — attach an evidence record (or external URL) to an audit or finding\n\nUse when: the agent needs to drive an audit engagement end to end — opening individual audits, logging the findings that come out of them, and attaching the evidence collected during fieldwork. For policy and control evidence outside an audit context, use snow_compliance_manage; for risk register operations, use snow_grc_risk_manage.\n\nReturns: audit rows with sys_id, engagement, state, lead auditor, planned and actual dates; finding rows with severity, recommendation, target remediation date; evidence rows with type and reference link. GRC plugin gating: the first call against the audit tables will surface a clear error if the GRC: Audit Management plugin is not active on the target instance.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "grc",
+            "audit",
+            "audit-management",
+            "findings",
+            "evidence"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "create_audit",
+                  "update_audit",
+                  "add_finding",
+                  "list_findings",
+                  "attach_evidence"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update_audit/add_finding/attach_evidence] Audit sys_id"
+              },
+              "engagement_sys_id": {
+                "type": "string",
+                "description": "[create_audit/list] Audit engagement sys_id (sn_audit_engagement)"
+              },
+              "finding_sys_id": {
+                "type": "string",
+                "description": "[attach_evidence] Finding sys_id when attaching evidence to a specific finding"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list/list_findings] Filter by state (draft, scheduled, in_progress, completed, closed, cancelled)"
+              },
+              "auditor": {
+                "type": "string",
+                "description": "[list] Filter by lead auditor sys_user sys_id"
+              },
+              "severity": {
+                "type": "string",
+                "description": "[list_findings] Filter by finding severity",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "informational"
+                ]
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_findings] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/list_findings] Comma-separated list of fields to return"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create_audit] Short description of the audit"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create_audit/update_audit] Long description / scope narrative"
+              },
+              "scope": {
+                "type": "string",
+                "description": "[create_audit/update_audit] Audit scope (free text)"
+              },
+              "lead_auditor": {
+                "type": "string",
+                "description": "[create_audit/update_audit] Lead auditor sys_user sys_id"
+              },
+              "planned_start_date": {
+                "type": "string",
+                "description": "[create_audit/update_audit] ISO date string (YYYY-MM-DD) when the audit is planned to start"
+              },
+              "planned_end_date": {
+                "type": "string",
+                "description": "[create_audit/update_audit] ISO date string (YYYY-MM-DD) when the audit is planned to end"
+              },
+              "audit_type": {
+                "type": "string",
+                "description": "[create_audit] Audit type label (internal, external, regulatory, sox, soc, iso, custom)"
+              },
+              "audit_state": {
+                "type": "string",
+                "description": "[update_audit] New audit state",
+                "enum": [
+                  "draft",
+                  "scheduled",
+                  "in_progress",
+                  "completed",
+                  "closed",
+                  "cancelled"
+                ]
+              },
+              "finding_short_description": {
+                "type": "string",
+                "description": "[add_finding] Short description of the finding"
+              },
+              "finding_description": {
+                "type": "string",
+                "description": "[add_finding] Long description / observation detail"
+              },
+              "finding_severity": {
+                "type": "string",
+                "description": "[add_finding] Severity rating",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "informational"
+                ]
+              },
+              "recommendation": {
+                "type": "string",
+                "description": "[add_finding] Recommended remediation action"
+              },
+              "target_remediation_date": {
+                "type": "string",
+                "description": "[add_finding] ISO date string (YYYY-MM-DD) for target remediation"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[add_finding] sys_user sys_id of the remediation owner"
+              },
+              "evidence_type": {
+                "type": "string",
+                "description": "[attach_evidence] Evidence type label",
+                "enum": [
+                  "document",
+                  "screenshot",
+                  "report",
+                  "attestation",
+                  "log",
+                  "interview",
+                  "other"
+                ],
+                "default": "document"
+              },
+              "evidence_url": {
+                "type": "string",
+                "description": "[attach_evidence] External URL pointing at the evidence (used when no existing sys_id is given)"
+              },
+              "evidence_sys_id": {
+                "type": "string",
+                "description": "[attach_evidence] Existing sn_audit_evidence sys_id to link instead of creating a new row"
+              },
+              "evidence_description": {
+                "type": "string",
+                "description": "[attach_evidence] Description for the evidence record"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "audit-rules",
+      "displayName": "Audit Rules",
+      "tools": [
+        {
+          "name": "snow_create_audit_rule",
+          "description": "Configure audit tracking on a table: which events (insert/update/delete) and which fields to log, retention period in days, and an optional filter. Writes to sys_audit.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "configuration",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "table": {
+                "type": "string"
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "retention": {
+                "type": "number"
+              },
+              "filter": {
+                "type": "string"
+              },
+              "active": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "events"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "audit-trail",
+      "displayName": "Audit Trail",
+      "tools": [
+        {
+          "name": "snow_audit_trail_analysis",
+          "description": "Analyze the audit trail (sys_audit): aggregates events by user, table, and action, surfaces top activities, and optionally flags anomalies (users with 3x the average activity). Filter by timeframe, user, or table; export as json/csv/pdf.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "analysis",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "timeframe": {
+                "type": "string"
+              },
+              "user": {
+                "type": "string"
+              },
+              "table": {
+                "type": "string"
+              },
+              "anomalies": {
+                "type": "boolean"
+              },
+              "exportFormat": {
+                "type": "string",
+                "enum": [
+                  "json",
+                  "csv",
+                  "pdf"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "bulk-operations",
+      "displayName": "Bulk Operations",
+      "tools": [
+        {
+          "name": "snow_bulk_update",
+          "description": "Apply the same field updates to every record on a table matching an encoded query, up to a row limit (default 100). Issues one PATCH per matched record. Use carefully — this fires business rules and workflows for each row.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "bulk-update",
+            "data-management",
+            "batch"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query to select records"
+              },
+              "updates": {
+                "type": "object",
+                "description": "Fields to update"
+              },
+              "limit": {
+                "type": "number",
+                "default": 100,
+                "description": "Max records to update"
+              }
+            },
+            "required": [
+              "table",
+              "query",
+              "updates"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "callbacks",
+      "displayName": "Callbacks",
+      "tools": [
+        {
+          "name": "snow_callback_handler",
+          "description": "Create callback handler for async operations",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "callbacks",
+            "async",
+            "integration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Callback name"
+              },
+              "callback_url": {
+                "type": "string",
+                "description": "Callback URL"
+              },
+              "http_method": {
+                "type": "string",
+                "enum": [
+                  "POST",
+                  "PUT",
+                  "PATCH"
+                ],
+                "default": "POST"
+              }
+            },
+            "required": [
+              "name",
+              "callback_url"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "catalog",
+      "displayName": "Catalog",
+      "tools": [
+        {
+          "name": "snow_blast_radius_apps",
+          "description": "List all applications/scopes in the instance with configuration summary counts.\n\n📋 USE THIS TO:\n- Get an overview of all apps and their configuration footprint\n- Find which apps have the most business rules, client scripts, etc.\n- Identify apps by name or scope prefix\n- Start a Blast Radius analysis session\n\n📊 RETURNS:\n- List of applications with name, scope, vendor\n- Per-app counts of business rules, client scripts, UI actions, UI policies, script includes, ACLs\n- Instance-level summary totals",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "discovery",
+            "governance"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "search": {
+                "type": "string",
+                "description": "Filter by app name or scope prefix (partial match)"
+              },
+              "include_global": {
+                "type": "boolean",
+                "description": "Include Global scope in results (default: true)",
+                "default": true
+              },
+              "include_config_counts": {
+                "type": "boolean",
+                "description": "Include per-app counts of BRs, client scripts, etc. (default: true)",
+                "default": true
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only show active applications (default: true)",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of applications to return (default: 50)",
+                "default": 50
+              }
+            },
+            "required": []
+          }
+        },
+        {
+          "name": "snow_catalog_item_manager",
+          "description": "Create, update, or manage service catalog items",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog-management",
+            "service-catalog",
+            "crud"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Action to perform",
+                "enum": [
+                  "create",
+                  "update",
+                  "activate",
+                  "deactivate",
+                  "delete"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Catalog item sys_id (required for update/activate/deactivate/delete)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Catalog item name (required for create)"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "Short description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Category sys_id"
+              },
+              "price": {
+                "type": "string",
+                "description": "Item price"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_catalog_item_search",
+          "description": "Search service catalog items with filtering options",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "catalog-search",
+            "service-catalog",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query (searches name and short_description)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only return active catalog items",
+                "default": true
+              },
+              "category": {
+                "type": "string",
+                "description": "Filter by category sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of results",
+                "default": 20,
+                "minimum": 1,
+                "maximum": 100
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_create_variable",
+          "description": "Add a question variable to a catalog item: name, question text, input type (string, multi_line_text, select_box, checkbox, reference), mandatory flag, and display order. Writes to item_option_new under the given cat_item.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog-variables",
+            "service-catalog",
+            "form-fields"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cat_item": {
+                "type": "string",
+                "description": "Catalog item sys_id to attach this variable to"
+              },
+              "name": {
+                "type": "string",
+                "description": "Variable name"
+              },
+              "question_text": {
+                "type": "string",
+                "description": "Question text"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "multi_line_text",
+                  "select_box",
+                  "checkbox",
+                  "reference"
+                ],
+                "default": "string"
+              },
+              "mandatory": {
+                "type": "boolean",
+                "default": false
+              },
+              "order": {
+                "type": "number",
+                "description": "Display order"
+              }
+            },
+            "required": [
+              "name",
+              "question_text",
+              "cat_item"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_variable_set",
+          "description": "Create a reusable variable set (item_option_new_set) — a grouping of catalog variables that can be attached to multiple catalog items, e.g. a shared 'Approver / Department' block.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "variable-sets",
+            "service-catalog",
+            "form-templates"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Variable set title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description"
+              },
+              "internal_name": {
+                "type": "string",
+                "description": "Internal name"
+              }
+            },
+            "required": [
+              "title",
+              "internal_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "change",
+      "displayName": "Change",
+      "tools": [
+        {
+          "name": "snow_change_manage",
+          "description": "Unified change management (create, update_state, approve, create_task, schedule_cab)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "change-management",
+            "itsm",
+            "workflow"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Change management action",
+                "enum": [
+                  "create",
+                  "update_state",
+                  "approve",
+                  "create_task",
+                  "schedule_cab"
+                ]
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create/create_task] Short description"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/create_task] Full description"
+              },
+              "type": {
+                "type": "string",
+                "description": "[create] Change type",
+                "enum": [
+                  "standard",
+                  "normal",
+                  "emergency"
+                ]
+              },
+              "risk": {
+                "type": "string",
+                "description": "[create] Risk level",
+                "enum": [
+                  "high",
+                  "medium",
+                  "low"
+                ]
+              },
+              "impact": {
+                "type": "number",
+                "description": "[create] Impact",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[update_state/approve/create_task/schedule_cab] Change sys_id or number"
+              },
+              "state": {
+                "type": "string",
+                "description": "[update_state] New state",
+                "enum": [
+                  "draft",
+                  "assess",
+                  "authorize",
+                  "scheduled",
+                  "implement",
+                  "review",
+                  "closed",
+                  "cancelled"
+                ]
+              },
+              "close_notes": {
+                "type": "string",
+                "description": "[update_state] Closure notes"
+              },
+              "close_code": {
+                "type": "string",
+                "description": "[update_state] Closure code"
+              },
+              "approval": {
+                "type": "string",
+                "description": "[approve] Approval decision",
+                "enum": [
+                  "approved",
+                  "rejected"
+                ]
+              },
+              "comments": {
+                "type": "string",
+                "description": "[approve] Approval comments"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[create_task] Assignee sys_id"
+              },
+              "due_date": {
+                "type": "string",
+                "description": "[create_task] Due date"
+              },
+              "cab_date": {
+                "type": "string",
+                "description": "[schedule_cab] CAB meeting date"
+              },
+              "cab_agenda": {
+                "type": "string",
+                "description": "[schedule_cab] CAB agenda"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_change_query",
+          "description": "Unified change query (get, search, assess_risk)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "change-management",
+            "query",
+            "risk-assessment"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Query action",
+                "enum": [
+                  "get",
+                  "search",
+                  "assess_risk"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/assess_risk] Change sys_id or number"
+              },
+              "include_tasks": {
+                "type": "boolean",
+                "description": "[get] Include change tasks",
+                "default": true
+              },
+              "include_approvals": {
+                "type": "boolean",
+                "description": "[get] Include approval history",
+                "default": true
+              },
+              "query": {
+                "type": "string",
+                "description": "[search] Search query"
+              },
+              "state": {
+                "type": "string",
+                "description": "[search] Filter by state"
+              },
+              "type": {
+                "type": "string",
+                "description": "[search] Filter by type",
+                "enum": [
+                  "standard",
+                  "normal",
+                  "emergency"
+                ]
+              },
+              "risk": {
+                "type": "string",
+                "description": "[search] Filter by risk",
+                "enum": [
+                  "high",
+                  "medium",
+                  "low"
+                ]
+              },
+              "limit": {
+                "type": "number",
+                "description": "[search] Maximum results",
+                "default": 10
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "code-analysis",
+      "displayName": "Code Analysis",
+      "tools": [
+        {
+          "name": "snow_detect_code_patterns",
+          "description": "Detect code patterns, anti-patterns, and best practices in ServiceNow scripts",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "code-quality",
+            "analysis"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "JavaScript code to analyze"
+              },
+              "check_es5": {
+                "type": "boolean",
+                "description": "Check for ES5 compliance",
+                "default": true
+              },
+              "check_performance": {
+                "type": "boolean",
+                "description": "Check for performance anti-patterns",
+                "default": true
+              },
+              "check_security": {
+                "type": "boolean",
+                "description": "Check for security issues",
+                "default": true
+              },
+              "check_best_practices": {
+                "type": "boolean",
+                "description": "Check ServiceNow best practices",
+                "default": true
+              }
+            },
+            "required": [
+              "code"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "comments",
+      "displayName": "Comments",
+      "tools": [
+        {
+          "name": "snow_add_comment",
+          "description": "Add comment/work note to record",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "comments",
+            "work-notes",
+            "collaboration"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              },
+              "comment": {
+                "type": "string",
+                "description": "Comment text"
+              },
+              "work_note": {
+                "type": "boolean",
+                "default": false,
+                "description": "Is work note (internal)"
+              }
+            },
+            "required": [
+              "table",
+              "record_sys_id",
+              "comment"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_journal_entries",
+          "description": "Get journal entries for record",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "journals",
+            "audit",
+            "history"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "default": 100
+              }
+            },
+            "required": [
+              "table",
+              "record_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "compliance",
+      "displayName": "Compliance",
+      "tools": [
+        {
+          "name": "snow_compliance_manage",
+          "description": "Unified tool for ServiceNow compliance lifecycle beyond rule authoring and scanning: list_exceptions, exception_create, evidence_link, evidence_list, mark_compliant. Wraps the GRC tables sn_compliance_policy_exception, sn_compliance_control, and sn_compliance_evidence.\n\nActions:\n- list_exceptions — list policy exceptions, optionally filtered by control, state, or framework\n- exception_create — open a new policy exception against a control with justification and expiry\n- evidence_link — attach an existing evidence record (or arbitrary URL) to a control\n- evidence_list — list evidence rows linked to a given control\n- mark_compliant — set a control's compliance state to compliant with an attestation note\n\nUse when: the agent needs to manage the human side of compliance — granting time-bound exceptions to a control, attaching evidence collected outside ServiceNow to satisfy audit requirements, or attesting that a control is compliant. For authoring the rule itself, use snow_create_compliance_rule; for running a scan against a framework, use snow_run_compliance_scan.\n\nReturns: exception rows with sys_id, state, expiry; evidence rows with type and link reference; control state transitions with attestation work notes.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "compliance",
+            "grc",
+            "exceptions",
+            "evidence",
+            "controls"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_exceptions",
+                  "exception_create",
+                  "evidence_link",
+                  "evidence_list",
+                  "mark_compliant"
+                ]
+              },
+              "control_sys_id": {
+                "type": "string",
+                "description": "[exception_create/evidence_link/evidence_list/mark_compliant] sn_compliance_control sys_id"
+              },
+              "exception_sys_id": {
+                "type": "string",
+                "description": "[list_exceptions] Filter to a specific exception by sys_id"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_exceptions] Filter by exception state",
+                "enum": [
+                  "draft",
+                  "review",
+                  "approved",
+                  "rejected",
+                  "expired",
+                  "withdrawn"
+                ]
+              },
+              "framework": {
+                "type": "string",
+                "description": "[list_exceptions] Filter by compliance framework (SOX, GDPR, HIPAA, etc.)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_exceptions/evidence_list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_exceptions/evidence_list] Comma-separated list of fields to return"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[exception_create] Short description of the exception"
+              },
+              "justification": {
+                "type": "string",
+                "description": "[exception_create] Business justification for the exception"
+              },
+              "expiry": {
+                "type": "string",
+                "description": "[exception_create] ISO date string (YYYY-MM-DD) when the exception expires"
+              },
+              "requestor": {
+                "type": "string",
+                "description": "[exception_create] sys_user sys_id of the requestor (defaults to the calling user)"
+              },
+              "evidence_sys_id": {
+                "type": "string",
+                "description": "[evidence_link] Existing sn_compliance_evidence sys_id to link"
+              },
+              "evidence_url": {
+                "type": "string",
+                "description": "[evidence_link] External evidence URL (used to create a new sn_compliance_evidence row when evidence_sys_id is absent)"
+              },
+              "evidence_type": {
+                "type": "string",
+                "description": "[evidence_link] Evidence type label",
+                "enum": [
+                  "document",
+                  "screenshot",
+                  "report",
+                  "attestation",
+                  "log",
+                  "other"
+                ],
+                "default": "document"
+              },
+              "evidence_description": {
+                "type": "string",
+                "description": "[evidence_link] Optional description for the evidence record"
+              },
+              "attestation_note": {
+                "type": "string",
+                "description": "[mark_compliant] Work note explaining why the control is being marked compliant"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_compliance_rule",
+          "description": "Creates compliance rules for regulatory frameworks (SOX, GDPR, HIPAA). Defines validation, remediation, and severity levels.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "rules",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Compliance rule name"
+              },
+              "framework": {
+                "type": "string",
+                "description": "Compliance framework (SOX, GDPR, HIPAA, etc.)"
+              },
+              "requirement": {
+                "type": "string",
+                "description": "Specific requirement or control"
+              },
+              "validation": {
+                "type": "string",
+                "description": "Validation script or condition"
+              },
+              "remediation": {
+                "type": "string",
+                "description": "Remediation actions"
+              },
+              "severity": {
+                "type": "string",
+                "description": "Severity level (critical, high, medium, low)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Rule active status"
+              }
+            },
+            "required": [
+              "name",
+              "framework",
+              "requirement",
+              "validation"
+            ]
+          }
+        },
+        {
+          "name": "snow_run_compliance_scan",
+          "description": "Run compliance scans against security frameworks (SOX, GDPR, HIPAA, PCI-DSS)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "security",
+            "compliance",
+            "audit"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "framework": {
+                "type": "string",
+                "description": "Compliance framework to scan against",
+                "enum": [
+                  "sox",
+                  "gdpr",
+                  "hipaa",
+                  "pci_dss",
+                  "iso27001",
+                  "nist"
+                ]
+              },
+              "scope": {
+                "type": "string",
+                "description": "Scan scope",
+                "enum": [
+                  "full",
+                  "critical_only",
+                  "incremental"
+                ],
+                "default": "full"
+              },
+              "target_table": {
+                "type": "string",
+                "description": "Specific table to scan (optional)"
+              },
+              "generate_report": {
+                "type": "boolean",
+                "description": "Generate compliance report",
+                "default": true
+              }
+            },
+            "required": [
+              "framework"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "compliance-issues",
+      "displayName": "Compliance Issues",
+      "tools": [
+        {
+          "name": "snow_grc_issue_manage",
+          "description": "Unified tool for ServiceNow GRC compliance issues and exceptions beyond control-side authoring. Wraps the sn_compliance_issue, sn_compliance_policy_exception, sn_compliance_remediation, and sn_compliance_evidence tables that ship with the GRC: Policy and Compliance Management plugin.\n\nActions:\n- list_issues — list compliance issues, optionally filtered by control, state, or severity\n- list_exceptions — list policy exceptions raised against controls\n- exception_create — open a new policy exception with justification and expiry\n- link_evidence — attach an evidence record (or external URL) to a compliance issue\n- mark_remediated — close an issue by attaching a remediation record and transitioning state\n\nUse when: the agent needs to manage the issue side of GRC — listing issues raised by automated scans or auditors, granting time-bound exceptions, attaching evidence that supports the remediation, and closing the issue once remediated. For the control-side exception/evidence/attestation flow use snow_compliance_manage; for audit-driven findings use snow_grc_audit_manage.\n\nReturns: issue rows with sys_id, control reference, severity, state; exception rows with state, expiry, requestor; remediation rows with plan, target date, owner; evidence rows with type and reference link. GRC plugin gating: the first call against these tables will surface a clear error if the GRC: Policy and Compliance Management plugin is not active on the target instance.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "grc",
+            "compliance",
+            "issues",
+            "exceptions",
+            "remediation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_exceptions",
+                  "exception_create",
+                  "link_evidence",
+                  "mark_remediated",
+                  "list_issues"
+                ]
+              },
+              "issue_sys_id": {
+                "type": "string",
+                "description": "[link_evidence/mark_remediated] Compliance issue sys_id"
+              },
+              "control_sys_id": {
+                "type": "string",
+                "description": "[exception_create/list_issues/list_exceptions] Compliance control sys_id (sn_compliance_control)"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_issues/list_exceptions] Filter by state"
+              },
+              "severity": {
+                "type": "string",
+                "description": "[list_issues] Filter by issue severity",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "informational"
+                ]
+              },
+              "framework": {
+                "type": "string",
+                "description": "[list_issues/list_exceptions] Filter by compliance framework (SOX, GDPR, HIPAA, ISO27001, etc.)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_issues/list_exceptions] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_issues/list_exceptions] Comma-separated list of fields to return"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[exception_create] Short description of the exception"
+              },
+              "justification": {
+                "type": "string",
+                "description": "[exception_create] Business justification for the exception"
+              },
+              "expiry": {
+                "type": "string",
+                "description": "[exception_create] ISO date string (YYYY-MM-DD) when the exception expires"
+              },
+              "requestor": {
+                "type": "string",
+                "description": "[exception_create] sys_user sys_id of the requestor (defaults to the calling user)"
+              },
+              "evidence_sys_id": {
+                "type": "string",
+                "description": "[link_evidence] Existing sn_compliance_evidence sys_id to link"
+              },
+              "evidence_url": {
+                "type": "string",
+                "description": "[link_evidence] External evidence URL (used to create a new evidence row when evidence_sys_id is absent)"
+              },
+              "evidence_type": {
+                "type": "string",
+                "description": "[link_evidence] Evidence type label",
+                "enum": [
+                  "document",
+                  "screenshot",
+                  "report",
+                  "attestation",
+                  "log",
+                  "other"
+                ],
+                "default": "document"
+              },
+              "evidence_description": {
+                "type": "string",
+                "description": "[link_evidence] Optional description for the evidence record"
+              },
+              "remediation_summary": {
+                "type": "string",
+                "description": "[mark_remediated] Summary of the remediation action taken"
+              },
+              "remediation_owner": {
+                "type": "string",
+                "description": "[mark_remediated] sys_user sys_id of the person who remediated the issue"
+              },
+              "remediation_completed_at": {
+                "type": "string",
+                "description": "[mark_remediated] ISO date string (YYYY-MM-DD) when the remediation was completed (defaults to today)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "configuration",
+      "displayName": "Configuration",
+      "tools": [
+        {
+          "name": "snow_property_manager",
+          "description": "Enhanced property management with get, set, and validation in one tool",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "properties",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "get",
+                  "set",
+                  "validate"
+                ],
+                "description": "Action to perform: get, set, or validate"
+              },
+              "name": {
+                "type": "string",
+                "description": "Property name"
+              },
+              "value": {
+                "type": "string",
+                "description": "Property value (required for set action)"
+              },
+              "mask_sensitive": {
+                "type": "boolean",
+                "description": "Mask sensitive values like API keys",
+                "default": true
+              }
+            },
+            "required": [
+              "action",
+              "name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "connectors",
+      "displayName": "Connectors",
+      "tools": [
+        {
+          "name": "snow_batch_request",
+          "description": "Send multiple REST calls in a single round-trip via /api/now/v1/batch. Each entry has method, url, and body — replies come back in order under a generated batch ID. Cuts overhead when issuing many small operations.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "batch-requests",
+            "bulk-operations",
+            "performance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "requests": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "method": {
+                      "type": "string",
+                      "enum": [
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "PATCH",
+                        "DELETE"
+                      ]
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "description": "Array of requests"
+              }
+            },
+            "required": [
+              "requests"
+            ]
+          }
+        },
+        {
+          "name": "snow_configure_connection",
+          "description": "Configure ServiceNow connection alias",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "connection-config",
+            "multi-instance",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Connection alias name"
+              },
+              "instance_url": {
+                "type": "string",
+                "description": "Instance URL"
+              },
+              "description": {
+                "type": "string",
+                "description": "Connection description"
+              }
+            },
+            "required": [
+              "name",
+              "instance_url"
+            ]
+          }
+        },
+        {
+          "name": "snow_test_connection",
+          "description": "Smoke-test the current ServiceNow connection: authenticates and fetches one sys_user row. Returns the resolved instance URL on success; use as a quick liveness/credentials check before running other tools.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "connection-test",
+            "authentication",
+            "diagnostics"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      ]
+    },
+    {
+      "name": "creation",
+      "displayName": "Creation",
+      "tools": [
+        {
+          "name": "snow_create_workspace",
+          "description": "Create complete Agent Workspace with experience, config, routes, and lists via Builder Toolkit API",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "agent-workspace",
+            "creation"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Workspace name (e.g., \"IT Support Workspace\")"
+              },
+              "description": {
+                "type": "string",
+                "description": "Workspace description"
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tables to include in workspace (e.g., [\"incident\", \"task\"])",
+                "default": []
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Required roles to access workspace",
+                "default": []
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_pa_create",
+          "description": "Unified PA creation (indicator, breakdown, threshold, widget, visualization, scheduled_report)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "performance-analytics",
+            "kpi",
+            "dashboards",
+            "reporting"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "PA creation action",
+                "enum": [
+                  "indicator",
+                  "breakdown",
+                  "threshold",
+                  "widget",
+                  "visualization",
+                  "scheduled_report"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "[indicator/breakdown/widget/visualization/scheduled_report] Name"
+              },
+              "description": {
+                "type": "string",
+                "description": "[indicator] Description"
+              },
+              "table": {
+                "type": "string",
+                "description": "[indicator/breakdown] Source table"
+              },
+              "field": {
+                "type": "string",
+                "description": "[indicator/breakdown] Field name"
+              },
+              "aggregate": {
+                "type": "string",
+                "description": "[indicator] Aggregation (COUNT, SUM, AVG, MIN, MAX)"
+              },
+              "metric": {
+                "type": "string",
+                "description": "[indicator] Metric to measure"
+              },
+              "aggregation": {
+                "type": "string",
+                "description": "[indicator] Aggregation function"
+              },
+              "conditions": {
+                "type": "string",
+                "description": "[indicator/scheduled_report] Conditions/filters"
+              },
+              "target": {
+                "type": "number",
+                "description": "[indicator] Target value"
+              },
+              "threshold": {
+                "type": "object",
+                "description": "[indicator] Threshold config"
+              },
+              "unit": {
+                "type": "string",
+                "description": "[indicator] Unit of measurement"
+              },
+              "frequency": {
+                "type": "string",
+                "description": "[indicator] Update frequency"
+              },
+              "related_field": {
+                "type": "string",
+                "description": "[breakdown] Related field path"
+              },
+              "matrix_source": {
+                "type": "boolean",
+                "description": "[breakdown] Is matrix breakdown"
+              },
+              "indicator": {
+                "type": "string",
+                "description": "[threshold/widget] Indicator sys_id"
+              },
+              "type": {
+                "type": "string",
+                "description": "[threshold/widget/visualization] Type"
+              },
+              "operator": {
+                "type": "string",
+                "description": "[threshold] Operator (>, <, >=, <=, =)"
+              },
+              "value": {
+                "type": "number",
+                "description": "[threshold] Threshold value"
+              },
+              "duration": {
+                "type": "number",
+                "description": "[threshold] Duration before alert"
+              },
+              "notification_group": {
+                "type": "string",
+                "description": "[threshold] Group to notify"
+              },
+              "breakdown": {
+                "type": "string",
+                "description": "[widget] Breakdown field"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "[widget] Time range (7days, 30days, etc.)"
+              },
+              "dashboard": {
+                "type": "string",
+                "description": "[widget] Dashboard sys_id"
+              },
+              "size_x": {
+                "type": "number",
+                "description": "[widget] Widget width"
+              },
+              "size_y": {
+                "type": "number",
+                "description": "[widget] Widget height"
+              },
+              "dataSource": {
+                "type": "string",
+                "description": "[visualization] Data source table/report"
+              },
+              "xAxis": {
+                "type": "string",
+                "description": "[visualization] X-axis field"
+              },
+              "yAxis": {
+                "type": "string",
+                "description": "[visualization] Y-axis field"
+              },
+              "series": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[visualization] Data series config"
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[visualization] Chart filters"
+              },
+              "colors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[visualization] Color palette"
+              },
+              "interactive": {
+                "type": "boolean",
+                "description": "[visualization] Interactive chart"
+              },
+              "reportName": {
+                "type": "string",
+                "description": "[scheduled_report] Source report name"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "[scheduled_report] Schedule frequency"
+              },
+              "recipients": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[scheduled_report] Email recipients"
+              },
+              "format": {
+                "type": "string",
+                "description": "[scheduled_report] Report format (PDF, Excel, CSV)"
+              },
+              "subject": {
+                "type": "string",
+                "description": "[scheduled_report] Email subject"
+              },
+              "message": {
+                "type": "string",
+                "description": "[scheduled_report] Email message"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "credentials",
+      "displayName": "Credentials",
+      "tools": [
+        {
+          "name": "snow_create_connection_alias",
+          "description": "Create connection alias for IntegrationHub/Flow Designer to reference external credentials",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration-hub",
+            "flow-designer",
+            "credentials",
+            "connections"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Connection alias name (e.g., \"Jira Production\", \"Azure DevOps\")"
+              },
+              "connection_type": {
+                "type": "string",
+                "enum": [
+                  "http",
+                  "jdbc",
+                  "ldap",
+                  "ssh",
+                  "custom"
+                ],
+                "description": "Type of connection",
+                "default": "http"
+              },
+              "configuration_template": {
+                "type": "string",
+                "description": "sys_id of the connection configuration template (e.g., for specific Spoke)"
+              },
+              "credential_alias": {
+                "type": "string",
+                "description": "sys_id of credential alias to use (if already exists)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the alias is active",
+                "default": true
+              },
+              "http_connection": {
+                "type": "object",
+                "description": "HTTP connection details (for http type)",
+                "properties": {
+                  "base_url": {
+                    "type": "string",
+                    "description": "Base URL of the external system"
+                  },
+                  "default_headers": {
+                    "type": "object",
+                    "description": "Default headers to send"
+                  },
+                  "use_mutual_auth": {
+                    "type": "boolean",
+                    "description": "Enable mutual TLS authentication"
+                  },
+                  "mid_server": {
+                    "type": "string",
+                    "description": "MID Server to use for connection"
+                  }
+                }
+              },
+              "retry_policy": {
+                "type": "object",
+                "description": "Retry policy for failed connections",
+                "properties": {
+                  "max_retries": {
+                    "type": "number",
+                    "description": "Maximum number of retries",
+                    "default": 3
+                  },
+                  "retry_interval_seconds": {
+                    "type": "number",
+                    "description": "Seconds between retries",
+                    "default": 5
+                  }
+                }
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_credential_alias",
+          "description": "Create credential alias for secure storage of API keys, passwords, and OAuth tokens",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "credentials",
+            "security",
+            "authentication",
+            "api-keys"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Credential alias name (e.g., \"Jira API Credentials\", \"AWS Access Keys\")"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "basic",
+                  "api_key",
+                  "oauth2",
+                  "ssh",
+                  "certificate",
+                  "custom"
+                ],
+                "description": "Type of credential",
+                "default": "basic"
+              },
+              "basic_auth": {
+                "type": "object",
+                "description": "Basic authentication credentials",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Username"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password (stored encrypted)"
+                  }
+                }
+              },
+              "api_key": {
+                "type": "object",
+                "description": "API key credentials",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "API key value (stored encrypted)"
+                  },
+                  "header_name": {
+                    "type": "string",
+                    "description": "Header name for API key (e.g., \"X-API-Key\", \"Authorization\")",
+                    "default": "X-API-Key"
+                  },
+                  "prefix": {
+                    "type": "string",
+                    "description": "Prefix for the key value (e.g., \"Bearer \", \"Api-Key \")"
+                  }
+                }
+              },
+              "oauth2": {
+                "type": "object",
+                "description": "OAuth 2.0 credential reference",
+                "properties": {
+                  "oauth_profile_id": {
+                    "type": "string",
+                    "description": "sys_id of the OAuth profile to use"
+                  }
+                }
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the credential is active",
+                "default": true
+              },
+              "tag": {
+                "type": "string",
+                "description": "Tag for organizing credentials"
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "crud",
+      "displayName": "Crud",
+      "tools": [
+        {
+          "name": "snow_apply_template",
+          "description": "Apply template to create record",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "templates",
+            "record-creation",
+            "automation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "template_sys_id": {
+                "type": "string",
+                "description": "Template sys_id"
+              },
+              "additional_values": {
+                "type": "object",
+                "description": "Additional field values"
+              }
+            },
+            "required": [
+              "template_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ci",
+          "description": "Create Configuration Item in CMDB",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "create",
+            "configuration-item"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_class": {
+                "type": "string",
+                "description": "CI class (cmdb_ci_server, cmdb_ci_app, etc.)"
+              },
+              "name": {
+                "type": "string",
+                "description": "CI name"
+              },
+              "attributes": {
+                "type": "object",
+                "description": "CI attributes"
+              },
+              "operational_status": {
+                "type": "string",
+                "description": "Operational status"
+              },
+              "asset_tag": {
+                "type": "string",
+                "description": "Asset tag"
+              }
+            },
+            "required": [
+              "ci_class",
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_by_sysid",
+          "description": "Get any ServiceNow record by sys_id with optional field selection",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "read",
+            "records"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name (e.g., sp_widget, sys_ux_page, incident)"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of the record to retrieve"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Specific fields to return (default: all)",
+                "default": []
+              },
+              "display_value": {
+                "type": "boolean",
+                "description": "Return display values for reference fields",
+                "default": false
+              }
+            },
+            "required": [
+              "table",
+              "sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_query_table",
+          "description": "Query any ServiceNow table with filtering, pagination, and field selection. Always returns sys_id for each record.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "query",
+            "read",
+            "records"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name to query (e.g., incident, task, sys_user)"
+              },
+              "query": {
+                "type": "string",
+                "description": "Encoded query string (e.g., active=true^priority=1)"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to return (default: all fields)",
+                "default": []
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of records to return",
+                "default": 100,
+                "minimum": 1,
+                "maximum": 10000
+              },
+              "offset": {
+                "type": "number",
+                "description": "Number of records to skip (for pagination)",
+                "default": 0,
+                "minimum": 0
+              },
+              "order_by": {
+                "type": "string",
+                "description": "Field to order by (prefix with - for descending, e.g., -sys_created_on)"
+              },
+              "display_value": {
+                "type": "boolean",
+                "description": "Return display values instead of sys_ids for reference fields",
+                "default": false
+              },
+              "truncate_output": {
+                "type": "boolean",
+                "description": "Truncate large field values (scripts, templates, etc.) for cleaner output",
+                "default": true
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_record_manage",
+          "description": "Primary tool for CRUD+query on any ServiceNow record. Replaces the per-table create/update/get/delete tools (snow_create_incident, snow_update_change, snow_query_problems, etc.) — use this for any record operation.\n\nActions: create, get, update, delete, query.\n\nSupported table presets (friendly names map to platform tables, with sensible default field sets):\n- ITSM: incident, problem, change, change_request, change_task, request, task\n- CMDB: ci, server, computer, ci_relationship\n- Users: user, group, group_member\n- Assets: asset, hardware_asset, software_license\n- HR/CSM: hr_case, hr_task, customer_case, customer_account\n- Projects: project, project_task\n- Other: purchase_order, knowledge_article\n\nPass any other table name directly — presets are a convenience, not a restriction.\n\nExamples:\n- { action: \"create\", table: \"incident\", short_description: \"...\", urgency: 2 }\n- { action: \"update\", table: \"incident\", sys_id: \"...\", state: 6 }\n- { action: \"query\", table: \"incident\", query: \"state=1\" }\n- { action: \"get\", table: \"incident\", number: \"INC0010001\" }",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "create incident",
+            "update incident",
+            "get incident",
+            "delete incident",
+            "query incidents",
+            "create change",
+            "update change",
+            "get change",
+            "delete change",
+            "query changes",
+            "create problem",
+            "update problem",
+            "get problem",
+            "delete problem",
+            "query problems",
+            "create user",
+            "update user",
+            "get user",
+            "delete user",
+            "query users",
+            "create asset",
+            "update asset",
+            "get asset",
+            "delete asset",
+            "query assets",
+            "create ci",
+            "update ci",
+            "get ci",
+            "delete ci",
+            "query ci",
+            "create record",
+            "update record",
+            "get record",
+            "delete record",
+            "query records",
+            "incident management",
+            "change management",
+            "problem management",
+            "user management",
+            "modify incident",
+            "edit incident",
+            "change incident state",
+            "assign incident",
+            "modify change",
+            "edit change",
+            "modify problem",
+            "edit problem"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Operation to perform",
+                "enum": [
+                  "create",
+                  "get",
+                  "update",
+                  "delete",
+                  "query"
+                ]
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name or preset (incident, change, user, asset, etc.)"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update/delete] Record sys_id"
+              },
+              "number": {
+                "type": "string",
+                "description": "[get] Record number (e.g., INC0010001, CHG0001234)"
+              },
+              "data": {
+                "type": "object",
+                "description": "[create/update] Field values for the record (alternative to helper shortcuts)"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create/update] Brief description (incident, problem, change, etc.)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/update] Detailed description"
+              },
+              "caller_id": {
+                "type": "string",
+                "description": "[incident] User sys_id or username of caller"
+              },
+              "urgency": {
+                "type": "number",
+                "description": "[incident/problem] 1=High, 2=Medium, 3=Low",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ],
+                "default": 3
+              },
+              "impact": {
+                "type": "number",
+                "description": "[incident/change] 1=High, 2=Medium, 3=Low",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ],
+                "default": 3
+              },
+              "priority": {
+                "type": "number",
+                "description": "[incident/problem/change] 1=Critical, 2=High, 3=Moderate, 4=Low, 5=Planning",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ]
+              },
+              "category": {
+                "type": "string",
+                "description": "[incident/problem] Category (e.g., \"software\", \"hardware\", \"network\")"
+              },
+              "subcategory": {
+                "type": "string",
+                "description": "[incident/problem] Subcategory"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[incident/change/problem] Assignment group sys_id or name"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[incident/change/problem] Assigned user sys_id or username"
+              },
+              "configuration_item": {
+                "type": "string",
+                "description": "[incident] Configuration Item sys_id or name"
+              },
+              "work_notes": {
+                "type": "string",
+                "description": "[incident/change/problem] Work notes (internal)"
+              },
+              "comments": {
+                "type": "string",
+                "description": "[incident/change/problem] Additional comments (customer visible)"
+              },
+              "state": {
+                "type": "number",
+                "description": "[incident] State: 1=New, 2=InProgress, 3=OnHold, 6=Resolved, 7=Closed"
+              },
+              "type": {
+                "type": "string",
+                "description": "[change] Change type",
+                "enum": [
+                  "normal",
+                  "standard",
+                  "emergency"
+                ]
+              },
+              "risk": {
+                "type": "number",
+                "description": "[change] Risk level: 1=Very High, 2=High, 3=Moderate, 4=Low",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "start_date": {
+                "type": "string",
+                "description": "[change/project] Planned start date (YYYY-MM-DD HH:mm:ss)"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "[change/project] Planned end date (YYYY-MM-DD HH:mm:ss)"
+              },
+              "justification": {
+                "type": "string",
+                "description": "[change] Business justification"
+              },
+              "implementation_plan": {
+                "type": "string",
+                "description": "[change] Implementation plan"
+              },
+              "backout_plan": {
+                "type": "string",
+                "description": "[change] Backout/rollback plan"
+              },
+              "test_plan": {
+                "type": "string",
+                "description": "[change] Test plan"
+              },
+              "cab_required": {
+                "type": "boolean",
+                "description": "[change] Requires CAB approval",
+                "default": false
+              },
+              "user_name": {
+                "type": "string",
+                "description": "[user] Username (login ID)"
+              },
+              "first_name": {
+                "type": "string",
+                "description": "[user/contact] First name"
+              },
+              "last_name": {
+                "type": "string",
+                "description": "[user/contact] Last name"
+              },
+              "email": {
+                "type": "string",
+                "description": "[user/contact/group] Email address"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[user/group/contact] Active status",
+                "default": true
+              },
+              "department": {
+                "type": "string",
+                "description": "[user] Department sys_id or name"
+              },
+              "location": {
+                "type": "string",
+                "description": "[user/ci/asset] Location sys_id or name"
+              },
+              "manager": {
+                "type": "string",
+                "description": "[user/group] Manager sys_id or username"
+              },
+              "title": {
+                "type": "string",
+                "description": "[user/contact] Job title"
+              },
+              "phone": {
+                "type": "string",
+                "description": "[user/contact/account] Phone number"
+              },
+              "name": {
+                "type": "string",
+                "description": "[group/ci/asset/account] Name"
+              },
+              "ip_address": {
+                "type": "string",
+                "description": "[ci/server/computer] IP address"
+              },
+              "mac_address": {
+                "type": "string",
+                "description": "[ci] MAC address"
+              },
+              "os": {
+                "type": "string",
+                "description": "[server/computer] Operating system"
+              },
+              "os_version": {
+                "type": "string",
+                "description": "[server/computer] OS version"
+              },
+              "operational_status": {
+                "type": "number",
+                "description": "[ci] 1=Operational, 2=Non-Operational, 3=Repair, 4=Retired",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4
+                ]
+              },
+              "install_status": {
+                "type": "number",
+                "description": "[ci/asset] 1=Installed, 2=In Stock, 3=On Order, 6=In Maintenance, 7=Retired",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  7
+                ]
+              },
+              "support_group": {
+                "type": "string",
+                "description": "[ci] Support group sys_id or name"
+              },
+              "manufacturer": {
+                "type": "string",
+                "description": "[ci] Manufacturer sys_id or name"
+              },
+              "model_id": {
+                "type": "string",
+                "description": "[ci] Model sys_id or name"
+              },
+              "serial_number": {
+                "type": "string",
+                "description": "[ci/asset] Serial number"
+              },
+              "cpu_count": {
+                "type": "number",
+                "description": "[server] Number of CPUs"
+              },
+              "cpu_type": {
+                "type": "string",
+                "description": "[server/computer] CPU type"
+              },
+              "ram": {
+                "type": "number",
+                "description": "[server/computer] RAM in MB"
+              },
+              "disk_space": {
+                "type": "number",
+                "description": "[server] Disk space in GB"
+              },
+              "parent": {
+                "type": "string",
+                "description": "[ci_relationship/project_task/hr_task] Parent CI/record sys_id"
+              },
+              "child": {
+                "type": "string",
+                "description": "[ci_relationship] Child CI sys_id"
+              },
+              "relationship_type": {
+                "type": "string",
+                "description": "[ci_relationship] Relationship type sys_id or name"
+              },
+              "display_name": {
+                "type": "string",
+                "description": "[asset] Display name"
+              },
+              "asset_tag": {
+                "type": "string",
+                "description": "[asset] Asset tag"
+              },
+              "model": {
+                "type": "string",
+                "description": "[asset] Model sys_id or name"
+              },
+              "cost": {
+                "type": "number",
+                "description": "[asset] Cost"
+              },
+              "acquisition_method": {
+                "type": "string",
+                "description": "[asset] Acquisition method"
+              },
+              "vendor": {
+                "type": "string",
+                "description": "[asset/purchase_order] Vendor sys_id or name"
+              },
+              "warranty_expiration": {
+                "type": "string",
+                "description": "[asset] Warranty expiration date (YYYY-MM-DD)"
+              },
+              "hr_service": {
+                "type": "string",
+                "description": "[hr_case] HR Service sys_id or name"
+              },
+              "opened_for": {
+                "type": "string",
+                "description": "[hr_case] Opened for user sys_id or username"
+              },
+              "account": {
+                "type": "string",
+                "description": "[customer_case/contact] Customer account sys_id or name"
+              },
+              "contact": {
+                "type": "string",
+                "description": "[customer_case] Customer contact sys_id or name"
+              },
+              "product": {
+                "type": "string",
+                "description": "[customer_case] Product sys_id or name"
+              },
+              "account_code": {
+                "type": "string",
+                "description": "[customer_account] Account code"
+              },
+              "primary_contact": {
+                "type": "string",
+                "description": "[customer_account] Primary contact sys_id or name"
+              },
+              "city": {
+                "type": "string",
+                "description": "[customer_account] City"
+              },
+              "country": {
+                "type": "string",
+                "description": "[customer_account] Country"
+              },
+              "website": {
+                "type": "string",
+                "description": "[customer_account] Website URL"
+              },
+              "project_manager": {
+                "type": "string",
+                "description": "[project] Project manager sys_id or username"
+              },
+              "percent_complete": {
+                "type": "number",
+                "description": "[project/project_task] Percent complete (0-100)"
+              },
+              "primary_goal": {
+                "type": "string",
+                "description": "[project] Primary goal"
+              },
+              "text": {
+                "type": "string",
+                "description": "[knowledge_article] Article body/content"
+              },
+              "kb_knowledge_base": {
+                "type": "string",
+                "description": "[knowledge_article] Knowledge base sys_id or name"
+              },
+              "author": {
+                "type": "string",
+                "description": "[knowledge_article] Author sys_id or username"
+              },
+              "workflow_state": {
+                "type": "string",
+                "description": "[knowledge_article] Workflow state",
+                "enum": [
+                  "draft",
+                  "review",
+                  "published",
+                  "retired"
+                ]
+              },
+              "valid_to": {
+                "type": "string",
+                "description": "[knowledge_article] Valid until date (YYYY-MM-DD)"
+              },
+              "auto_assign": {
+                "type": "boolean",
+                "description": "[incident/change/problem] Auto-assign based on category and assignment rules",
+                "default": false
+              },
+              "query": {
+                "type": "string",
+                "description": "[query] Encoded query string (e.g., \"state=1^priority<=2^active=true\")"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[query] Maximum records to return (default: 20, max: 1000)",
+                "default": 20
+              },
+              "offset": {
+                "type": "number",
+                "description": "[query] Number of records to skip for pagination",
+                "default": 0
+              },
+              "order_by": {
+                "type": "string",
+                "description": "[query] Field to order by (prefix with - for descending)"
+              },
+              "fields": {
+                "type": "string",
+                "description": "[get/query] Comma-separated fields to return"
+              },
+              "display_value": {
+                "type": "boolean",
+                "description": "Return display values instead of sys_ids",
+                "default": true
+              },
+              "validate_references": {
+                "type": "boolean",
+                "description": "[create] Validate reference fields exist",
+                "default": true
+              },
+              "check_version": {
+                "type": "boolean",
+                "description": "[update] Perform optimistic locking check",
+                "default": false
+              },
+              "expected_version": {
+                "type": "string",
+                "description": "[update] Expected sys_mod_count for optimistic locking"
+              },
+              "check_references": {
+                "type": "boolean",
+                "description": "[delete] Check for dependent records",
+                "default": true
+              },
+              "soft_delete": {
+                "type": "boolean",
+                "description": "[delete] Mark as inactive instead of hard delete",
+                "default": false
+              },
+              "force": {
+                "type": "boolean",
+                "description": "[delete] Force deletion even with dependencies",
+                "default": false
+              }
+            },
+            "required": [
+              "action",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_update_ci",
+          "description": "Update Configuration Item attributes",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "update",
+            "configuration-item"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "CI sys_id"
+              },
+              "ci_class": {
+                "type": "string",
+                "description": "CI class table"
+              },
+              "attributes": {
+                "type": "object",
+                "description": "Attributes to update"
+              }
+            },
+            "required": [
+              "sys_id",
+              "ci_class",
+              "attributes"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "csm",
+      "displayName": "Csm",
+      "tools": [
+        {
+          "name": "snow_create_customer_case",
+          "description": "Open a Customer Service Management (CSM) case on sn_customerservice_case for a given account, with optional contact and priority. Use this for customer-facing tickets; for internal IT use snow_create_incident.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "customer-service",
+            "case-management",
+            "csm"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "string"
+              },
+              "account": {
+                "type": "string"
+              },
+              "contact": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "subject",
+              "account"
+            ]
+          }
+        },
+        {
+          "name": "snow_csm_communication_manage",
+          "description": "Unified tool for ServiceNow CSM customer interactions. Wraps the interaction table (emails, chats, calls), interaction_related_record (case links), and channel-specific records reachable through them.\n\nActions:\n- list — list interactions filtered by account, channel, state, or date\n- get — fetch a single interaction by sys_id with linked records\n- log_interaction — create a new interaction record (channel, direction, body, opened_for, account, contact)\n- link_to_case — attach an existing interaction to a CSM case via interaction_related_record\n- list_for_case — list every interaction linked to a given case\n- list_by_channel — list interactions for a channel (email, chat, phone) within an optional date range\n\nUse when: the agent needs to log or audit customer communications around a CSM case. Companion tools: snow_create_customer_case (opens the case), snow_csm_contract_manage (defines what the customer is entitled to). For internal IT communications use the platform's sys_email tools instead.\n\nRequires com.sn_customerservice. When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "customer-service",
+            "interactions",
+            "communications",
+            "csm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "log_interaction",
+                  "link_to_case",
+                  "list_for_case",
+                  "list_by_channel"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/link_to_case] interaction sys_id"
+              },
+              "number": {
+                "type": "string",
+                "description": "[get] Interaction number (alternative to sys_id)"
+              },
+              "case_sys_id": {
+                "type": "string",
+                "description": "[link_to_case/list_for_case] sn_customerservice_case sys_id"
+              },
+              "account": {
+                "type": "string",
+                "description": "[list/log_interaction] Customer account sys_id"
+              },
+              "contact": {
+                "type": "string",
+                "description": "[list/log_interaction] Customer contact sys_id"
+              },
+              "channel": {
+                "type": "string",
+                "description": "[list/log_interaction/list_by_channel] Communication channel",
+                "enum": [
+                  "email",
+                  "chat",
+                  "phone",
+                  "sms",
+                  "social",
+                  "web",
+                  "walk-in"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "description": "[list] Interaction state filter (new, work_in_progress, on_hold, closed_complete)"
+              },
+              "from_date": {
+                "type": "string",
+                "description": "[list/list_by_channel] Earliest opened_at date filter (YYYY-MM-DD)"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[log_interaction] Subject/short_description for the interaction"
+              },
+              "direction": {
+                "type": "string",
+                "description": "[log_interaction] Communication direction",
+                "enum": [
+                  "inbound",
+                  "outbound"
+                ]
+              },
+              "body": {
+                "type": "string",
+                "description": "[log_interaction] Free-text body or comment captured on the interaction"
+              },
+              "opened_for": {
+                "type": "string",
+                "description": "[log_interaction] sys_user the interaction was opened for"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[log_interaction] Agent (sys_user) handling the interaction"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_for_case/list_by_channel] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/list_for_case/list_by_channel] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_csm_contract_manage",
+          "description": "Wraps ast_contract (asset contract) + service_entitlement + service_offering. CSM (com.sn_customerservice) does not have native contract tables; ast_contract is the closest functional equivalent and service_entitlement.contract is a native reference to it.\n\nActions:\n- list_contracts — query ast_contract, optional filters: account, vendor, customer, state, active_only\n- get_contract — fetch one ast_contract row by sys_id or number, with related entitlement and offering counts\n- create_contract — create an ast_contract; vendor + vendor_contract + contract_model are required by the schema\n- list_entitlements — query service_entitlement, optional filters: contract, account, asset, active_only\n- link_entitlement_to_contract — set service_entitlement.contract on an existing entitlement (the schema's native join)\n- list_offerings — query service_offering, optional filters: company, vendor, contract, name\n\nCompanion tools: snow_csm_communication_manage (logs the customer interactions governed by the contract), snow_create_customer_account (creates the account), snow_create_entitlement (single-entitlement create).\n\nPlugin requirement: ast_contract is platform-stock so it always exists, but service_entitlement and service_offering ship with com.sn_customerservice / Service Portfolio Management. When the underlying tables do not exist the tool returns a clear plugin-missing error.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "customer-service",
+            "contracts",
+            "entitlements",
+            "offerings",
+            "csm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_contracts",
+                  "get_contract",
+                  "create_contract",
+                  "list_entitlements",
+                  "link_entitlement_to_contract",
+                  "list_offerings"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get_contract] ast_contract sys_id. [link_entitlement_to_contract] target ast_contract sys_id (the contract the entitlement should be linked to)."
+              },
+              "number": {
+                "type": "string",
+                "description": "[get_contract] ast_contract.number (alternative to sys_id)"
+              },
+              "account": {
+                "type": "string",
+                "description": "[list_contracts/list_entitlements] customer_account sys_id filter"
+              },
+              "vendor": {
+                "type": "string",
+                "description": "[list_contracts/list_offerings/create_contract] core_company sys_id of the vendor"
+              },
+              "customer": {
+                "type": "string",
+                "description": "[list_contracts/create_contract] core_company sys_id of the customer (ast_contract.customer)"
+              },
+              "contract": {
+                "type": "string",
+                "description": "[list_entitlements/list_offerings] ast_contract sys_id filter"
+              },
+              "asset": {
+                "type": "string",
+                "description": "[list_entitlements] alm_asset sys_id filter on service_entitlement.asset"
+              },
+              "company": {
+                "type": "string",
+                "description": "[list_offerings] core_company sys_id filter on service_offering.company"
+              },
+              "name": {
+                "type": "string",
+                "description": "[list_offerings/create_contract] for list_offerings: LIKE filter on service_offering.name. For create_contract: short_description (Name)."
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_contracts/create_contract] ast_contract.state — choices: draft, active, expired, cancelled"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_contracts/list_entitlements] only return rows where active=true",
+                "default": false
+              },
+              "vendor_contract": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.vendor_contract — vendor's contract number / external identifier. Mandatory on the dictionary."
+              },
+              "contract_model": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.contract_model — cmdb_model sys_id of the contract model. Mandatory on the dictionary."
+              },
+              "starts": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.starts (YYYY-MM-DD)"
+              },
+              "ends": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.ends (YYYY-MM-DD)"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.short_description (Name on the form)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.description (free-text)"
+              },
+              "cost_center": {
+                "type": "string",
+                "description": "[create_contract] cmn_cost_center sys_id"
+              },
+              "po_number": {
+                "type": "string",
+                "description": "[create_contract] ast_contract.po_number"
+              },
+              "entitlement": {
+                "type": "string",
+                "description": "[link_entitlement_to_contract] service_entitlement sys_id to update. Its .contract field will be set to the value of `sys_id`."
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_*] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_*/get_contract] Comma-separated sysparm_fields override"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "customer-service",
+      "displayName": "Customer Service",
+      "tools": [
+        {
+          "name": "snow_create_customer_account",
+          "description": "Create customer account for tracking relationships and entitlements",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "csm",
+            "accounts",
+            "customers"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Account name"
+              },
+              "account_number": {
+                "type": "string",
+                "description": "Account number"
+              },
+              "type": {
+                "type": "string",
+                "description": "Account type: Customer, Partner, Prospect"
+              },
+              "industry": {
+                "type": "string",
+                "description": "Industry"
+              },
+              "annual_revenue": {
+                "type": "string",
+                "description": "Annual revenue"
+              },
+              "employees": {
+                "type": "number",
+                "description": "Number of employees"
+              },
+              "primary_contact": {
+                "type": "string",
+                "description": "Primary contact sys_id"
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_entitlement",
+          "description": "Create service entitlement for customer",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "csm",
+            "entitlements",
+            "sla"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "account": {
+                "type": "string",
+                "description": "Customer account sys_id"
+              },
+              "service": {
+                "type": "string",
+                "description": "Service offering"
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Entitlement start date"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "Entitlement end date"
+              },
+              "support_level": {
+                "type": "string",
+                "description": "Support level: Basic, Standard, Premium"
+              },
+              "hours_included": {
+                "type": "number",
+                "description": "Support hours included"
+              },
+              "response_time": {
+                "type": "string",
+                "description": "SLA response time"
+              }
+            },
+            "required": [
+              "account",
+              "service",
+              "start_date",
+              "end_date"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_customer_history",
+          "description": "Retrieve complete customer interaction history",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "csm",
+            "history",
+            "customer-360"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "customer": {
+                "type": "string",
+                "description": "Customer account or contact sys_id"
+              },
+              "include_cases": {
+                "type": "boolean",
+                "description": "Include case history",
+                "default": true
+              },
+              "include_communications": {
+                "type": "boolean",
+                "description": "Include communications",
+                "default": true
+              },
+              "date_range": {
+                "type": "string",
+                "description": "Date range filter"
+              }
+            },
+            "required": [
+              "customer"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "dashboard",
+      "displayName": "Dashboard",
+      "tools": [
+        {
+          "name": "snow_security_dashboard",
+          "description": "Generate real-time security operations dashboard with key metrics",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "monitoring",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "dashboard_type": {
+                "type": "string",
+                "description": "Dashboard type",
+                "enum": [
+                  "executive",
+                  "analyst",
+                  "incident_response",
+                  "compliance"
+                ]
+              },
+              "time_range": {
+                "type": "string",
+                "description": "Time range for metrics",
+                "enum": [
+                  "24_hours",
+                  "7_days",
+                  "30_days",
+                  "90_days"
+                ]
+              },
+              "include_trends": {
+                "type": "boolean",
+                "description": "Include trend analysis"
+              },
+              "export_format": {
+                "type": "string",
+                "description": "Export format",
+                "enum": [
+                  "json",
+                  "pdf",
+                  "csv"
+                ]
+              }
+            },
+            "required": [
+              "dashboard_type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "dashboards",
+      "displayName": "Dashboards",
+      "tools": [
+        {
+          "name": "snow_add_dashboard_widget",
+          "description": "Attach a widget to an existing dashboard (sys_dashboard) with a widget type and optional title and position. Writes to sys_dashboard_widget.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "dashboards",
+            "widgets",
+            "visualization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "dashboard_sys_id": {
+                "type": "string",
+                "description": "Dashboard sys_id"
+              },
+              "widget_type": {
+                "type": "string",
+                "description": "Widget type"
+              },
+              "title": {
+                "type": "string",
+                "description": "Widget title"
+              },
+              "position": {
+                "type": "number",
+                "description": "Widget position"
+              }
+            },
+            "required": [
+              "dashboard_sys_id",
+              "widget_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_dashboard",
+          "description": "Create a new sys_dashboard with a title, optional description, column count (default 2), and active flag. Widgets are added separately with snow_add_dashboard_widget.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "dashboards",
+            "reporting",
+            "visualization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Dashboard title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Dashboard description"
+              },
+              "columns": {
+                "type": "number",
+                "default": 2,
+                "description": "Number of columns"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_pa_dashboard",
+          "description": "Create a Performance Analytics dashboard with widgets (pa_dashboards table). For Service Portal / classic dashboards use snow_create_dashboard.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "dashboards",
+            "visualization",
+            "analytics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Dashboard name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Dashboard description"
+              },
+              "layout": {
+                "type": "string",
+                "description": "Dashboard layout (grid, tabs, accordion)",
+                "enum": [
+                  "grid",
+                  "tabs",
+                  "accordion"
+                ]
+              },
+              "widgets": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Dashboard widgets configuration"
+              },
+              "permissions": {
+                "type": "array",
+                "description": "User/role permissions",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "refresh_interval": {
+                "type": "number",
+                "description": "Auto-refresh interval in minutes"
+              },
+              "public": {
+                "type": "boolean",
+                "description": "Public dashboard"
+              }
+            },
+            "required": [
+              "name",
+              "widgets"
+            ]
+          }
+        },
+        {
+          "name": "snow_dashboard_manage",
+          "description": "Unified tool for ServiceNow dashboard lifecycle beyond creation: list, get, share, embed, tab_create, tab_list. Wraps sys_dashboard, sys_dashboard_admin, and pa_tabs.\n\nActions:\n- list — list sys_dashboard rows, optionally filtered by owner or active flag\n- get — retrieve a dashboard by sys_id or title (includes tab and widget counts)\n- share — share a dashboard with a user or group through sys_dashboard_admin\n- embed — produce an embed URL and iframe snippet for a dashboard (no write to ServiceNow)\n- tab_create — create a pa_tabs row attached to a dashboard\n- tab_list — list pa_tabs rows attached to a dashboard\n\nUse when: the agent needs to manage dashboards after they exist — sharing them, embedding them in a portal page, or organising their tab layout. For authoring a new dashboard, use snow_create_dashboard; for attaching widgets to it, use snow_add_dashboard_widget.\n\nReturns: dashboard records with sys_id, title, columns, active; share rows with user_or_group references; tab rows with order and title.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "dashboards",
+            "reporting",
+            "sharing",
+            "embedding",
+            "tabs"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "share",
+                  "embed",
+                  "tab_create",
+                  "tab_list"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/share/embed/tab_create/tab_list] Dashboard sys_id"
+              },
+              "title": {
+                "type": "string",
+                "description": "[get/share/embed/tab_create/tab_list] Dashboard title (used as identifier when sys_id is absent)"
+              },
+              "owner": {
+                "type": "string",
+                "description": "[list] Filter by sys_user sys_id (dashboard owner)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list] Only return active dashboards",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/tab_list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/tab_list] Comma-separated list of fields to return"
+              },
+              "user": {
+                "type": "string",
+                "description": "[share] sys_user sys_id to grant view/edit access"
+              },
+              "group": {
+                "type": "string",
+                "description": "[share] sys_user_group sys_id to grant view/edit access (alternative to user)"
+              },
+              "share_role": {
+                "type": "string",
+                "description": "[share] Access level granted",
+                "enum": [
+                  "read",
+                  "write"
+                ],
+                "default": "read"
+              },
+              "embed_height": {
+                "type": "number",
+                "description": "[embed] Iframe height in pixels",
+                "default": 800
+              },
+              "embed_width": {
+                "type": "string",
+                "description": "[embed] Iframe width (px or %)",
+                "default": "100%"
+              },
+              "tab_title": {
+                "type": "string",
+                "description": "[tab_create] Tab title shown on the dashboard"
+              },
+              "tab_order": {
+                "type": "number",
+                "description": "[tab_create] Tab display order (lower = first)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "data-integration",
+      "displayName": "Data Integration",
+      "tools": [
+        {
+          "name": "snow_configure_uib_data_broker",
+          "description": "Update data broker configuration including queries, caching, and refresh settings",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "data",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "data_broker_id": {
+                "type": "string",
+                "description": "Data broker sys_id to configure"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query string for data retrieval"
+              },
+              "refresh_interval": {
+                "type": "number",
+                "description": "Refresh interval in seconds"
+              },
+              "enable_caching": {
+                "type": "boolean",
+                "description": "Enable data caching"
+              },
+              "cache_duration": {
+                "type": "number",
+                "description": "Cache duration in seconds"
+              },
+              "parameters": {
+                "type": "object",
+                "description": "Data broker parameters"
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Data filters"
+              }
+            },
+            "required": [
+              "data_broker_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_uib_data_broker",
+          "description": "Create data broker to connect UI Builder pages to ServiceNow data sources",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "data",
+            "integration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Target page sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Data broker name"
+              },
+              "table": {
+                "type": "string",
+                "description": "ServiceNow table to query"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query string for data retrieval"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to retrieve",
+                "default": []
+              },
+              "order_by": {
+                "type": "string",
+                "description": "Order by field"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum records to retrieve",
+                "default": 100
+              }
+            },
+            "required": [
+              "page_id",
+              "name",
+              "table"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "data-quality",
+      "displayName": "Data Quality",
+      "tools": [
+        {
+          "name": "snow_analyze_data_quality",
+          "description": "Analyze data quality including completeness, consistency, and accuracy metrics",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "data-quality",
+            "analysis",
+            "metrics"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table to analyze"
+              },
+              "fields": {
+                "type": "array",
+                "description": "Specific fields to analyze",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "check_completeness": {
+                "type": "boolean",
+                "description": "Check data completeness"
+              },
+              "check_consistency": {
+                "type": "boolean",
+                "description": "Check data consistency"
+              },
+              "check_accuracy": {
+                "type": "boolean",
+                "description": "Check data accuracy"
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_duplicate_detection",
+          "description": "Check whether a candidate record would duplicate existing rows on a table by matching on the given fields. Returns up to 10 existing matches; useful for de-dup checks before insert.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "duplicate-detection",
+            "data-quality",
+            "data-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "match_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to match"
+              },
+              "record_data": {
+                "type": "object",
+                "description": "Record data to check"
+              }
+            },
+            "required": [
+              "table",
+              "match_fields",
+              "record_data"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "data-transformation",
+      "displayName": "Data Transformation",
+      "tools": [
+        {
+          "name": "snow_create_field_map",
+          "description": "Create field mapping within transform map for data transformation",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "transformation",
+            "mapping"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "transformMapName": {
+                "type": "string",
+                "description": "Parent Transform Map name or sys_id"
+              },
+              "sourceField": {
+                "type": "string",
+                "description": "Source field name"
+              },
+              "targetField": {
+                "type": "string",
+                "description": "Target field name"
+              },
+              "transform": {
+                "type": "string",
+                "description": "Transform script (JavaScript to transform value)"
+              },
+              "coalesce": {
+                "type": "boolean",
+                "description": "Use as coalesce field for matching records",
+                "default": false
+              },
+              "defaultValue": {
+                "type": "string",
+                "description": "Default value if source is empty"
+              },
+              "choice": {
+                "type": "boolean",
+                "description": "Use choice list for mapping",
+                "default": false
+              }
+            },
+            "required": [
+              "transformMapName",
+              "sourceField",
+              "targetField"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "data-utilities",
+      "displayName": "Data Utilities",
+      "tools": [
+        {
+          "name": "snow_data_convert",
+          "description": "Unified data conversion (csv_to_json, json_to_csv, json_to_xml, xml_to_json)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "conversion",
+            "data-transformation",
+            "csv",
+            "xml",
+            "json"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Conversion action",
+                "enum": [
+                  "csv_to_json",
+                  "json_to_csv",
+                  "json_to_xml",
+                  "xml_to_json"
+                ]
+              },
+              "csv": {
+                "type": "string",
+                "description": "[csv_to_json] CSV string"
+              },
+              "delimiter": {
+                "type": "string",
+                "description": "[csv_to_json/json_to_csv] Field delimiter"
+              },
+              "json": {
+                "type": [
+                  "array",
+                  "object"
+                ],
+                "description": "[json_to_csv/json_to_xml] JSON data"
+              },
+              "root_tag": {
+                "type": "string",
+                "description": "[json_to_xml] Root XML tag name"
+              },
+              "xml": {
+                "type": "string",
+                "description": "[xml_to_json] XML string"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_data_export",
+          "description": "Export table data to CSV/XML/JSON format. Always includes sys_id. Returns records array with full data.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "export",
+            "data-management",
+            "backup"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query filter"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to export"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv",
+                  "xml",
+                  "json"
+                ],
+                "default": "json"
+              },
+              "limit": {
+                "type": "number",
+                "default": 1000
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_data_mapper",
+          "description": "Advanced data mapping with transformations",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "data-mapping",
+            "transformation",
+            "integration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Source data array"
+              },
+              "mapping_rules": {
+                "type": "object",
+                "description": "Mapping rules"
+              }
+            },
+            "required": [
+              "data",
+              "mapping_rules"
+            ]
+          }
+        },
+        {
+          "name": "snow_date_filter",
+          "description": "Build an encoded-query fragment that filters a date field by either a relative window (today/yesterday/this-or-last-week/month) or an absolute start/end range. Returns the query string for use in sysparm_query.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "filtering",
+            "date-queries",
+            "query-building"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Date field name"
+              },
+              "relative": {
+                "type": "string",
+                "enum": [
+                  "today",
+                  "yesterday",
+                  "thisWeek",
+                  "lastWeek",
+                  "thisMonth",
+                  "lastMonth"
+                ],
+                "description": "Relative date"
+              },
+              "start_date": {
+                "type": "string",
+                "description": "Start date (YYYY-MM-DD)"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "End date (YYYY-MM-DD)"
+              }
+            },
+            "required": [
+              "field"
+            ]
+          }
+        },
+        {
+          "name": "snow_diff_objects",
+          "description": "Compare two objects and get differences",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "comparison",
+            "diff",
+            "data-analysis"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "object1": {
+                "type": "object",
+                "description": "First object"
+              },
+              "object2": {
+                "type": "object",
+                "description": "Second object"
+              }
+            },
+            "required": [
+              "object1",
+              "object2"
+            ]
+          }
+        },
+        {
+          "name": "snow_field_filter",
+          "description": "Build an encoded-query fragment matching one field against a list of values, OR-joined. Match type is exact (=), contains (LIKE), startsWith, or endsWith. Returns the query string for use in sysparm_query.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "filtering",
+            "field-queries",
+            "query-building"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "field": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Values to filter"
+              },
+              "match_type": {
+                "type": "string",
+                "enum": [
+                  "exact",
+                  "contains",
+                  "startsWith",
+                  "endsWith"
+                ],
+                "default": "exact"
+              }
+            },
+            "required": [
+              "field",
+              "values"
+            ]
+          }
+        },
+        {
+          "name": "snow_field_mapper",
+          "description": "Project a source object into a new shape using a target-field → source-field mapping. Useful for shaping data between systems (e.g. inbound integration payload → ServiceNow record fields).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "field-mapping",
+            "schema-transformation",
+            "integration"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "source_data": {
+                "type": "object",
+                "description": "Source data"
+              },
+              "field_mapping": {
+                "type": "object",
+                "description": "Field mapping rules"
+              }
+            },
+            "required": [
+              "source_data",
+              "field_mapping"
+            ]
+          }
+        },
+        {
+          "name": "snow_paginate",
+          "description": "Calculate pagination parameters",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "pagination",
+            "data-retrieval",
+            "performance"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "total_records": {
+                "type": "number",
+                "description": "Total record count"
+              },
+              "page_size": {
+                "type": "number",
+                "default": 100
+              },
+              "current_page": {
+                "type": "number",
+                "default": 1
+              }
+            },
+            "required": [
+              "total_records"
+            ]
+          }
+        },
+        {
+          "name": "snow_parse_json",
+          "description": "Parse a JSON string and validate it: returns the parsed object plus the top-level key count, or an error message if the JSON is malformed. Runs locally — no ServiceNow call.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "parsing",
+            "validation",
+            "json"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "json_string": {
+                "type": "string",
+                "description": "JSON string to parse"
+              }
+            },
+            "required": [
+              "json_string"
+            ]
+          }
+        },
+        {
+          "name": "snow_query_filter",
+          "description": "Build ServiceNow encoded query filter",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "filtering",
+            "encoded-queries",
+            "query-building"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "conditions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": [
+                        "=",
+                        "!=",
+                        ">",
+                        "<",
+                        ">=",
+                        "<=",
+                        "LIKE",
+                        "IN",
+                        "STARTSWITH",
+                        "ENDSWITH"
+                      ]
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "description": "Filter conditions"
+              },
+              "logic": {
+                "type": "string",
+                "enum": [
+                  "AND",
+                  "OR"
+                ],
+                "default": "AND"
+              }
+            },
+            "required": [
+              "conditions"
+            ]
+          }
+        },
+        {
+          "name": "snow_transform_data",
+          "description": "Transform data using field mappings",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "data-transformation",
+            "field-mapping",
+            "integration"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "source_data": {
+                "type": "object",
+                "description": "Source data"
+              },
+              "field_mappings": {
+                "type": "object",
+                "description": "Field mapping rules"
+              }
+            },
+            "required": [
+              "source_data",
+              "field_mappings"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "debugging",
+      "displayName": "Debugging",
+      "tools": [
+        {
+          "name": "snow_debug_widget_fetch",
+          "description": "Debug widget data fetching and server communication issues",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "debugging",
+            "widgets"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Target page sys_id"
+              },
+              "widget_name": {
+                "type": "string",
+                "description": "Widget name to debug"
+              },
+              "trace_requests": {
+                "type": "boolean",
+                "description": "Trace HTTP requests",
+                "default": true
+              },
+              "log_level": {
+                "type": "string",
+                "description": "Log level (info, debug, warn, error)",
+                "default": "debug"
+              }
+            },
+            "required": [
+              "page_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_inspect_mutations",
+          "description": "Inspect what mutations (INSERT/UPDATE/DELETE) occurred on the ServiceNow instance in a time window. Queries sys_audit for successful changes, syslog for errors, and optionally syslog_transaction for HTTP requests including failures. Essential for debugging tool behavior after execution.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "debugging",
+            "audit",
+            "mutations"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "required": [
+              "since"
+            ],
+            "properties": {
+              "since": {
+                "type": "string",
+                "description": "Start of time window. ISO 8601 timestamp or relative: \"30s\", \"2m\", \"1h\", \"1d\". A 2-second buffer is subtracted for timestamp precision."
+              },
+              "until": {
+                "type": "string",
+                "description": "End of time window. Same format as since. Defaults to now."
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Filter on specific tables (e.g. [\"sys_hub_flow\", \"sys_hub_action_instance\"])"
+              },
+              "exclude_tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tables to exclude from results (noise reduction)",
+                "default": [
+                  "syslog",
+                  "sys_audit",
+                  "sys_audit_relation",
+                  "ha_log"
+                ]
+              },
+              "user": {
+                "type": "string",
+                "description": "Filter by username who made the change"
+              },
+              "record_id": {
+                "type": "string",
+                "description": "Filter on a specific record sys_id"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "INSERT",
+                    "UPDATE",
+                    "DELETE"
+                  ]
+                },
+                "description": "Filter by action type (e.g. [\"INSERT\"], [\"UPDATE\",\"DELETE\"])"
+              },
+              "include_syslog": {
+                "type": "boolean",
+                "description": "Also retrieve errors/warnings from syslog in the time window",
+                "default": true
+              },
+              "include_transactions": {
+                "type": "boolean",
+                "description": "Query syslog_transaction for inbound HTTP requests including failures. Available on most instances by default.",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max audit records to return",
+                "default": 500,
+                "minimum": 1,
+                "maximum": 5000
+              },
+              "group_by": {
+                "type": "string",
+                "enum": [
+                  "table_and_record",
+                  "table",
+                  "chronological"
+                ],
+                "description": "How to group results",
+                "default": "table_and_record"
+              },
+              "snapshot_record": {
+                "type": "object",
+                "description": "Fetch current state of a specific record alongside audit trail",
+                "properties": {
+                  "table": {
+                    "type": "string",
+                    "description": "Table name"
+                  },
+                  "sys_id": {
+                    "type": "string",
+                    "description": "Record sys_id"
+                  },
+                  "fields": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Specific fields to retrieve (defaults to all)"
+                  }
+                },
+                "required": [
+                  "table",
+                  "sys_id"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "dependency-analysis",
+      "displayName": "Dependency Analysis",
+      "tools": [
+        {
+          "name": "snow_blast_radius_dependents",
+          "description": "Find every artifact across the instance that uses, calls, or depends on a given artifact. Answers \"what breaks if I change or delete this?\"\n\nCall this before: deleting a script include, business rule, client script, UI action, UI policy, or widget; refactoring the name / api_name / signature of a script include; removing a table; promoting a breaking change to another instance; or telling the user \"it's safe to remove X\".\n\nThe output is the full impact list — every caller, every referrer, in every scope. Scans 100+ tables including workflows, notifications, email actions, catalog scripts, scheduled jobs, and custom scripted tables.\n\nTrigger phrases (agent should invoke this):\n- \"what uses X\" / \"what calls X\" / \"what references X\"\n- \"wat gebruikt X\" / \"wat roept X aan\" / \"wat heeft X nodig\"\n- \"can I delete X\" / \"is it safe to remove X\" / \"kan ik X verwijderen\"\n- \"impact analysis\" / \"blast radius\" / \"dependency audit\"\n- User asks to refactor, rename, or remove a named artifact\n\nReturns:\n- dependents[] — each with type, name, scope, source_table, source_field, cross_scope flag. source_table/source_field let you distinguish a workflow-condition hit from a business-rule hit (critical for triage).\n- summary — by_type + by_table counts + cross_scope count + truncation flag.\n- search_stats — per-phase timing + tables scanned + cache hit, so you know the scan was thorough.\n\nHow it searches (why you can trust a \"none found\"):\n- Phase 1: 25+ curated artifact types (human-attributed labels)\n- Phase 2: sys_dictionary discovery — every table with script-type fields\n- Phase 3: concurrency-limited batch query over the long tail\n\nDeep-only by design. Takes 2-10s depending on instance size.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "dependency-audit",
+            "refactoring",
+            "safe-delete-check",
+            "find-callers",
+            "find-references",
+            "breaking-change-review",
+            "blast-radius"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_type": {
+                "type": "string",
+                "enum": [
+                  "script_include",
+                  "business_rule",
+                  "client_script",
+                  "ui_action",
+                  "widget",
+                  "table"
+                ],
+                "description": "Type of artifact to find dependents of"
+              },
+              "artifact_identifier": {
+                "type": "string",
+                "description": "sys_id, api_name (for script includes), or table name"
+              },
+              "search_scope": {
+                "type": "string",
+                "enum": [
+                  "same_app",
+                  "all"
+                ],
+                "description": "Search within same app scope or across all scopes (default: all)",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of dependents to return (default: 100)",
+                "default": 100
+              },
+              "phase3_concurrency": {
+                "type": "number",
+                "description": "Parallel REST requests during Phase-3 long-tail search. Default 10. Raise on beefy instances.",
+                "default": 10
+              }
+            },
+            "required": [
+              "artifact_type",
+              "artifact_identifier"
+            ]
+          }
+        },
+        {
+          "name": "snow_blast_radius_sys_properties",
+          "description": "Search sys_property records for plain-string references to an artifact name. Closes a recurring blind spot of snow_blast_radius_dependents: property values are NOT script-typed columns, so they're invisible to the script-bearing scan even though gs.getProperty() reads them at runtime.\n\nCall this together with snow_blast_radius_dependents when:\n- Deleting or renaming a script include / business rule / widget / scheduled job / table\n- Renaming a field name that may be referenced in property-driven dynamic queries\n- Checking whether a role or user name is hardcoded in a config flag\n\nReturns:\n- properties[] — each match with name, value preview, description, last_updated, scope, category\n- summary — total hits + counts by detected category (platform, scoped_app, plugin, custom)\n- impact_warning — non-null when matches exist, with a reminder to update them alongside the rename/delete\n\nCaveat: LIKE-matched then word-boundary regex confirmed. False positives are possible if the name occurs as a literal substring in unrelated property text. For low hit counts: inspect the value previews.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "refactoring",
+            "safe-delete-check",
+            "property-audit",
+            "config-flag-discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_identifier": {
+                "type": "string",
+                "description": "Name to search for in sys_property values (e.g. 'IncidentUtils', 'x_acme_workflow', 'assignment_group')."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum properties to return (default: 100).",
+                "default": 100
+              }
+            },
+            "required": [
+              "artifact_identifier"
+            ]
+          }
+        },
+        {
+          "name": "snow_blast_radius_update_sets",
+          "description": "Search pending and committed update sets for references to a given artifact. Closes the \"did anyone include this in an unloaded update set?\" gap that snow_blast_radius_dependents leaves behind — update-set XML payloads are not script-bearing fields, so the regular scan never reads them.\n\nCall this when:\n- Preparing to delete or rename an artifact (combine with snow_blast_radius_dependents).\n- Investigating why a promotion broke or will break in another instance.\n- The user asks \"is this in any pending update sets?\" / \"wat zit er nog in update sets?\".\n\nReturns:\n- updates[] — each XML hit with set_name, set_state (in_progress / complete / ignore), update_xml_name, type, target_name, action, last_updated.\n- summary — by_state counts, by_set counts, total hits.\n- impact_warning — non-null when matches exist in any in_progress update set; those will break on commit if the artifact is gone.\n\nNote: LIKE-matches the artifact identifier across payload + name + target_name. False positives are possible (the name appearing in a comment); confirm by inspecting the update XML when the count is low.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "refactoring",
+            "safe-delete-check",
+            "promotion-readiness",
+            "update-set-audit"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_identifier": {
+                "type": "string",
+                "description": "Name, api_name, or sys_id of the artifact to search for in update-set XML payloads."
+              },
+              "states": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "in_progress",
+                    "complete",
+                    "ignore"
+                  ]
+                },
+                "description": "Which update-set states to include (default: ['in_progress', 'complete']). 'ignore' is rarely useful."
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of update_xml records to return (default: 200).",
+                "default": 200
+              }
+            },
+            "required": [
+              "artifact_identifier"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "deployment",
+      "displayName": "Deployment",
+      "tools": [
+        {
+          "name": "snow_artifact_manage",
+          "description": "Unified tool for ServiceNow artifact lifecycle: create, get, update, delete, find, list, analyze, export, import, verify.\n\nActions:\n- create — create a new artifact (widget, page, script, table, field, etc.)\n- get — retrieve by sys_id or identifier\n- update — update fields, including _file parameters for file-based updates\n- delete — delete (with soft-delete support)\n- find — search artifacts by query\n- list — list all artifacts of a type\n- analyze — analyze artifact dependencies\n- export — export to JSON/XML\n- import — import from JSON/XML file\n- verify — compare local files against deployed artifact content\n\nSupported artifact types: sp_widget/widget, sp_page/page, sys_ux_page/uib_page (UI Builder), script_include, business_rule, client_script, ui_policy, ui_action, rest_message, scheduled_job, transform_map, fix_script, table (sys_db_object), field (sys_dictionary), flow (sys_hub_flow), application (sys_app).\n\nES5 only: server-side scripts must use ES5 syntax (var, function, string concatenation — no arrow functions, const/let, template literals).\n\nApplication scope: pass application_scope to target a specific scope, or \"global\" for global-scope artifacts.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "artifacts",
+            "widgets",
+            "scripts",
+            "tables",
+            "crud"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "create",
+                  "get",
+                  "update",
+                  "delete",
+                  "find",
+                  "list",
+                  "analyze",
+                  "export",
+                  "import",
+                  "verify"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "description": "Artifact type (sp_widget, script_include, business_rule, table, field, etc.)",
+                "enum": [
+                  "sp_widget",
+                  "widget",
+                  "sp_page",
+                  "page",
+                  "sys_ux_page",
+                  "uib_page",
+                  "script_include",
+                  "business_rule",
+                  "client_script",
+                  "ui_policy",
+                  "ui_action",
+                  "rest_message",
+                  "scheduled_job",
+                  "transform_map",
+                  "fix_script",
+                  "table",
+                  "field",
+                  "flow",
+                  "application"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update/delete/analyze/export] Artifact sys_id"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "[get/update/delete] Artifact identifier (name/id) - alternative to sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create] Artifact name/ID (required for create)"
+              },
+              "title": {
+                "type": "string",
+                "description": "[create] Display title (for widgets/pages)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/update] Artifact description"
+              },
+              "template": {
+                "type": "string",
+                "description": "[create/update] HTML template (for widgets/pages)"
+              },
+              "server_script": {
+                "type": "string",
+                "description": "[create/update] Server-side script (ES5 only!)"
+              },
+              "client_script": {
+                "type": "string",
+                "description": "[create/update] Client-side script"
+              },
+              "css": {
+                "type": "string",
+                "description": "[create/update] CSS stylesheet (for widgets)"
+              },
+              "option_schema": {
+                "type": "string",
+                "description": "[create/update] Option schema JSON (for widgets)"
+              },
+              "script": {
+                "type": "string",
+                "description": "[create/update] Script content (for script includes, business rules, etc.)"
+              },
+              "api_name": {
+                "type": "string",
+                "description": "[create] API name (for script includes)"
+              },
+              "table": {
+                "type": "string",
+                "description": "[create/find] Table name (for business rules, client scripts, fields, etc.)"
+              },
+              "when": {
+                "type": "string",
+                "enum": [
+                  "before",
+                  "after",
+                  "async",
+                  "display"
+                ],
+                "description": "[create] When to execute (business rules)"
+              },
+              "insert": {
+                "type": "boolean",
+                "description": "[create] Run on insert (business rules)"
+              },
+              "update_trigger": {
+                "type": "boolean",
+                "description": "[create] Run on update (business rules)"
+              },
+              "delete_trigger": {
+                "type": "boolean",
+                "description": "[create] Run on delete (business rules)"
+              },
+              "query_trigger": {
+                "type": "boolean",
+                "description": "[create] Run on query (business rules)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[create/update] Activate immediately",
+                "default": true
+              },
+              "label": {
+                "type": "string",
+                "description": "[create] Table label (for tables) or field label (for fields)"
+              },
+              "extends_table": {
+                "type": "string",
+                "description": "[create] Parent table to extend (for tables)"
+              },
+              "is_extendable": {
+                "type": "boolean",
+                "description": "[create] Whether the table can be extended",
+                "default": true
+              },
+              "create_module": {
+                "type": "boolean",
+                "description": "[create] Create navigation module for the table",
+                "default": true
+              },
+              "create_access_controls": {
+                "type": "boolean",
+                "description": "[create] Create default ACLs for the table",
+                "default": false
+              },
+              "column_name": {
+                "type": "string",
+                "description": "[create] Column/field name (for fields)"
+              },
+              "column_label": {
+                "type": "string",
+                "description": "[create] Column/field display label (for fields)"
+              },
+              "internal_type": {
+                "type": "string",
+                "description": "[create] Field type (for fields)",
+                "enum": [
+                  "string",
+                  "integer",
+                  "boolean",
+                  "reference",
+                  "glide_date",
+                  "glide_date_time",
+                  "decimal",
+                  "float",
+                  "choice",
+                  "journal",
+                  "journal_input",
+                  "html",
+                  "url",
+                  "email",
+                  "phone_number_e164",
+                  "currency",
+                  "price"
+                ]
+              },
+              "reference_table": {
+                "type": "string",
+                "description": "[create] Reference table name (for reference fields)"
+              },
+              "max_length": {
+                "type": "number",
+                "description": "[create] Maximum length for string fields",
+                "default": 255
+              },
+              "mandatory": {
+                "type": "boolean",
+                "description": "[create] Whether the field is mandatory",
+                "default": false
+              },
+              "default_value": {
+                "type": "string",
+                "description": "[create] Default value for the field"
+              },
+              "choice_options": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "description": "[create] Choice options for choice fields"
+              },
+              "config": {
+                "type": "object",
+                "description": "[update] Fields to update (only specified fields will be changed)"
+              },
+              "validate": {
+                "type": "boolean",
+                "description": "[update] Validate before update",
+                "default": true
+              },
+              "create_backup": {
+                "type": "boolean",
+                "description": "[update] Create backup before update",
+                "default": false
+              },
+              "soft_delete": {
+                "type": "boolean",
+                "description": "[delete] Mark as inactive instead of hard delete",
+                "default": false
+              },
+              "force": {
+                "type": "boolean",
+                "description": "[delete] Force deletion even with dependencies",
+                "default": false
+              },
+              "query": {
+                "type": "string",
+                "description": "[find] Search query (natural language or encoded query)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[find/list] Maximum results to return",
+                "default": 10
+              },
+              "fields": {
+                "type": "string",
+                "description": "[get/find/list] Comma-separated list of fields to return"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json",
+                  "xml",
+                  "files"
+                ],
+                "description": "[export] Export format. Use \"files\" to export to separate files per field (template.html, server.js, etc.)",
+                "default": "json"
+              },
+              "export_path": {
+                "type": "string",
+                "description": "[export] Directory path to export files to (required for format=\"files\")"
+              },
+              "file_path": {
+                "type": "string",
+                "description": "[import] Path to the artifact file"
+              },
+              "data": {
+                "type": "object",
+                "description": "[import] Artifact data object (alternative to file_path)"
+              },
+              "artifact_directory": {
+                "type": "string",
+                "description": "[create/update/verify] Directory containing artifact files. Auto-maps files like template.html→template, server.js→script, etc."
+              },
+              "template_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to HTML template file (widgets)"
+              },
+              "server_script_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to server-side script file"
+              },
+              "client_script_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to client-side script file"
+              },
+              "css_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to CSS stylesheet file (widgets)"
+              },
+              "option_schema_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to option schema JSON file (widgets)"
+              },
+              "script_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to script file (for script includes, business rules, etc.)"
+              },
+              "condition_file": {
+                "type": "string",
+                "description": "[create/update/verify] Path to condition script file (business rules, UI actions)"
+              },
+              "application_scope": {
+                "type": "string",
+                "description": "Application scope for the artifact. Use \"global\" for global scope."
+              },
+              "validate_es5": {
+                "type": "boolean",
+                "description": "Validate ES5 syntax for server scripts",
+                "default": true
+              }
+            },
+            "required": [
+              "action",
+              "type"
+            ]
+          }
+        },
+        {
+          "name": "snow_auth_diagnostics",
+          "description": "Performs comprehensive authentication and permission diagnostics. Tests OAuth tokens, API access, table permissions, and provides specific remediation steps.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "diagnostics",
+            "authentication"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "run_write_test": {
+                "type": "boolean",
+                "description": "Test widget write permissions (creates and deletes test widget)",
+                "default": true
+              },
+              "include_recommendations": {
+                "type": "boolean",
+                "description": "Include troubleshooting recommendations",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_clone_instance_artifact",
+          "description": "Clones artifacts directly between ServiceNow instances (dev→test→prod). Handles authentication, dependency resolution, and data migration.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "migration",
+            "clone"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "source_instance": {
+                "type": "string",
+                "description": "Source instance URL"
+              },
+              "target_instance": {
+                "type": "string",
+                "description": "Target instance URL"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "widget",
+                  "application"
+                ],
+                "description": "Artifact type"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Sys ID of the artifact to clone"
+              }
+            },
+            "required": [
+              "source_instance",
+              "target_instance",
+              "type",
+              "sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_solution_package",
+          "description": "Bundle multiple related artifacts into a single deployment package, tracked by a freshly created Update Set switched as current.\n\nUse when: building a feature bundle of 3+ related artifacts that ship as one unit (e.g. HR Portal: widget + script includes + business rule). For single artifacts use snow_artifact_manage directly — this tool delegates to it for each artifact and adds package-level Update Set wiring on top.\n\nEach artifact entry has a type and a create object that's passed through to snow_artifact_manage. Failures per artifact are collected (not fatal) so you can retry the failures individually.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "multi-artifact",
+            "solution-bundle",
+            "feature-package"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Solution package name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Package description"
+              },
+              "artifacts": {
+                "type": "array",
+                "description": "Artifacts to include in the package",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "widget",
+                        "script_include",
+                        "business_rule",
+                        "table"
+                      ]
+                    },
+                    "create": {
+                      "type": "object",
+                      "description": "Artifact creation configuration"
+                    }
+                  }
+                }
+              },
+              "new_update_set": {
+                "type": "boolean",
+                "description": "Force new update set",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "artifacts"
+            ]
+          }
+        },
+        {
+          "name": "snow_deployment_debug",
+          "description": "Provides detailed debugging information including authentication status, permissions, active sessions, and recent deployment logs for troubleshooting.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "debugging",
+            "diagnostics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        {
+          "name": "snow_deployment_status",
+          "description": "Retrieves comprehensive deployment status including active deployments, recent history, success rates, and performance metrics.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "monitoring",
+            "history"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "number",
+                "description": "Number of recent deployments to show",
+                "default": 10
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_github_deploy",
+          "description": "Deploy files directly from GitHub to ServiceNow — content never passes through LLM context.\n\nThree modes:\n1. Single file: source_path → one artifact field\n2. Directory → Widget: source_directory auto-maps files (template.html→template, server.js→script, etc.)\n3. Bulk: source_directory + bulk=true → each file becomes a separate artifact\n\nRequires: Enterprise license with 'github' feature. GitHub PAT is managed server-side.\n\nSupported target types: widget, script_include, business_rule, client_script, ui_action, scheduled_job, fix_script, etc.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "github",
+            "deployment",
+            "pipeline",
+            "widgets",
+            "scripts"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "type": "string",
+                "description": "GitHub owner or organization"
+              },
+              "repo": {
+                "type": "string",
+                "description": "Repository name"
+              },
+              "branch": {
+                "type": "string",
+                "description": "Branch name (default: \"main\")"
+              },
+              "source_path": {
+                "type": "string",
+                "description": "[Mode 1] Path to a single file in the repo (e.g. \"scripts/MyScript.js\")"
+              },
+              "source_directory": {
+                "type": "string",
+                "description": "[Mode 2/3] Path to a directory in the repo (e.g. \"widgets/my_widget/\")"
+              },
+              "target_type": {
+                "type": "string",
+                "description": "ServiceNow artifact type",
+                "enum": [
+                  "sp_widget",
+                  "widget",
+                  "sp_page",
+                  "page",
+                  "sys_ux_page",
+                  "uib_page",
+                  "script_include",
+                  "business_rule",
+                  "client_script",
+                  "ui_policy",
+                  "ui_action",
+                  "rest_message",
+                  "scheduled_job",
+                  "transform_map",
+                  "fix_script",
+                  "flow",
+                  "application"
+                ]
+              },
+              "target_identifier": {
+                "type": "string",
+                "description": "[Mode 1/2] Name or ID of the target artifact in ServiceNow"
+              },
+              "target_sys_id": {
+                "type": "string",
+                "description": "Alternative: sys_id of the target artifact"
+              },
+              "target_field": {
+                "type": "string",
+                "description": "[Mode 1] Which field to update (auto-detected if omitted, e.g. \"script\", \"template\")"
+              },
+              "upsert": {
+                "type": "boolean",
+                "description": "Create artifact if it does not exist (default: true)"
+              },
+              "bulk": {
+                "type": "boolean",
+                "description": "[Mode 3] Deploy each file in directory as a separate artifact (default: false)"
+              },
+              "file_extension_filter": {
+                "type": "string",
+                "description": "[Mode 3] Filter files by extension in bulk mode (e.g. \".js\")"
+              },
+              "field_mapping": {
+                "type": "object",
+                "description": "[Mode 2] Custom filename→field mapping override (e.g. {\"my-template.html\": \"template\"})"
+              },
+              "dry_run": {
+                "type": "boolean",
+                "description": "Preview what would be deployed without actually deploying (default: false)"
+              }
+            },
+            "required": [
+              "owner",
+              "repo",
+              "target_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_github_tree",
+          "description": "Browse GitHub repository structure via enterprise proxy. Returns metadata only (paths, types, sizes) — no file content in LLM context.\n\nUse this to explore a repo before deploying files with snow_github_deploy.\n\nRequires: Enterprise license with 'github' feature. GitHub PAT is managed server-side.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "github",
+            "deployment",
+            "browse",
+            "repository"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "type": "string",
+                "description": "GitHub owner or organization (e.g. \"serac-labs\")"
+              },
+              "repo": {
+                "type": "string",
+                "description": "Repository name (e.g. \"serac\")"
+              },
+              "path": {
+                "type": "string",
+                "description": "Subdirectory path to browse (default: root \"/\")"
+              },
+              "branch": {
+                "type": "string",
+                "description": "Branch name (default: \"main\")"
+              }
+            },
+            "required": [
+              "owner",
+              "repo"
+            ]
+          }
+        },
+        {
+          "name": "snow_rollback_deployment",
+          "description": "Rollback failed deployment by reverting to previous version or deleting artifact",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "rollback",
+            "recovery"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of artifact to rollback"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name (sp_widget, sys_ux_page, etc.)",
+                "enum": [
+                  "sp_widget",
+                  "sys_ux_page",
+                  "sys_hub_flow",
+                  "sys_script_include"
+                ]
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "revert",
+                  "delete"
+                ],
+                "description": "Rollback action: revert to previous version or delete artifact",
+                "default": "revert"
+              },
+              "update_set_id": {
+                "type": "string",
+                "description": "Update Set sys_id to rollback (optional)"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Reason for rollback (for audit trail)"
+              }
+            },
+            "required": [
+              "sys_id",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_deployment",
+          "description": "Validate artifact before deployment (ES5, coherence, dependencies, security)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "deployment",
+            "validation",
+            "quality"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "widget",
+                  "page",
+                  "flow",
+                  "script_include",
+                  "business_rule"
+                ],
+                "description": "Artifact type to validate"
+              },
+              "artifact": {
+                "type": "object",
+                "description": "Artifact configuration to validate"
+              },
+              "checks": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "es5",
+                    "coherence",
+                    "dependencies",
+                    "security",
+                    "performance"
+                  ]
+                },
+                "description": "Validation checks to perform",
+                "default": [
+                  "es5",
+                  "coherence",
+                  "dependencies"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "artifact"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "devops",
+      "displayName": "Devops",
+      "tools": [
+        {
+          "name": "snow_cicd_deploy",
+          "description": "Trigger CI/CD deployment pipeline",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cicd",
+            "deployment",
+            "devops"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "pipeline_id": {
+                "type": "string",
+                "description": "Pipeline ID"
+              },
+              "environment": {
+                "type": "string",
+                "enum": [
+                  "dev",
+                  "test",
+                  "prod"
+                ],
+                "description": "Target environment"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version to deploy"
+              }
+            },
+            "required": [
+              "pipeline_id",
+              "environment"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_devops_change",
+          "description": "Create automated DevOps change request for deployments",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "devops",
+            "change-management",
+            "deployments"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "application": {
+                "type": "string",
+                "description": "Application to deploy"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version to deploy"
+              },
+              "environment": {
+                "type": "string",
+                "description": "Target environment"
+              },
+              "deployment_date": {
+                "type": "string",
+                "description": "Planned deployment date"
+              },
+              "risk_assessment": {
+                "type": "object",
+                "description": "Risk assessment data"
+              },
+              "rollback_plan": {
+                "type": "string",
+                "description": "Rollback procedure"
+              }
+            },
+            "required": [
+              "application",
+              "version",
+              "environment",
+              "deployment_date"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_devops_insights",
+          "description": "Retrieve DevOps metrics and insights",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "devops",
+            "metrics",
+            "analytics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "application": {
+                "type": "string",
+                "description": "Application to analyze"
+              },
+              "metric_type": {
+                "type": "string",
+                "description": "Metric type: velocity, quality, stability"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "Analysis time range"
+              },
+              "include_trends": {
+                "type": "boolean",
+                "description": "Include trend analysis",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_source_control",
+          "description": "Unified tool for the ServiceNow Studio Source Control plugin. Bridges git-style operations against an application's linked repository (status, push, pull, branch, commit, diff, stash) through the platform's Source Control REST endpoints under /api/sn_source_control.\n\nActions:\n- status — show working-copy status (changed/added/deleted records) for an application\n- push — push local commits to the remote tracking branch\n- pull — pull and apply remote changes onto the working copy\n- branch — list, create, switch, or delete branches on the application's repository\n- commit — commit the working copy with a message\n- diff — show the diff for a specific record or for the whole working copy\n- stash — list, create, apply, or drop stashes against the working copy\n\nUse when: the agent needs to interact with a scoped application that is linked to a git repository (Studio Source Control) and the user wants git-equivalent operations from within the platform. Prefer update sets for environments that do not use source control.\n\nReturns: action-specific result envelopes. For status/diff: per-record change rows. For push/pull/commit: operation summary. For branch/stash: the resulting branch or stash record. All paths are best-effort against published Source Control plugin docs and require live-instance verification before relying on them in production.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "devops",
+            "source-control",
+            "git",
+            "branching",
+            "studio"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Source-control action to perform",
+                "enum": [
+                  "status",
+                  "push",
+                  "pull",
+                  "branch",
+                  "commit",
+                  "diff",
+                  "stash"
+                ]
+              },
+              "app_sys_id": {
+                "type": "string",
+                "description": "sys_id of the scoped application (sys_app) whose repository is targeted"
+              },
+              "app_scope": {
+                "type": "string",
+                "description": "Alternative to app_sys_id: scope name (e.g. x_company_module). The tool will resolve it to a sys_app sys_id."
+              },
+              "branch_action": {
+                "type": "string",
+                "description": "[branch] Sub-action",
+                "enum": [
+                  "list",
+                  "create",
+                  "switch",
+                  "delete"
+                ]
+              },
+              "branch_name": {
+                "type": "string",
+                "description": "[branch] Branch name (required for create/switch/delete)"
+              },
+              "from_branch": {
+                "type": "string",
+                "description": "[branch action=create] Source branch to branch off (defaults to current)"
+              },
+              "commit_message": {
+                "type": "string",
+                "description": "[commit] Commit message"
+              },
+              "remote_branch": {
+                "type": "string",
+                "description": "[push/pull] Remote branch to push to / pull from (defaults to tracking branch)"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "[diff] Specific record sys_id to diff (omit for working-copy-wide diff)"
+              },
+              "stash_action": {
+                "type": "string",
+                "description": "[stash] Sub-action",
+                "enum": [
+                  "list",
+                  "create",
+                  "apply",
+                  "drop"
+                ]
+              },
+              "stash_name": {
+                "type": "string",
+                "description": "[stash] Stash name (required for create/apply/drop)"
+              },
+              "stash_message": {
+                "type": "string",
+                "description": "[stash action=create] Optional stash description"
+              },
+              "credentials_alias": {
+                "type": "string",
+                "description": "Alias for stored repository credentials (sys_repo_credential), if remote auth is required"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_track_deployment",
+          "description": "Track application deployment through DevOps pipeline",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "devops",
+            "deployments",
+            "tracking"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "application": {
+                "type": "string",
+                "description": "Application name"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version being deployed"
+              },
+              "environment": {
+                "type": "string",
+                "description": "Target environment"
+              },
+              "pipeline": {
+                "type": "string",
+                "description": "Pipeline used"
+              },
+              "change_request": {
+                "type": "string",
+                "description": "Associated change request"
+              },
+              "status": {
+                "type": "string",
+                "description": "Deployment status"
+              },
+              "start_time": {
+                "type": "string",
+                "description": "Deployment start time"
+              }
+            },
+            "required": [
+              "application",
+              "version",
+              "environment"
+            ]
+          }
+        },
+        {
+          "name": "snow_velocity_tracking",
+          "description": "Track team velocity and delivery metrics",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "devops",
+            "metrics",
+            "velocity"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "team": {
+                "type": "string",
+                "description": "Team name"
+              },
+              "sprint": {
+                "type": "string",
+                "description": "Sprint identifier"
+              },
+              "story_points": {
+                "type": "number",
+                "description": "Story points completed"
+              },
+              "deployments": {
+                "type": "number",
+                "description": "Number of deployments"
+              },
+              "lead_time": {
+                "type": "number",
+                "description": "Average lead time in hours"
+              },
+              "mttr": {
+                "type": "number",
+                "description": "Mean time to recovery in minutes"
+              }
+            },
+            "required": [
+              "team"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "diagnostics",
+      "displayName": "Diagnostics",
+      "tools": [
+        {
+          "name": "snow_validate_live_connection",
+          "description": "Validates ServiceNow connection status, authentication tokens, and user permissions. Returns detailed diagnostics with response times.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "validation",
+            "diagnostics",
+            "connection-test"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "test_level": {
+                "type": "string",
+                "enum": [
+                  "basic",
+                  "full",
+                  "permissions"
+                ],
+                "description": "Level of validation (basic=ping, full=read test, permissions=write test)",
+                "default": "basic"
+              },
+              "include_performance": {
+                "type": "boolean",
+                "description": "Include response time metrics",
+                "default": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "discovery",
+      "displayName": "Discovery",
+      "tools": [
+        {
+          "name": "snow_asset_discovery",
+          "description": "Discover and normalize assets from multiple sources",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "discovery",
+            "asset-management",
+            "normalization"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "discovery_source": {
+                "type": "string",
+                "description": "Discovery source",
+                "enum": [
+                  "network_scan",
+                  "agent_based",
+                  "manual_import",
+                  "csv_upload"
+                ]
+              },
+              "ip_range": {
+                "type": "string",
+                "description": "IP range for network discovery (CIDR notation)"
+              },
+              "normalize_duplicates": {
+                "type": "boolean",
+                "description": "Automatically normalize duplicate assets"
+              },
+              "create_relationships": {
+                "type": "boolean",
+                "description": "Create CI relationships automatically"
+              }
+            },
+            "required": [
+              "discovery_source"
+            ]
+          }
+        },
+        {
+          "name": "snow_cmdb_search",
+          "description": "Searches Configuration Management Database (CMDB) for configuration items with relationship mapping",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "configuration-items"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query for configuration items (e.g., \"server name\", \"application\")"
+              },
+              "ci_type": {
+                "type": "string",
+                "description": "Type of CI to search",
+                "enum": [
+                  "server",
+                  "application",
+                  "database",
+                  "network_device",
+                  "service",
+                  "any"
+                ],
+                "default": "any"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of results",
+                "default": 10,
+                "minimum": 1,
+                "maximum": 100
+              },
+              "include_relationships": {
+                "type": "boolean",
+                "description": "Include CI relationships",
+                "default": false
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_automation_jobs",
+          "description": "Discovers automation jobs (scheduled scripts, executions) in the instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "discovery",
+            "jobs"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "active": {
+                "type": "boolean",
+                "description": "Filter by active status"
+              },
+              "nameContains": {
+                "type": "string",
+                "description": "Search by name pattern"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of jobs to return",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_data_sources",
+          "description": "Discover available data sources for integration including import sets and REST endpoints",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "discovery",
+            "data-sources"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sourceType": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "import_set",
+                  "rest",
+                  "jdbc",
+                  "ldap",
+                  "file"
+                ],
+                "description": "Filter by source type",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of results per type",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_events",
+          "description": "Discovers system events registered in the instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "events",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Filter by table name"
+              },
+              "nameContains": {
+                "type": "string",
+                "description": "Search by event name pattern"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of events to return",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_integration_endpoints",
+          "description": "Discover existing integration endpoints (REST, SOAP, LDAP, EMAIL)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "discovery",
+            "endpoints"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "REST",
+                  "SOAP",
+                  "LDAP",
+                  "EMAIL"
+                ],
+                "description": "Filter by endpoint type",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results per type",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_mobile_configs",
+          "description": "Discovers mobile application configurations including layouts, actions, and offline sync settings.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "discovery",
+            "mobile-config",
+            "mobile"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "config_type": {
+                "type": "string",
+                "description": "Configuration type: layout, action, offline_sync, all"
+              },
+              "table": {
+                "type": "string",
+                "description": "Filter by table name"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active configurations",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_platform_tables",
+          "description": "Discover platform development tables by category (ui, script, policy, action, security, system). Optimized for fast parallel queries with timeout handling.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "table-discovery",
+            "schema-exploration",
+            "platform-development"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "ui",
+                  "script",
+                  "policy",
+                  "action",
+                  "security",
+                  "system",
+                  "itsm",
+                  "cmdb"
+                ],
+                "description": "Filter by table category",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results per category (default: 25)",
+                "default": 25
+              },
+              "use_cache": {
+                "type": "boolean",
+                "description": "Use pre-defined common tables instead of querying (faster, but less complete)",
+                "default": false
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Timeout per category in milliseconds (default: 10000)",
+                "default": 10000
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_discover_schedules",
+          "description": "Discovers schedules (business hours, maintenance windows) in the instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "schedules",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "nameContains": {
+                "type": "string",
+                "description": "Search by schedule name pattern"
+              },
+              "type": {
+                "type": "string",
+                "description": "Filter by schedule type"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of schedules to return",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_instance_info",
+          "description": "Get ServiceNow instance information",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "instance-info",
+            "version-check",
+            "diagnostics"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        {
+          "name": "snow_pa_discover",
+          "description": "Unified PA discovery (indicators, report_fields, reporting_tables)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "performance-analytics",
+            "discovery",
+            "reporting"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "PA discovery action",
+                "enum": [
+                  "indicators",
+                  "report_fields",
+                  "reporting_tables"
+                ]
+              },
+              "table": {
+                "type": "string",
+                "description": "[indicators/report_fields] Table filter"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[indicators] Show only active indicators"
+              },
+              "fieldType": {
+                "type": "string",
+                "description": "[report_fields] Filter by field type"
+              },
+              "category": {
+                "type": "string",
+                "description": "[reporting_tables] Table category filter"
+              },
+              "hasData": {
+                "type": "boolean",
+                "description": "[reporting_tables] Only tables with data"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_run_discovery",
+          "description": "Queue a CMDB discovery scan against a discovery schedule, optionally narrowed to a target IP/range and a specific MID Server. Creates a discovery_schedule_item; the scan runs asynchronously.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "discovery",
+            "scanning"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "discovery_schedule": {
+                "type": "string",
+                "description": "Discovery schedule sys_id"
+              },
+              "target_ip": {
+                "type": "string",
+                "description": "Target IP or range"
+              },
+              "mid_server": {
+                "type": "string",
+                "description": "MID Server to use"
+              }
+            },
+            "required": [
+              "discovery_schedule"
+            ]
+          }
+        },
+        {
+          "name": "snow_table_schema_discovery",
+          "description": "Discover comprehensive table schema including fields, relationships, ACLs, and business rules",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "schema-discovery",
+            "table-analysis",
+            "metadata"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name to discover schema"
+              },
+              "include_fields": {
+                "type": "boolean",
+                "description": "Include field definitions",
+                "default": true
+              },
+              "include_relationships": {
+                "type": "boolean",
+                "description": "Include table relationships",
+                "default": true
+              },
+              "include_acls": {
+                "type": "boolean",
+                "description": "Include access control rules",
+                "default": false
+              },
+              "include_business_rules": {
+                "type": "boolean",
+                "description": "Include business rules",
+                "default": false
+              },
+              "include_ui_policies": {
+                "type": "boolean",
+                "description": "Include UI policies",
+                "default": false
+              }
+            },
+            "required": [
+              "table_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "documentation",
+      "displayName": "Documentation",
+      "tools": [
+        {
+          "name": "snow_generate_docs",
+          "description": "Generate documentation for ServiceNow artifacts",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "documentation",
+            "analysis"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_type": {
+                "type": "string",
+                "enum": [
+                  "widget",
+                  "script_include",
+                  "business_rule",
+                  "workflow",
+                  "rest_message",
+                  "transform_map"
+                ],
+                "description": "Type of artifact to document"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Artifact sys_id"
+              },
+              "include_dependencies": {
+                "type": "boolean",
+                "description": "Include dependency analysis",
+                "default": true
+              },
+              "include_usage_examples": {
+                "type": "boolean",
+                "description": "Generate usage examples",
+                "default": true
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "markdown",
+                  "html",
+                  "json"
+                ],
+                "description": "Documentation format",
+                "default": "markdown"
+              }
+            },
+            "required": [
+              "artifact_type",
+              "sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "editing",
+      "displayName": "Editing",
+      "tools": [
+        {
+          "name": "snow_edit_by_sysid",
+          "description": "Updates specific fields of an artifact using sys_id. Provides direct field-level modifications with validation.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "edit",
+            "update",
+            "direct-modification"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "System ID of the artifact to edit"
+              },
+              "table": {
+                "type": "string",
+                "description": "ServiceNow table name"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field name to update (e.g., script, server_script, template)"
+              },
+              "value": {
+                "type": "string",
+                "description": "New value for the field"
+              }
+            },
+            "required": [
+              "sys_id",
+              "table",
+              "field",
+              "value"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "elevation",
+      "displayName": "Elevation",
+      "tools": [
+        {
+          "name": "snow_elevate_role",
+          "description": "Execute a server-side operation that requires elevated privileges (security_admin scope — ACL modifications, high-security properties, etc.). ALWAYS returns a confirmation prompt on the first call; executes only when re-called with user_confirmed=true. Agents cannot skip this confirmation.",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "acl-modification",
+            "security-config",
+            "high-security-properties",
+            "elevated-operations"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Elevated roles this operation declares it needs (e.g. ['security_admin']). Shown verbatim in the confirmation prompt so the user can judge scope before approving. This list is informational — the actual privilege comes from the authenticated user and the server-side execution context."
+              },
+              "operation_summary": {
+                "type": "string",
+                "description": "Short human-readable description of what this operation does. Shown in the confirmation prompt so the user knows what they are approving."
+              },
+              "script": {
+                "type": "string",
+                "description": "ES5 JavaScript to execute with elevation attempts. Runs server-side via scripted REST + GlideRecord. Use GlideUpdateManager2.loadUpdateXML() for ACL/security-table writes that field-level ACLs would otherwise block."
+              },
+              "user_confirmed": {
+                "type": "boolean",
+                "description": "MUST be explicitly true for the script to run. Default false returns a confirmation prompt — the user must re-call the tool with user_confirmed=true after reviewing the prompt. No other parameter can bypass this.",
+                "default": false
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Execution timeout in milliseconds (applies to scheduler fallback only). Default 30000.",
+                "default": 30000
+              }
+            },
+            "required": [
+              "roles",
+              "operation_summary",
+              "script"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "displayName": "Email",
+      "tools": [
+        {
+          "name": "snow_create_email_config",
+          "description": "Create email server configuration for SMTP, POP3, or IMAP",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "email",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Email configuration name"
+              },
+              "serverType": {
+                "type": "string",
+                "enum": [
+                  "SMTP",
+                  "POP3",
+                  "IMAP",
+                  "SMTPS",
+                  "POP3S",
+                  "IMAPS"
+                ],
+                "description": "Email server type"
+              },
+              "serverName": {
+                "type": "string",
+                "description": "Email server hostname or IP"
+              },
+              "port": {
+                "type": "number",
+                "description": "Server port (default: auto-detect by type)"
+              },
+              "encryption": {
+                "type": "string",
+                "enum": [
+                  "SSL",
+                  "TLS",
+                  "None"
+                ],
+                "description": "Encryption type",
+                "default": "None"
+              },
+              "username": {
+                "type": "string",
+                "description": "Authentication username"
+              },
+              "password": {
+                "type": "string",
+                "description": "Authentication password"
+              },
+              "description": {
+                "type": "string",
+                "description": "Configuration description"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active flag",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "serverType",
+              "serverName"
+            ]
+          }
+        },
+        {
+          "name": "snow_inbound_email_action",
+          "description": "Manage inbound email actions: list, get, create, update, delete, enable/disable",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "email",
+            "inbound-processing",
+            "automation",
+            "record-creation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "enable",
+                  "disable"
+                ],
+                "description": "Action to perform"
+              },
+              "action_id": {
+                "type": "string",
+                "description": "Inbound email action sys_id or name"
+              },
+              "name": {
+                "type": "string",
+                "description": "Action name"
+              },
+              "target_table": {
+                "type": "string",
+                "description": "Table to create/update records in"
+              },
+              "action_type": {
+                "type": "string",
+                "enum": [
+                  "record",
+                  "forward",
+                  "reply",
+                  "ignore"
+                ],
+                "description": "What to do with matching emails",
+                "default": "record"
+              },
+              "stop_processing": {
+                "type": "boolean",
+                "description": "Stop processing other actions after this one matches",
+                "default": true
+              },
+              "order": {
+                "type": "number",
+                "description": "Processing order (lower = earlier)",
+                "default": 100
+              },
+              "filter_condition": {
+                "type": "string",
+                "description": "Condition to match emails (e.g., \"subject:incident\")"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script to execute when email matches"
+              },
+              "template": {
+                "type": "string",
+                "description": "Template for reply emails"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether action is active",
+                "default": true
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only list active actions",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results for list",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "error-handling",
+      "displayName": "Error Handling",
+      "tools": [
+        {
+          "name": "snow_error_handler",
+          "description": "Register a server-side error handler (sys_error_handler) bound to a specific error type. The handler_script runs when that error fires; must be ES5-compatible (no arrow functions, const/let, etc.).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "error-handling",
+            "debugging",
+            "logging"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Handler name"
+              },
+              "error_type": {
+                "type": "string",
+                "description": "Error type to handle"
+              },
+              "handler_script": {
+                "type": "string",
+                "description": "Handler script (ES5 only!)"
+              }
+            },
+            "required": [
+              "name",
+              "error_type",
+              "handler_script"
+            ]
+          }
+        },
+        {
+          "name": "snow_exception_handler",
+          "description": "Handle exceptions with logging",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "exceptions",
+            "logging",
+            "debugging"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "exception_message": {
+                "type": "string",
+                "description": "Exception message"
+              },
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "info",
+                  "warning",
+                  "error",
+                  "critical"
+                ],
+                "default": "error"
+              },
+              "source": {
+                "type": "string",
+                "description": "Exception source"
+              }
+            },
+            "required": [
+              "exception_message"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "event-management",
+      "displayName": "Event Management",
+      "tools": [
+        {
+          "name": "snow_create_alert",
+          "description": "Create system alert for monitoring",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "alerts",
+            "monitoring",
+            "notifications"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Alert name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Target table"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Alert condition"
+              },
+              "message": {
+                "type": "string",
+                "description": "Alert message"
+              },
+              "severity": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "description": "Alert severity"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "condition"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_alert_rule",
+          "description": "Create alert rules for automated monitoring and notifications",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "alerts",
+            "rules",
+            "monitoring"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Alert rule name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Target table to monitor"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Alert trigger condition"
+              },
+              "severity": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "description": "Alert severity (1=Critical, 5=Info)"
+              },
+              "notification_group": {
+                "type": "string",
+                "description": "Group to notify"
+              },
+              "notification_user": {
+                "type": "string",
+                "description": "User to notify"
+              },
+              "email_template": {
+                "type": "string",
+                "description": "Email template sys_id"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Rule active status",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "condition"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_event",
+          "description": "Create system event for event management",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "events",
+            "automation",
+            "workflows"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Event name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Source table"
+              },
+              "parm1": {
+                "type": "string",
+                "description": "Event parameter 1"
+              },
+              "parm2": {
+                "type": "string",
+                "description": "Event parameter 2"
+              },
+              "instance": {
+                "type": "string",
+                "description": "Instance name"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_event_handler",
+          "description": "Register a script action (sysevent_script_action) that runs when a named platform event fires. Script must be ES5-compatible (no arrow functions, const/let, etc.).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "events",
+            "handlers",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Handler name"
+              },
+              "event_name": {
+                "type": "string",
+                "description": "Event name to handle"
+              },
+              "script": {
+                "type": "string",
+                "description": "Handler script (ES5 only!)"
+              }
+            },
+            "required": [
+              "name",
+              "event_name",
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_event_correlation",
+          "description": "Get event correlation results showing how events are grouped into alerts",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "events",
+            "correlation"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "alert_id": {
+                "type": "string",
+                "description": "Alert sys_id to analyze"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "Time range to check (e.g., \"24 hours\", \"7 days\")"
+              },
+              "include_suppressed": {
+                "type": "boolean",
+                "description": "Include suppressed events",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_event_queue",
+          "description": "Get event queue status and pending events",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "events",
+            "monitoring",
+            "troubleshooting"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "ready",
+                  "processing",
+                  "error"
+                ],
+                "description": "Event state"
+              },
+              "limit": {
+                "type": "number",
+                "default": 50
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "events",
+      "displayName": "Events",
+      "tools": [
+        {
+          "name": "snow_create_uib_event",
+          "description": "Create custom events for UI Builder component communication",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "events",
+            "components"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Target page sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Event name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Event description"
+              },
+              "payload_schema": {
+                "type": "object",
+                "description": "Event payload schema"
+              },
+              "bubbles": {
+                "type": "boolean",
+                "description": "Event bubbles up the DOM",
+                "default": true
+              }
+            },
+            "required": [
+              "page_id",
+              "name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "field-analysis",
+      "displayName": "Field Analysis",
+      "tools": [
+        {
+          "name": "snow_blast_radius_field_references",
+          "description": "Find every artifact that references a specific table.field across the instance. Use to audit references before changing or removing a field, understand the blast radius of a rename/refactor, or distinguish reads vs writes vs condition uses.\n\nExample: \"What touches incident.assignment_group?\"\n\nCoverage (26 artifact types):\n- Business rules, client scripts, UI actions, UI policies (+ actions), ACLs\n- Data policies (+ rules), email notifications, metric definitions\n- Script includes, scheduled jobs, fix scripts, script actions, UI scripts\n- Scripted REST resources, processors, email scripts, inbound email actions\n- Service Portal widgets, catalog client scripts, catalog UI policies\n- Transform entries/scripts, ATF step inputs, dictionary dependent fields\n- Condition/filter columns (not just scripts) where relevant\n- Parent tables walked via sys_db_object.super_class (opt-out)\n\nLimitations:\n- Reference dotwalks (current.assignment_group.manager) are not resolved\n- Dynamic field access (gr.setValue(someVar, value)) cannot be detected\n- Availability of scoped artifact tables depends on installed plugins",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "field-audit",
+            "change-risk"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name (e.g., 'incident')"
+              },
+              "field_name": {
+                "type": "string",
+                "description": "Field name (e.g., 'assignment_group')"
+              },
+              "artifact_types": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "business_rules",
+                    "client_scripts",
+                    "ui_actions",
+                    "ui_policies",
+                    "ui_policy_actions",
+                    "data_policies",
+                    "data_policy_rules",
+                    "acls",
+                    "email_notifications",
+                    "metric_definitions",
+                    "dictionary_dependent",
+                    "script_includes",
+                    "scheduled_jobs",
+                    "fix_scripts",
+                    "script_actions",
+                    "transform_scripts",
+                    "transform_entries",
+                    "processors",
+                    "ui_scripts",
+                    "scripted_rest_resources",
+                    "email_scripts",
+                    "inbound_email_actions",
+                    "portal_widgets",
+                    "catalog_client_scripts",
+                    "catalog_ui_policies",
+                    "atf_steps"
+                  ]
+                },
+                "description": "Limit search to specific artifact types. Default: all."
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive artifacts (default: false)",
+                "default": false
+              },
+              "include_parent_tables": {
+                "type": "boolean",
+                "description": "Also search artifacts scoped to parent tables in the class hierarchy (e.g. 'task' when querying 'incident'). Default: true.",
+                "default": true
+              },
+              "limit_per_type": {
+                "type": "number",
+                "description": "Maximum results per artifact type (default: 25)",
+                "default": 25
+              },
+              "include_filters": {
+                "type": "boolean",
+                "description": "Also scan sys_filter (saved list filters) and sys_report records for references to this field. These are not script-bearing and would otherwise be missed by the script-field scan, which is the main reason a delete/rename can break dashboards and reports the dependents scan said nothing about. Default: true.",
+                "default": true
+              }
+            },
+            "required": [
+              "table_name",
+              "field_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "field-service",
+      "displayName": "Field Service",
+      "tools": [
+        {
+          "name": "snow_fsm_dispatch_manage",
+          "description": "Unified tool for ServiceNow Field Service Management dispatch lookups. Modern ServiceNow FSM does not store dispatch in a single table — there is no wm_agent / wm_dispatch_group table. This tool composes the answer from several real tables: sys_user (filtered by wm_* role) for technicians, sys_user_group for assignment groups, wm_agent_schedule_attribute_plan for per-user schedule policy, and wm_work_order_task_potential_assignment_groups for which groups are eligible for a specific work task.\n\nCompanion tool: snow_fsm_work_order_manage handles wm_order CRUD and snow_fsm_parts_manage handles sm_part_requirement CRUD.\n\nActions:\n- list_agents - list sys_user rows that hold any FSM role (wm_agent, wm_dispatcher, wm_manager, ...). Optional filters: role, group, location, active flag, and free-text name search\n- list_groups - list sys_user_group rows. Optional filter: name LIKE search and active flag. Use for picking an assignment_group on a wm_order\n- list_schedules - list wm_agent_schedule_attribute_plan rows for a given sys_user (or the full set with no filter). Returns home base, travel radius, overtime / penalty rates and the schedule window\n- list_potential_groups_for_task - list wm_work_order_task_potential_assignment_groups rows for a given wm_task sys_id. Tells you which assignment groups are eligible to take that task\n- assign_to_work_order - patch a wm_order with assigned_to (sys_user) and/or assignment_group (sys_user_group). Inherited from task — both fields exist on wm_order even though they aren't declared directly on wm_order in sys_dictionary\n\nUse when: the agent needs to pick a technician or assignment group, audit FSM role membership, look up a technician's schedule policy, or do the actual assignment on a work order. Read actions hit live tables only — no AI dispatch / scheduling engine is invoked.\n\nReturns: agents include sys_id, user_name, name, email, active, location, fsm_roles. Groups include sys_id, name, active, manager. Schedule plans include sys_id, user, default flag, from/to window, start/end location, travel radius, overtime caps and penalty rates. Potential-group rows include sys_id, work_order_task, assignment_group, active. assign_to_work_order returns the patched wm_order.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "field-service",
+            "dispatch",
+            "scheduling",
+            "technician",
+            "assignment",
+            "fsm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_agents",
+                  "list_groups",
+                  "list_schedules",
+                  "list_potential_groups_for_task",
+                  "assign_to_work_order"
+                ]
+              },
+              "role": {
+                "type": "string",
+                "description": "[list_agents] Filter to a single FSM role name (e.g. wm_agent, wm_dispatcher). Default is any wm_* role"
+              },
+              "group": {
+                "type": "string",
+                "description": "[list_agents] sys_user_group sys_id to filter agents by group membership"
+              },
+              "location": {
+                "type": "string",
+                "description": "[list_agents] cmn_location sys_id to filter agents by location"
+              },
+              "name_like": {
+                "type": "string",
+                "description": "[list_agents/list_groups] Free-text LIKE match against the name column"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_agents/list_groups/list_schedules/list_potential_groups_for_task] Only return active rows",
+                "default": true
+              },
+              "user": {
+                "type": "string",
+                "description": "[list_schedules] sys_user sys_id to filter schedule attribute plans by"
+              },
+              "work_order_task": {
+                "type": "string",
+                "description": "[list_potential_groups_for_task] wm_task sys_id to look up potential assignment groups for"
+              },
+              "work_order_sys_id": {
+                "type": "string",
+                "description": "[assign_to_work_order] sys_id of the wm_order to assign"
+              },
+              "work_order_number": {
+                "type": "string",
+                "description": "[assign_to_work_order] number of the wm_order (used when work_order_sys_id is absent)"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[assign_to_work_order] sys_user sys_id of the technician to assign"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[assign_to_work_order] sys_user_group sys_id of the assignment group to set"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_*] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_*] Comma-separated list of fields to return (defaults to a curated set per action)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_fsm_parts_manage",
+          "description": "Unified tool for ServiceNow Field Service Management part requirements. Wraps the sm_part_requirement table installed by the Field Service Management plugin (com.snc.work_management). A part requirement records \"this work order needs N of this cmdb_model\" and tracks reserved, sourced and delivered quantities.\n\nCompanion tool: snow_fsm_work_order_manage handles the wm_order lifecycle.\n\nActions:\n- list_requirements - list sm_part_requirement rows, filtered by work order, requested_for, model, or status flags (requested/sourced/delivered/reserved-only)\n- get - retrieve a single requirement by sys_id (or by number)\n- create - create a new requirement (model + required_quantity + requested_for required; optional required_by_date, mandatory, include_substitute, requested_quantity)\n- update_quantity - update requested_quantity, reserved_quantity, or required_quantity on an existing requirement\n- update_status - flip the requested / sourced / delivered booleans on an existing requirement\n- delete - delete a requirement by sys_id\n\nUse when: the agent needs to plan parts for a work order, attach a required model to a work order, mark parts as reserved/sourced/delivered, or audit outstanding part requirements. Stockroom-level availability (alm_stockroom / alm_asset) is intentionally out of scope and is not modelled by sm_part_requirement.\n\nReturns: requirement records with sys_id, number, model (cmdb_model reference), required_quantity, requested_quantity, reserved_quantity, requested_for, affected_product (wm_m2m_product_to_work_order reference), service_order_task, required_by_date, status booleans (requested, sourced, delivered, mandatory, include_substitute), and a navigation URL.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "field-service",
+            "parts",
+            "inventory",
+            "work-order",
+            "fsm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_requirements",
+                  "get",
+                  "create",
+                  "update_quantity",
+                  "update_status",
+                  "delete"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update_quantity/update_status/delete] sm_part_requirement sys_id"
+              },
+              "number": {
+                "type": "string",
+                "description": "[get] sm_part_requirement number (used when sys_id is absent)"
+              },
+              "work_order_sys_id": {
+                "type": "string",
+                "description": "[list_requirements] sys_id of a wm_order to filter requirements by (resolved through the wm_m2m_product_to_work_order link)"
+              },
+              "work_order_number": {
+                "type": "string",
+                "description": "[list_requirements] number of a wm_order to filter by (used when work_order_sys_id is absent)"
+              },
+              "requested_for": {
+                "type": "string",
+                "description": "[list_requirements/create] sys_user sys_id of the technician the parts are requested for"
+              },
+              "model_filter": {
+                "type": "string",
+                "description": "[list_requirements] cmdb_model sys_id to filter by"
+              },
+              "service_order_task": {
+                "type": "string",
+                "description": "[list_requirements/create] sm_task sys_id this requirement belongs to"
+              },
+              "reserved_only": {
+                "type": "boolean",
+                "description": "[list_requirements] Only return requirements that have a reserved_quantity > 0",
+                "default": false
+              },
+              "requested_only": {
+                "type": "boolean",
+                "description": "[list_requirements] Only return requirements where requested=true",
+                "default": false
+              },
+              "sourced_only": {
+                "type": "boolean",
+                "description": "[list_requirements] Only return requirements where sourced=true",
+                "default": false
+              },
+              "delivered_only": {
+                "type": "boolean",
+                "description": "[list_requirements] Only return requirements where delivered=true",
+                "default": false
+              },
+              "model": {
+                "type": "string",
+                "description": "[create] cmdb_model sys_id of the part model required (mandatory)"
+              },
+              "required_quantity": {
+                "type": "number",
+                "description": "[create/update_quantity] How many of the model are required for the work (mandatory on create)"
+              },
+              "requested_quantity": {
+                "type": "number",
+                "description": "[create/update_quantity] How many have been requested from stock (defaults to required_quantity on create when omitted)"
+              },
+              "reserved_quantity": {
+                "type": "number",
+                "description": "[update_quantity] How many have been reserved in a stockroom for this requirement"
+              },
+              "required_by_date": {
+                "type": "string",
+                "description": "[create] Date by which the part is required (YYYY-MM-DD HH:MM:SS in instance TZ)"
+              },
+              "mandatory": {
+                "type": "boolean",
+                "description": "[create] Mark requirement as mandatory (cannot be substituted)"
+              },
+              "include_substitute": {
+                "type": "boolean",
+                "description": "[create] Allow substitute models to satisfy the requirement"
+              },
+              "affected_product": {
+                "type": "string",
+                "description": "[create] wm_m2m_product_to_work_order sys_id linking this requirement to a product on a work order"
+              },
+              "requested": {
+                "type": "boolean",
+                "description": "[update_status] Mark requirement as requested (or clear by passing false)"
+              },
+              "sourced": {
+                "type": "boolean",
+                "description": "[update_status] Mark requirement as sourced"
+              },
+              "delivered": {
+                "type": "boolean",
+                "description": "[update_status] Mark requirement as delivered"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_requirements] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_requirements/get] Comma-separated list of fields to return (defaults to a curated set)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_fsm_work_order_manage",
+          "description": "Unified tool for ServiceNow Field Service Management work orders. Wraps the wm_order, wm_task and wm_order_history tables installed by the Field Service Management plugin (com.snc.work_management).\n\nActions:\n- list — list work orders, optionally filtered by state, assignment_group, assigned_to, or location\n- get — retrieve a single work order by sys_id or number (includes related task and history counts)\n- create — create a new work order with short_description, location, contact, priority, and optional scheduling window\n- assign — assign the work order to a technician (assigned_to) and/or dispatch group (assignment_group)\n- schedule — set the scheduled work_start and work_end on the work order\n- update_status — transition the state field by human-readable state name (Draft, Scheduled, En Route, Onsite, Closed Complete, ...)\n- list_tasks — list the wm_task rows linked to a parent work order\n\nUse when: the agent needs to create, dispatch, schedule, or report on field-service work orders. Requires the Field Service Management plugin (com.snc.work_management) on the target instance — every action surfaces a clear PLUGIN_MISSING error if wm_order is absent.\n\nReturns: work order records with sys_id, number, short_description, state, priority, assignment_group, assigned_to, location, contact, work_start, work_end. For list_tasks returns wm_task rows with sys_id, number, short_description and state.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "field-service",
+            "work-order",
+            "dispatch",
+            "scheduling",
+            "fsm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "assign",
+                  "schedule",
+                  "update_status",
+                  "list_tasks"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/assign/schedule/update_status/list_tasks] Work order sys_id"
+              },
+              "number": {
+                "type": "string",
+                "description": "[get/assign/schedule/update_status/list_tasks] Work order number (e.g. WO0001234) — used when sys_id is absent"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create] One-line summary of the work to be performed"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create] Long description / instructions for the technician"
+              },
+              "priority": {
+                "type": "number",
+                "description": "[create] Priority (1 = Critical, 2 = High, 3 = Moderate, 4 = Low, 5 = Planning)",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ]
+              },
+              "location": {
+                "type": "string",
+                "description": "[create] cmn_location sys_id or name where the work is performed"
+              },
+              "contact": {
+                "type": "string",
+                "description": "[create] sys_user sys_id of the on-site contact for the work order"
+              },
+              "company": {
+                "type": "string",
+                "description": "[create] core_company sys_id of the customer / account"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[create/assign] sys_user_group sys_id or name of the dispatch group"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[create/assign] sys_user sys_id or user_name of the technician"
+              },
+              "work_start": {
+                "type": "string",
+                "description": "[create/schedule] Scheduled start datetime (YYYY-MM-DD HH:MM:SS in instance TZ)"
+              },
+              "work_end": {
+                "type": "string",
+                "description": "[create/schedule] Scheduled end datetime (YYYY-MM-DD HH:MM:SS in instance TZ)"
+              },
+              "state": {
+                "type": "string",
+                "description": "[update_status] New state name. Resolved against the wm_order state choice list on the target instance.",
+                "enum": [
+                  "Draft",
+                  "Pending Dispatch",
+                  "Scheduled",
+                  "Dispatched",
+                  "En Route",
+                  "Onsite",
+                  "Work in Progress",
+                  "Closed Complete",
+                  "Closed Incomplete",
+                  "Cancelled"
+                ]
+              },
+              "close_notes": {
+                "type": "string",
+                "description": "[update_status] Close notes (recorded when state is set to Closed Complete or Closed Incomplete)"
+              },
+              "filter_state": {
+                "type": "string",
+                "description": "[list] Filter by state name (matches the same choice list as update_status)"
+              },
+              "filter_assigned_to": {
+                "type": "string",
+                "description": "[list] Filter by assigned_to (sys_user sys_id or user_name)"
+              },
+              "filter_assignment_group": {
+                "type": "string",
+                "description": "[list] Filter by assignment_group (sys_user_group sys_id or name)"
+              },
+              "filter_location": {
+                "type": "string",
+                "description": "[list] Filter by location (cmn_location sys_id or name)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_tasks] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/list_tasks] Comma-separated list of fields to return (defaults to a curated set)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "flow-designer",
+      "displayName": "Flow Designer",
+      "tools": [
+        {
+          "name": "snow_manage_flow",
+          "description": "Complete Flow Designer lifecycle: create flows/subflows, add/update triggers and actions, list, get details, update, activate, deactivate, delete and publish. Use update_trigger to change an existing trigger (e.g. switch from record_created to record_create_or_update) without deleting the flow. IMPORTANT: Flow elements (triggers, actions, flow logic, subflows) can ONLY be created/updated/deleted via this tool's GraphQL mutations. Direct Table API operations on sys_hub_action_instance, sys_hub_flow_logic, sys_hub_sub_flow_instance, sys_hub_trigger_instance will NOT work — these tables do not contain individual element records.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "flow-designer",
+            "automation",
+            "flow-management",
+            "subflow"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "create_subflow",
+                  "list",
+                  "get",
+                  "update",
+                  "activate",
+                  "deactivate",
+                  "delete",
+                  "publish",
+                  "add_trigger",
+                  "update_trigger",
+                  "delete_trigger",
+                  "add_action",
+                  "update_action",
+                  "delete_action",
+                  "add_flow_logic",
+                  "update_flow_logic",
+                  "delete_flow_logic",
+                  "add_subflow",
+                  "update_subflow",
+                  "delete_subflow",
+                  "add_flow_variable",
+                  "add_stage",
+                  "update_stage",
+                  "delete_stage",
+                  "open_flow",
+                  "checkout",
+                  "close_flow",
+                  "force_unlock",
+                  "check_execution"
+                ],
+                "description": "Action to perform. CREATE FLOW: 'create' builds the flow AND its trigger in one call when trigger_type is provided. Skip add_trigger afterwards — calling it on a flow that already has a trigger now returns a clear error pointing you at update_trigger or add_action. Only call add_trigger when you originally created the flow without a trigger_type. The editing lock stays open after create, so you can immediately call add_action, add_flow_logic, etc. EDIT EXISTING FLOWS: call checkout (or open_flow) first to acquire the editing lock. Mutation actions (add_action, add_subflow, etc.) also auto-acquire the lock if not already held. ALWAYS call close_flow as the LAST step to release the lock. LOCK RECOVERY: If open_flow fails with \"locked by another user\", use force_unlock first to clear ghost locks, then retry open_flow. Validation errors like 'Missing required parameter' are NOT lock issues — they mean a parameter is missing, not that the flow is locked; do not chase them with force_unlock. add_*/update_*/delete_* for triggers, actions, flow_logic, subflows, stages. update_trigger replaces the trigger type. delete_* removes elements by element_id. add_stage/update_stage/delete_stage for stage management (visual progress grouping of actions). Stages use componentIndexes to map which actions belong to each stage. Flow variable operations (set_flow_variable, append, get_output) are flow LOGIC — use add_flow_logic, not add_action. 'check_execution' queries sys_flow_context and sys_hub_flow_run for execution status/errors/outputs — use after activating to verify the flow runs correctly."
+              },
+              "flow_id": {
+                "type": "string",
+                "description": "Flow sys_id or name (required for get, update, activate, deactivate, delete, publish)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Flow name (required for create / create_subflow)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Flow description"
+              },
+              "trigger_type": {
+                "type": "string",
+                "description": "Trigger type - looked up dynamically in sys_hub_trigger_definition. Common values: record_create, record_update, record_create_or_update, scheduled, manual (default: manual)",
+                "default": "manual"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table for record-based triggers (e.g. \"incident\") or list filter. Also accepted as \"trigger_table\"."
+              },
+              "trigger_table": {
+                "type": "string",
+                "description": "Alias for \"table\" — table for record-based triggers (e.g. \"incident\")"
+              },
+              "action_table": {
+                "type": "string",
+                "description": "Shorthand for setting the table input on an action (e.g. \"incident\" for create_record/update_record/lookup_record). Injected as the \"table\" input."
+              },
+              "action_field_values": {
+                "type": "object",
+                "description": "Alias for \"action_inputs\" — key-value pairs for action inputs. Same behavior as action_inputs."
+              },
+              "trigger_condition": {
+                "type": "string",
+                "description": "Encoded query condition for the trigger"
+              },
+              "category": {
+                "type": "string",
+                "description": "Flow category",
+                "default": "custom"
+              },
+              "run_as": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "system"
+                ],
+                "description": "Run-as context (default: user)",
+                "default": "user"
+              },
+              "activities": {
+                "type": "array",
+                "description": "Flow action steps",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Step name"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Action type - looked up dynamically in sys_hub_action_type_snapshot by internal_name or name. Common values: log, create_record, update_record, lookup_record, delete_record, send_notification, field_update, wait, create_approval. Note: there is NO generic \"script\" action in Flow Designer — use a subflow or business rule for custom scripts."
+                    },
+                    "inputs": {
+                      "type": "object",
+                      "description": "Step-specific input values"
+                    }
+                  }
+                }
+              },
+              "inputs": {
+                "type": "array",
+                "description": "Flow input variables",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "integer",
+                        "boolean",
+                        "reference",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "mandatory": {
+                      "type": "boolean"
+                    },
+                    "default_value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "outputs": {
+                "type": "array",
+                "description": "Flow output variables",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "integer",
+                        "boolean",
+                        "reference",
+                        "object",
+                        "array"
+                      ]
+                    }
+                  }
+                }
+              },
+              "activate": {
+                "type": "boolean",
+                "description": "Activate flow after creation (default: true)",
+                "default": true
+              },
+              "logic_type": {
+                "type": "string",
+                "description": "Flow logic type for add_flow_logic. Looked up dynamically in sys_hub_flow_logic_definition. Common aliases (FOR_EACH, DO_UNTIL, etc.) are auto-normalized to ServiceNow types. Available types: IF, ELSEIF, ELSE — conditional branching. Use ELSEIF (not nested ELSE+IF) for else-if branches. ELSE and ELSEIF require connected_to set to the If block's uiUniqueIdentifier. FOREACH (or FOR_EACH), DOUNTIL (or DO_UNTIL) — loops. CONTINUE (skip iteration) and BREAK (exit loop) can be used inside loops. PARALLEL — execute branches in parallel. DECISION — switch/decision table. TRY — error handling (try/catch). END — End Flow (stops execution). Always add END as the last element when the flow should terminate cleanly. TIMER — Wait for a duration of time. GOBACKTO (or GO_BACK_TO) — jump back to a previous step. SETFLOWVARIABLES, APPENDFLOWVARIABLES, GETFLOWOUTPUT — flow variable management. WORKFLOW — call a legacy workflow. DYNAMICFLOW — dynamically invoke a flow. Best practice: add an END element at the end of your flow for clean termination."
+              },
+              "logic_inputs": {
+                "type": "object",
+                "description": "Input values for the flow logic block. For IF/ELSEIF, prefer using the dedicated condition parameter instead."
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition for IF/ELSEIF flow logic. Accepts multiple formats (all auto-converted to Flow Designer pill format): \"priority<=2\" (encoded query), \"trigger.current.priority <= 2\" (dot notation), \"{{trigger.current.priority}}<=2\" (shorthand pill), \"category=software^priority!=1\" (multi-clause). Spaces around operators are auto-removed. Single `=` works the same as `==` or `===`. Operators: = != > < >= <= LIKE STARTSWITH ENDSWITH ISEMPTY ISNOTEMPTY. Combine with ^ (AND) or ^OR (OR). Word operators also accepted: \"equals\", \"not equals\", \"contains\", \"starts with\", \"is empty\"."
+              },
+              "condition_name": {
+                "type": "string",
+                "description": "REQUIRED for IF/ELSEIF: display label for the condition shown in Flow Designer UI (e.g. \"Check if P1 or P2 Incident\"). Falls back to annotation if not provided. Accepts alias logic_name."
+              },
+              "parent_ui_id": {
+                "type": "string",
+                "description": "Parent UI unique identifier for nesting elements inside flow logic blocks. REQUIRED for placing actions/subflows inside an If/Else block — get this from the `uiUniqueIdentifier` in the add_flow_logic response. The response also includes a `next_step.for_child` hint with the exact value to use."
+              },
+              "connected_to": {
+                "type": "string",
+                "description": "REQUIRED for ELSE blocks: the uiUniqueIdentifier of the If block this Else is connected to. Unlike parent_ui_id (which nests elements inside a block), connected_to links sibling blocks like Else to their If. Get this from the `connected_to_value` in the IF block's add_flow_logic response."
+              },
+              "subflow_id": {
+                "type": "string",
+                "description": "Subflow sys_id or name to call as a step (for add_subflow action). Looked up in sys_hub_flow where type=subflow."
+              },
+              "element_id": {
+                "type": "string",
+                "description": "Element sys_id or uiUniqueIdentifier for update_*/delete_* actions. For delete_* this can also be a comma-separated list of IDs."
+              },
+              "order": {
+                "type": "number",
+                "description": "GLOBAL position/order of the element in the flow (for add_* actions). If omitted, auto-calculated from current flow state. Previous response includes `next_order` — use that value for top-level elements. Do NOT guess order numbers. Flow Designer uses global sequential ordering across ALL elements (1, 2, 3...). For nested elements inside TRY/CATCH/IF blocks, order is computed automatically when parent_ui_id is set — the CATCH block and subsequent elements are shifted forward to make room."
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flow",
+                  "subflow",
+                  "all"
+                ],
+                "description": "Filter by type (list only, default: all)",
+                "default": "all"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only list active flows (default: true)",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results for list",
+                "default": 50
+              },
+              "action_type": {
+                "type": "string",
+                "description": "Action type to add (for add_action). Looked up dynamically by internal_name or name in sys_hub_action_type_snapshot and sys_hub_action_type_definition. Common short names: log, create_record, update_record, lookup_record, delete_record, notification, field_update, wait, approval. You can also use the exact ServiceNow internal name (e.g. \"global.update_record\") or display name (e.g. \"Update Record\"). If omitted, action_name is used as the lookup key. Use \"Subflow\" with subflow_id to add a subflow call. NOTE: there is NO generic \"script\" or \"run_script\" action — use a subflow for custom logic. Flow variable operations (set_flow_variable, append_flow_variable, get_flow_output) are flow LOGIC — use add_flow_logic instead.",
+                "default": "log"
+              },
+              "action_name": {
+                "type": "string",
+                "description": "Display name / type for the action (for add_action). If action_type is not specified, action_name is used to look up the action definition. Accepts display names like \"Update Record\", \"Ask for Approval\", \"Log\", \"Create Record\", \"Subflow\", etc."
+              },
+              "spoke": {
+                "type": "string",
+                "description": "Spoke/scope filter for action lookup (for add_action). Use to disambiguate when multiple spokes have actions with the same name (e.g. \"global\" for core actions, \"spoke-specific\" for spoke-specific Spoke actions). Matched against sys_scope and sys_package fields."
+              },
+              "action_inputs": {
+                "type": "object",
+                "description": "Key-value pairs for action inputs (also accepted as \"action_config\", \"action_field_values\", \"inputs\", or \"config\"). Keys are fuzzy-matched to ServiceNow parameter element names — you can use short names like \"to\" instead of \"ah_to\", \"subject\" instead of \"ah_subject\", \"table\" instead of \"table_name\", \"message\" instead of \"log_message\". Use `next_order` from the previous response for sequential ordering. Example: {to: \"admin@example.com\", subject: \"Alert\", body: \"Incident created\"}"
+              },
+              "display_text": {
+                "type": "string",
+                "description": "Optional custom label for an action step, shown on the Flow Designer canvas (for add_action). Defaults to the action type name when omitted. Example: \"Log high priority\"."
+              },
+              "variable_name": {
+                "type": "string",
+                "description": "Name of the user flow variable to add to an existing flow (for add_flow_variable). Flow inputs are trigger-derived and cannot be added this way."
+              },
+              "variable_label": {
+                "type": "string",
+                "description": "Display label for the flow variable (for add_flow_variable). Defaults to variable_name."
+              },
+              "variable_type": {
+                "type": "string",
+                "description": "Type of the flow variable (for add_flow_variable): string, integer, boolean, reference, etc. Default: string."
+              },
+              "update_fields": {
+                "type": "object",
+                "description": "Fields to update (for update action)",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "run_as": {
+                    "type": "string"
+                  }
+                }
+              },
+              "update_set_id": {
+                "type": "string",
+                "description": "[write actions] Explicit update set sys_id to switch to before making changes. Only used when ensure_update_set=true."
+              },
+              "update_set_name": {
+                "type": "string",
+                "description": "[write actions] Name for auto-created update set (default: \"Serac: Flow Designer changes\"). Only used when ensure_update_set=true and no update_set_id provided.",
+                "default": "Serac: Flow Designer changes"
+              },
+              "ensure_update_set": {
+                "type": "boolean",
+                "description": "[write actions] Opt-in: ensure an update set is active before making changes. When true, switches to or creates an update set for change tracking. Default: false (no update set tracking).",
+                "default": false
+              },
+              "application_scope": {
+                "type": "string",
+                "description": "[create/create_subflow] Application scope for the new flow. Default: \"global\". Provide a scope name (e.g. \"x_myco_app\") to create in a scoped application.",
+                "default": "global"
+              },
+              "force_unlock_all": {
+                "type": "boolean",
+                "description": "[force_unlock] Admin override: delete ALL locks including those < 5 minutes old. Without this, young locks are skipped (they may belong to an active user). Default: false.",
+                "default": false
+              },
+              "annotation": {
+                "type": "string",
+                "description": "Optional human-readable comment describing what this element does and why. Sent as the 'comment' field in the Flow Designer GraphQL mutation; defaults to empty string when omitted. Special case: for add_flow_logic with logic_type IF or ELSEIF, ServiceNow needs a condition label — provide condition_name explicitly, or annotation will be used as a fallback."
+              },
+              "verify": {
+                "type": "boolean",
+                "description": "Verify mutations via processflow API after GraphQL operations. Reads the real-time flow state to confirm changes took effect. Adds ~200ms latency per mutation. Recommended for debugging or critical flows.",
+                "default": false
+              },
+              "stage_label": {
+                "type": "string",
+                "description": "Label for the stage (for add_stage, update_stage). The display name shown in the flow's progress indicator."
+              },
+              "stage_component_indexes": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "description": "Array of action order indexes (0-based) that belong to this stage (for add_stage, update_stage). These correspond to the positional indexes of actions in the flow. Example: [0, 1] means the first two actions belong to this stage."
+              },
+              "stage_order": {
+                "type": "number",
+                "description": "Order of the stage in the stage list (0-based, for add_stage). Stages have their own ordering separate from the global action order. If omitted, defaults to 0."
+              },
+              "stage_states": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string",
+                      "description": "Display label (e.g. 'Pending - has not started')"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "State name (e.g. 'pending', 'in_progress', 'skipped', 'complete', 'error')"
+                    }
+                  }
+                },
+                "description": "Custom stage states (for add_stage, update_stage). Defaults to 5 standard states: pending, in_progress, skipped, complete, error. Only provide this if you need non-standard states."
+              },
+              "stage_always_show": {
+                "type": "boolean",
+                "description": "Whether the stage is always visible in the progress indicator (default: true).",
+                "default": true
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "forms",
+      "displayName": "Forms",
+      "tools": [
+        {
+          "name": "snow_add_form_field",
+          "description": "Add a field (element) to a form section by section sys_id, with optional field type and ordering position. Writes to sys_ui_element.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "forms",
+            "ui",
+            "fields"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "section_sys_id": {
+                "type": "string",
+                "description": "Section sys_id"
+              },
+              "element": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "type": {
+                "type": "string",
+                "description": "Field type"
+              },
+              "position": {
+                "type": "number",
+                "description": "Field position"
+              }
+            },
+            "required": [
+              "section_sys_id",
+              "element"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_form_layout",
+          "description": "Create a form layout (sys_ui_form) for a table and view, with layout type standard / related_list / split. Container for form sections — add sections with snow_create_form_section.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "forms",
+            "ui",
+            "layout"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Layout name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "view": {
+                "type": "string",
+                "description": "Form view"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "standard",
+                  "related_list",
+                  "split"
+                ],
+                "default": "standard"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_form_section",
+          "description": "Create a form section (sys_ui_section) on a table/view with an optional caption and ordering position. Sections group fields visually on a form — use snow_add_form_field to populate.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "forms",
+            "ui",
+            "sections"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Section name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "view": {
+                "type": "string",
+                "description": "Form view"
+              },
+              "caption": {
+                "type": "string",
+                "description": "Section caption"
+              },
+              "position": {
+                "type": "number",
+                "description": "Section position"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "frameworks",
+      "displayName": "Frameworks",
+      "tools": [
+        {
+          "name": "snow_discover_security_frameworks",
+          "description": "Discovers security and compliance frameworks available in the instance for policy creation and auditing.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "discovery",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Framework type (security, compliance, audit)"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "graphql",
+      "displayName": "Graphql",
+      "tools": [
+        {
+          "name": "snow_graphql_query",
+          "description": "Run a GraphQL query against /api/now/graphql with optional variables. Use when you need to fetch nested data across tables in one round-trip; for simple list/get on a single table, prefer the table API.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "graphql",
+            "query",
+            "data-retrieval"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "GraphQL query"
+              },
+              "variables": {
+                "type": "object",
+                "description": "Query variables"
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "hr",
+      "displayName": "Hr",
+      "tools": [
+        {
+          "name": "snow_create_hr_case",
+          "description": "Open an HR Service Delivery case on sn_hr_core_case for a given HR service, with subject, opened_for (employee), and optional priority. Use this for HR tickets; for IT incidents use snow_create_incident.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "case-management",
+            "hr"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "string"
+              },
+              "opened_for": {
+                "type": "string"
+              },
+              "hr_service": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "subject",
+              "hr_service"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_hr_task",
+          "description": "Create HR task for case fulfillment",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "task-management",
+            "case-fulfillment"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "hr_case": {
+                "type": "string",
+                "description": "Parent HR case sys_id"
+              },
+              "type": {
+                "type": "string",
+                "description": "Task type"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "Assigned user sys_id"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "Task description"
+              },
+              "due_date": {
+                "type": "string",
+                "description": "Due date"
+              },
+              "instructions": {
+                "type": "string",
+                "description": "Task instructions"
+              }
+            },
+            "required": [
+              "hr_case",
+              "type",
+              "short_description"
+            ]
+          }
+        },
+        {
+          "name": "snow_employee_offboarding",
+          "description": "Initiate employee offboarding workflow",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "offboarding",
+            "lifecycle"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "employee": {
+                "type": "string",
+                "description": "Employee sys_id or user name"
+              },
+              "last_date": {
+                "type": "string",
+                "description": "Last working date"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Offboarding reason"
+              },
+              "assets_to_return": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Assets to collect"
+              },
+              "knowledge_transfer": {
+                "type": "string",
+                "description": "Knowledge transfer plan"
+              }
+            },
+            "required": [
+              "employee",
+              "last_date",
+              "reason"
+            ]
+          }
+        },
+        {
+          "name": "snow_employee_onboarding",
+          "description": "Trigger employee onboarding workflow",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "onboarding",
+            "lifecycle"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "employee_sys_id": {
+                "type": "string"
+              },
+              "start_date": {
+                "type": "string"
+              },
+              "department": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "employee_sys_id",
+              "start_date"
+            ]
+          }
+        },
+        {
+          "name": "snow_hr_lifecycle_event",
+          "description": "Unified tool for ServiceNow HR Lifecycle Events (LEM): manage lifecycle-event cases (sn_hr_le_case), their activities (sn_hr_le_activity), and the journey templates that drive them (sn_hr_core_journey_template, sn_hr_core_journey_activity).\n\nActions:\n- create_event — open a new lifecycle-event case for an employee (onboarding, offboarding, transfer, role change). Optionally seeds activities from a journey template.\n- list_events — list lifecycle-event cases, filtered by employee, type, or state\n- complete_event — mark a lifecycle-event case as complete (closes the case and stops scheduled activities)\n- list_pending_for_employee — return open lifecycle-event activities assigned to an employee or owned by their case\n- trigger_journey — instantiate the activities defined on a journey template against an existing lifecycle-event case\n\nUse when: the agent needs to drive an end-to-end employee lifecycle event in HRSD. For a single ad-hoc HR ticket use snow_create_hr_case; for offboarding-only flows snow_employee_offboarding is a thinner wrapper around sn_hr_core_case.\n\nRequires the HR Lifecycle Events plugin (com.sn_hr_lifecycle_events). Tables may be absent on instances without the plugin, in which case the tool fails with a clear plugin-missing error.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "lifecycle-events",
+            "onboarding",
+            "offboarding",
+            "journeys"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "create_event",
+                  "list_events",
+                  "complete_event",
+                  "list_pending_for_employee",
+                  "trigger_journey"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[complete_event/trigger_journey] sn_hr_le_case sys_id"
+              },
+              "employee": {
+                "type": "string",
+                "description": "[create_event/list_events/list_pending_for_employee] Employee sys_id (sn_hr_core_profile or sys_user, depending on instance)"
+              },
+              "event_type": {
+                "type": "string",
+                "description": "[create_event/list_events] Lifecycle-event type",
+                "enum": [
+                  "onboarding",
+                  "offboarding",
+                  "transfer",
+                  "role_change",
+                  "leave_of_absence",
+                  "return_from_leave"
+                ]
+              },
+              "subject": {
+                "type": "string",
+                "description": "[create_event] Case subject/short_description"
+              },
+              "effective_date": {
+                "type": "string",
+                "description": "[create_event] Effective date (YYYY-MM-DD). Maps to start_date or effective_date depending on instance configuration."
+              },
+              "hr_service": {
+                "type": "string",
+                "description": "[create_event] HR service sys_id used to categorize the case"
+              },
+              "journey_template": {
+                "type": "string",
+                "description": "[create_event/trigger_journey] Journey template sys_id (sn_hr_core_journey_template) used to seed activities"
+              },
+              "opened_for": {
+                "type": "string",
+                "description": "[create_event] sys_user sys_id of the employee the event is opened for. Defaults to `employee` when omitted."
+              },
+              "priority": {
+                "type": "number",
+                "description": "[create_event] ServiceNow priority (1-5)"
+              },
+              "close_notes": {
+                "type": "string",
+                "description": "[complete_event] Notes recorded on close"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_events] State filter (open|in_progress|closed|cancelled)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_events/list_pending_for_employee] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_events/list_pending_for_employee] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_hr_profile_manage",
+          "description": "Unified tool for ServiceNow HR employee profiles (sn_hr_core_profile). Searches join through profile.user reference for sys_user fields (department, email, active).\n\nActions:\n- get_profile — fetch a profile by sys_id, user sys_id, or employee_number\n- update_profile — patch profile fields (employment_type, position, primary_job, location, personal_email, work_mobile, mobile_phone, im_name)\n- search_employees — search profiles by name, email, department, or employee_number\n\nUse when: the agent needs to read or maintain the canonical employee record used across all HR cases. Companion tools: snow_create_hr_case (opens HR tickets against a profile), snow_create_hr_task (creates task work on a case), snow_hr_lifecycle_event (drives onboarding/offboarding flows).\n\nRequires the HR Core plugin (com.sn_hr_core). When the plugin is missing the underlying tables don't exist and the tool returns a clear plugin-missing error.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "hr-service-delivery",
+            "employee-profile",
+            "hr-core"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "get_profile",
+                  "update_profile",
+                  "search_employees"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get_profile/update_profile] Profile sys_id"
+              },
+              "user": {
+                "type": "string",
+                "description": "[get_profile] sys_user sys_id (alternative to sys_id)"
+              },
+              "employee_number": {
+                "type": "string",
+                "description": "[get_profile/search_employees/update_profile] Employee number (alternative to sys_id)"
+              },
+              "employment_type": {
+                "type": "string",
+                "description": "[update_profile] Employment type (e.g. full_time, part_time, contractor)"
+              },
+              "position": {
+                "type": "string",
+                "description": "[update_profile] sn_hr_core_position sys_id"
+              },
+              "primary_job": {
+                "type": "string",
+                "description": "[update_profile] sn_hr_core_job sys_id"
+              },
+              "location": {
+                "type": "string",
+                "description": "[update_profile] cmn_location sys_id"
+              },
+              "personal_email": {
+                "type": "string",
+                "description": "[update_profile] Personal email address"
+              },
+              "work_mobile": {
+                "type": "string",
+                "description": "[update_profile] Work mobile phone number"
+              },
+              "mobile_phone": {
+                "type": "string",
+                "description": "[update_profile] Mobile phone number"
+              },
+              "im_name": {
+                "type": "string",
+                "description": "[update_profile] Instant-message / display name"
+              },
+              "name": {
+                "type": "string",
+                "description": "[search_employees] Substring match against legal_first_name and im_name (OR'd)"
+              },
+              "email": {
+                "type": "string",
+                "description": "[search_employees] Email substring match (dot-walks through user.email on sys_user)"
+              },
+              "department": {
+                "type": "string",
+                "description": "[search_employees] Department substring match (dot-walks through user.department on sys_user)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[search_employees] Only return profiles whose linked sys_user is active",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "[search_employees] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[get_profile/search_employees] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "impact-analysis",
+      "displayName": "Impact Analysis",
+      "tools": [
+        {
+          "name": "snow_get_ci_impact",
+          "description": "Calculate impact analysis for CI outage",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "impact",
+            "analysis"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_sys_id": {
+                "type": "string",
+                "description": "CI sys_id"
+              },
+              "include_services": {
+                "type": "boolean",
+                "description": "Include business services",
+                "default": true
+              }
+            },
+            "required": [
+              "ci_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_impact_analysis",
+          "description": "Perform impact analysis to identify affected services when a CI changes",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "impact",
+            "services"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_id": {
+                "type": "string",
+                "description": "CI sys_id to analyze"
+              },
+              "depth": {
+                "type": "number",
+                "description": "Relationship depth to analyze",
+                "default": 3
+              },
+              "include_services": {
+                "type": "boolean",
+                "description": "Include business services",
+                "default": true
+              }
+            },
+            "required": [
+              "ci_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "import-export",
+      "displayName": "Import Export",
+      "tools": [
+        {
+          "name": "snow_create_import_set",
+          "description": "Create import set for data import",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "import",
+            "data-migration",
+            "integration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Import set table name"
+              },
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Data to import"
+              }
+            },
+            "required": [
+              "table",
+              "data"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_transform_map",
+          "description": "Create transform map for import sets",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "transform-maps",
+            "data-transformation",
+            "import"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Transform map name"
+              },
+              "source_table": {
+                "type": "string",
+                "description": "Source import table (u_import_table)"
+              },
+              "target_table": {
+                "type": "string",
+                "description": "Target table (incident, task, etc.)"
+              },
+              "run_business_rules": {
+                "type": "boolean",
+                "default": true
+              },
+              "description": {
+                "type": "string",
+                "description": "Transform map description"
+              }
+            },
+            "required": [
+              "name",
+              "source_table",
+              "target_table"
+            ]
+          }
+        },
+        {
+          "name": "snow_execute_transform",
+          "description": "Execute transform map on import set",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "data-transformation",
+            "import",
+            "processing"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "import_set_sys_id": {
+                "type": "string",
+                "description": "Import set sys_id"
+              },
+              "transform_map_sys_id": {
+                "type": "string",
+                "description": "Transform map sys_id"
+              }
+            },
+            "required": [
+              "import_set_sys_id",
+              "transform_map_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_export_to_xml",
+          "description": "Export records from a table as XML, filtered by an encoded query and optionally a specific view. Returns the raw XML body — handy for record imports, backups, or update-set-style transfers.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "export",
+            "xml",
+            "backup"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table to export"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query filter"
+              },
+              "view": {
+                "type": "string",
+                "description": "View to use"
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "incidents",
+      "displayName": "Incidents",
+      "tools": [
+        {
+          "name": "snow_create_security_incident",
+          "description": "Create security incident with automated threat correlation and priority assignment",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "logging",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Security incident title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Detailed incident description"
+              },
+              "priority": {
+                "type": "string",
+                "description": "Incident priority",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low"
+                ]
+              },
+              "threat_type": {
+                "type": "string",
+                "description": "Type of security threat",
+                "enum": [
+                  "malware",
+                  "phishing",
+                  "data_breach",
+                  "unauthorized_access",
+                  "ddos",
+                  "insider_threat"
+                ]
+              },
+              "affected_systems": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of affected system CIs"
+              },
+              "iocs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Indicators of Compromise (IOCs)"
+              },
+              "source": {
+                "type": "string",
+                "description": "Incident source (SIEM, manual, automated)"
+              }
+            },
+            "required": [
+              "title",
+              "description",
+              "threat_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_sir_evidence_manage",
+          "description": "Unified tool for Security Incident Response (SIR) evidence and forensic artifact chain-of-custody on sn_si_evidence, sn_si_artifact, and sn_si_attachment. Critical for audit trails — every action records who attached/exported the evidence and when.\n\nActions:\n- attach — attach a new evidence record to a SIR incident with type, description, source, and an optional sys_attachment reference\n- list — list evidence rows linked to an incident\n- get — retrieve a single evidence row with related artifact and attachment metadata\n- hash_verify — recompute the SHA-256 hash of a stored artifact server-side (GlideDigest) and compare to the value recorded at attach time. Used to detect tampering or storage corruption\n- export — return a structured manifest of all evidence for an incident, suitable for handing off to legal/IR review\n\nUse when: the agent has produced or received forensic evidence (memory dumps, PCAPs, screenshots, exported logs) tied to a SIR incident and needs to track it under chain of custody. Companion tools: snow_sir_incident_manage (incident lifecycle), snow_sir_playbook_orchestrate (playbook steps that produce the evidence).\n\nPlugin gating: requires com.snc.security_incident. A 404 on sn_si_evidence is surfaced with the required plugin name. The hash_verify action uses GlideDigest via ES5-only server-side script execution.\n\nReturns: action-specific data. attach returns the created evidence row. list returns evidence summaries with hash and attached_by. get returns the row with related artifact records. hash_verify returns the recomputed hash, the stored hash, and a verified boolean. export returns the full evidence manifest for the incident.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sir",
+            "forensics",
+            "evidence",
+            "chain-of-custody",
+            "security"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Evidence management action to perform",
+                "enum": [
+                  "attach",
+                  "list",
+                  "get",
+                  "hash_verify",
+                  "export"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/hash_verify] Evidence record sys_id on sn_si_evidence"
+              },
+              "incident_sys_id": {
+                "type": "string",
+                "description": "[attach/list/export] Parent SIR incident sys_id (sn_si_incident)"
+              },
+              "incident_number": {
+                "type": "string",
+                "description": "[attach/list/export] Parent SIR incident number (e.g. SIR0010001), alternative to incident_sys_id"
+              },
+              "attachment_sys_id": {
+                "type": "string",
+                "description": "[attach/hash_verify] sys_attachment sys_id pointing at the stored file (when evidence is file-based)"
+              },
+              "artifact_sys_id": {
+                "type": "string",
+                "description": "[attach] Existing sn_si_artifact sys_id to link to the evidence (alternative to attachment_sys_id)"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[attach] Short description of the evidence"
+              },
+              "description": {
+                "type": "string",
+                "description": "[attach] Detailed description / context of how the evidence was produced"
+              },
+              "evidence_type": {
+                "type": "string",
+                "description": "[attach] Evidence type",
+                "enum": [
+                  "memory_dump",
+                  "pcap",
+                  "log",
+                  "screenshot",
+                  "file",
+                  "registry_export",
+                  "process_list",
+                  "network_capture",
+                  "other"
+                ]
+              },
+              "source": {
+                "type": "string",
+                "description": "[attach] Source system / collection method (EDR, SIEM, manual)"
+              },
+              "sha256": {
+                "type": "string",
+                "description": "[attach] SHA-256 hash of the evidence as captured at collection time (lowercase hex)"
+              },
+              "collected_by": {
+                "type": "string",
+                "description": "[attach] sys_user sys_id of the analyst who collected the evidence (defaults to caller)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/export] Comma-separated list of fields to return"
+              },
+              "include_artifacts": {
+                "type": "boolean",
+                "description": "[export] Include linked sn_si_artifact rows in the manifest",
+                "default": true
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_sir_incident_manage",
+          "description": "Unified tool for ServiceNow Security Incident Response (SIR) incident lifecycle on sn_si_incident and sn_si_task. Walks an incident through the NIST IR phases: triage, contain, eradicate, recover, close.\n\nActions:\n- list — list SIR incidents, optionally filtered by state, priority, or assignment_group\n- get — retrieve a single SIR incident by sys_id or number, with its related task summary\n- create — open a new SIR incident (short_description and category required)\n- triage — move an incident into the triage phase, optionally assigning analyst\n- contain — move an incident into the contain phase with a containment note\n- eradicate — move an incident into the eradicate phase with an eradication note\n- recover — move an incident into the recover phase with a recovery note\n- close — close an incident with a close code and resolution notes\n- list_tasks — list sn_si_task rows linked to the incident\n\nUse when: the agent needs to drive a security incident through the SIR phase model rather than just record one. Companion tools: snow_create_security_incident (initial record only), snow_automate_threat_response (run automated actions), snow_sir_playbook_orchestrate (run a multi-step playbook), snow_sir_evidence_manage (attach forensic evidence).\n\nPlugin gating: requires com.snc.security_incident. A 404 on sn_si_incident is surfaced with the required plugin name so the caller can install it.\n\nReturns: SIR incident records with sys_id, number, state, phase, priority, category, assigned_to, and the configured workflow phase. Task listings include sys_id, number, short_description, state, and assigned_to.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sir",
+            "security",
+            "incident-response",
+            "soar",
+            "nist-ir"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "triage",
+                  "contain",
+                  "eradicate",
+                  "recover",
+                  "close",
+                  "list_tasks"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/triage/contain/eradicate/recover/close/list_tasks] SIR incident sys_id"
+              },
+              "number": {
+                "type": "string",
+                "description": "[get/triage/contain/eradicate/recover/close/list_tasks] SIR incident number (e.g. SIR0010001), alternative to sys_id"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list] Filter by state code (numeric) or display value"
+              },
+              "priority": {
+                "type": "string",
+                "description": "[list] Filter by priority (1-5)"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[list] Filter by assignment_group sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_tasks] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/list_tasks] Comma-separated list of fields to return"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create] Short description of the incident"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create] Long description / initial observations"
+              },
+              "category": {
+                "type": "string",
+                "description": "[create] SIR category (malware, phishing, unauthorized_access, etc.)"
+              },
+              "subcategory": {
+                "type": "string",
+                "description": "[create] SIR subcategory"
+              },
+              "priority_value": {
+                "type": "string",
+                "description": "[create] Priority (1=Critical, 2=High, 3=Moderate, 4=Low, 5=Planning)",
+                "enum": [
+                  "1",
+                  "2",
+                  "3",
+                  "4",
+                  "5"
+                ]
+              },
+              "caller": {
+                "type": "string",
+                "description": "[create] sys_user sys_id of the caller / reporter"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[create/triage] sys_user sys_id of the analyst the incident is assigned to"
+              },
+              "assignment_group_sys_id": {
+                "type": "string",
+                "description": "[create/triage] assignment_group sys_id"
+              },
+              "triage_note": {
+                "type": "string",
+                "description": "[triage] Triage work note"
+              },
+              "contain_note": {
+                "type": "string",
+                "description": "[contain] Containment work note describing isolation / blocking actions taken"
+              },
+              "eradicate_note": {
+                "type": "string",
+                "description": "[eradicate] Eradication work note describing root-cause removal"
+              },
+              "recover_note": {
+                "type": "string",
+                "description": "[recover] Recovery work note describing service restoration"
+              },
+              "close_code": {
+                "type": "string",
+                "description": "[close] Close code",
+                "enum": [
+                  "resolved",
+                  "not_a_security_incident",
+                  "false_positive",
+                  "duplicate",
+                  "no_resolution"
+                ]
+              },
+              "close_notes": {
+                "type": "string",
+                "description": "[close] Resolution notes"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "integrationhub",
+      "displayName": "Integrationhub",
+      "tools": [
+        {
+          "name": "snow_create_flow_action",
+          "description": "Create custom IntegrationHub action for Flow Designer",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "flow-designer",
+            "integration-hub",
+            "custom-actions",
+            "automation"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Action name (e.g., \"Create Jira Issue\", \"Send Slack Message\")"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of what the action does"
+              },
+              "category": {
+                "type": "string",
+                "description": "Category for organizing the action",
+                "default": "Custom"
+              },
+              "action_type": {
+                "type": "string",
+                "enum": [
+                  "rest",
+                  "script",
+                  "subflow",
+                  "powershell",
+                  "ssh"
+                ],
+                "description": "Type of action implementation",
+                "default": "rest"
+              },
+              "connection_alias": {
+                "type": "string",
+                "description": "sys_id or name of connection alias to use"
+              },
+              "inputs": {
+                "type": "array",
+                "description": "Input parameters for the action",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Input parameter name"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "integer",
+                        "boolean",
+                        "reference",
+                        "object",
+                        "array"
+                      ],
+                      "description": "Data type"
+                    },
+                    "mandatory": {
+                      "type": "boolean",
+                      "description": "Is input required"
+                    },
+                    "default_value": {
+                      "type": "string",
+                      "description": "Default value"
+                    }
+                  }
+                }
+              },
+              "outputs": {
+                "type": "array",
+                "description": "Output parameters for the action",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Output parameter name"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Display label"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "integer",
+                        "boolean",
+                        "reference",
+                        "object",
+                        "array"
+                      ],
+                      "description": "Data type"
+                    }
+                  }
+                }
+              },
+              "rest_config": {
+                "type": "object",
+                "description": "REST action configuration (for rest action_type)",
+                "properties": {
+                  "http_method": {
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE"
+                    ]
+                  },
+                  "endpoint_path": {
+                    "type": "string",
+                    "description": "Relative endpoint path (can use {{input.param}} syntax)"
+                  },
+                  "request_body": {
+                    "type": "string",
+                    "description": "Request body template (JSON with {{input.param}} placeholders)"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "description": "Additional headers"
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "default": "application/json"
+                  }
+                }
+              },
+              "script_config": {
+                "type": "object",
+                "description": "Script action configuration (for script action_type)",
+                "properties": {
+                  "script": {
+                    "type": "string",
+                    "description": "ES5 JavaScript script to execute"
+                  }
+                }
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the action is active",
+                "default": true
+              },
+              "annotation": {
+                "type": "string",
+                "description": "Annotation/label for the action in Flow Designer"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_install_spoke",
+          "description": "Install and manage IntegrationHub Spokes (Jira, Slack, Azure DevOps, etc.)",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "spokes",
+            "integration-hub",
+            "marketplace",
+            "external-systems"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "list_available",
+                  "install",
+                  "activate",
+                  "deactivate",
+                  "status",
+                  "search"
+                ],
+                "description": "Action to perform",
+                "default": "list"
+              },
+              "spoke_name": {
+                "type": "string",
+                "description": "Name of the spoke (e.g., \"Jira\", \"Slack\", \"Microsoft Teams\")"
+              },
+              "spoke_id": {
+                "type": "string",
+                "description": "sys_id of the spoke (for activate/deactivate/status)"
+              },
+              "search_query": {
+                "type": "string",
+                "description": "Search query for finding spokes (for search action)"
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive spokes in list",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of results",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_manage_spoke_connection",
+          "description": "Manage IntegrationHub spoke connections: configure, test, and troubleshoot",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "spokes",
+            "connections",
+            "integration-hub",
+            "troubleshooting"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "configure",
+                  "test",
+                  "status",
+                  "update",
+                  "troubleshoot"
+                ],
+                "description": "Action to perform",
+                "default": "list"
+              },
+              "spoke_name": {
+                "type": "string",
+                "description": "Name of the spoke to manage connections for"
+              },
+              "connection_alias_id": {
+                "type": "string",
+                "description": "sys_id of specific connection alias"
+              },
+              "configuration": {
+                "type": "object",
+                "description": "Connection configuration to apply (for configure/update)",
+                "properties": {
+                  "base_url": {
+                    "type": "string",
+                    "description": "Base URL for the external system"
+                  },
+                  "credential_alias": {
+                    "type": "string",
+                    "description": "Credential alias sys_id"
+                  },
+                  "mid_server": {
+                    "type": "string",
+                    "description": "MID Server to use"
+                  },
+                  "timeout": {
+                    "type": "number",
+                    "description": "Connection timeout in seconds"
+                  },
+                  "retry_count": {
+                    "type": "number",
+                    "description": "Number of retry attempts"
+                  },
+                  "custom_headers": {
+                    "type": "object",
+                    "description": "Custom headers to include"
+                  }
+                }
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive connections",
+                "default": false
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "knowledge",
+      "displayName": "Knowledge",
+      "tools": [
+        {
+          "name": "snow_create_knowledge_base",
+          "description": "Creates a new knowledge base for organizing articles by topic, department, or audience.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "knowledge",
+            "create",
+            "knowledge-base"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Knowledge base title"
+              },
+              "description": {
+                "type": "string",
+                "description": "Knowledge base description"
+              },
+              "owner": {
+                "type": "string",
+                "description": "Owner user or group"
+              },
+              "managers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Manager users or groups"
+              },
+              "kb_version": {
+                "type": "string",
+                "description": "Version number"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active status",
+                "default": true
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_knowledge_bases",
+          "description": "Discovers available knowledge bases and their categories in the ServiceNow instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "knowledge",
+            "discovery",
+            "query"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active knowledge bases",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_knowledge_article_manage",
+          "description": "Unified knowledge article management (create, update, get, publish, retire, search)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "knowledge",
+            "articles",
+            "kb"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Knowledge article action to perform",
+                "enum": [
+                  "create",
+                  "update",
+                  "get",
+                  "publish",
+                  "retire",
+                  "search"
+                ]
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create/update] Article title"
+              },
+              "text": {
+                "type": "string",
+                "description": "[create/update] Article content (HTML supported)"
+              },
+              "kb_knowledge_base": {
+                "type": "string",
+                "description": "[create/search] Knowledge base sys_id or name"
+              },
+              "kb_category": {
+                "type": "string",
+                "description": "[create/search] Category sys_id or name"
+              },
+              "article_type": {
+                "type": "string",
+                "description": "[create] Type: text, html, wiki",
+                "default": "text"
+              },
+              "workflow_state": {
+                "type": "string",
+                "description": "[create/update/search] State: draft, review, published, retired",
+                "default": "draft"
+              },
+              "valid_to": {
+                "type": "string",
+                "description": "[create/update] Expiration date (YYYY-MM-DD)"
+              },
+              "meta_description": {
+                "type": "string",
+                "description": "[create/update] SEO meta description"
+              },
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[create/update] Search keywords"
+              },
+              "author": {
+                "type": "string",
+                "description": "[create] Author user sys_id or username"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update/retire] Article sys_id"
+              },
+              "article_sys_id": {
+                "type": "string",
+                "description": "[publish] Article sys_id (alias for sys_id)"
+              },
+              "include_attachments": {
+                "type": "boolean",
+                "description": "[get] Include attachment information",
+                "default": false
+              },
+              "retirement_reason": {
+                "type": "string",
+                "description": "[retire] Reason for retirement"
+              },
+              "replacement_article": {
+                "type": "string",
+                "description": "[retire] Replacement article sys_id"
+              },
+              "query": {
+                "type": "string",
+                "description": "[search] Search query text"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[search] Maximum results to return",
+                "default": 10
+              },
+              "include_content": {
+                "type": "boolean",
+                "description": "[search] Include full article content",
+                "default": false
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "kpi",
+      "displayName": "Kpi",
+      "tools": [
+        {
+          "name": "snow_define_kpi",
+          "description": "Define Key Performance Indicators for monitoring",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "kpi",
+            "monitoring",
+            "metrics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "KPI name"
+              },
+              "description": {
+                "type": "string",
+                "description": "KPI description"
+              },
+              "table": {
+                "type": "string",
+                "description": "Source table"
+              },
+              "metric": {
+                "type": "string",
+                "description": "Metric to measure"
+              },
+              "aggregation": {
+                "type": "string",
+                "description": "Aggregation function",
+                "enum": [
+                  "count",
+                  "sum",
+                  "avg",
+                  "max",
+                  "min"
+                ]
+              },
+              "conditions": {
+                "type": "string",
+                "description": "KPI conditions/filters"
+              },
+              "target": {
+                "type": "number",
+                "description": "Target value"
+              },
+              "threshold": {
+                "type": "object",
+                "description": "Threshold configuration"
+              },
+              "unit": {
+                "type": "string",
+                "description": "Unit of measurement"
+              },
+              "frequency": {
+                "type": "string",
+                "description": "Update frequency",
+                "enum": [
+                  "hourly",
+                  "daily",
+                  "weekly",
+                  "monthly"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "metric",
+              "aggregation"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "license-management",
+      "displayName": "License Management",
+      "tools": [
+        {
+          "name": "snow_manage_software_license",
+          "description": "Manage software licenses with compliance tracking and optimization",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "licenses",
+            "compliance",
+            "sam"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "license_name": {
+                "type": "string",
+                "description": "Software license name"
+              },
+              "publisher": {
+                "type": "string",
+                "description": "Software publisher/vendor"
+              },
+              "licensed_installs": {
+                "type": "number",
+                "description": "Number of licensed installations"
+              },
+              "license_type": {
+                "type": "string",
+                "description": "Type of license",
+                "enum": [
+                  "named_user",
+                  "concurrent_user",
+                  "server",
+                  "enterprise"
+                ]
+              },
+              "cost_per_license": {
+                "type": "number",
+                "description": "Cost per license"
+              },
+              "expiration_date": {
+                "type": "string",
+                "description": "License expiration (YYYY-MM-DD)"
+              },
+              "auto_renew": {
+                "type": "boolean",
+                "description": "Automatic renewal enabled"
+              }
+            },
+            "required": [
+              "license_name",
+              "publisher",
+              "licensed_installs"
+            ]
+          }
+        },
+        {
+          "name": "snow_optimize_licenses",
+          "description": "Analyze license usage and provide optimization recommendations",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "optimization",
+            "cost-reduction",
+            "sam"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "software_name": {
+                "type": "string",
+                "description": "Specific software to analyze (optional)"
+              },
+              "optimization_type": {
+                "type": "string",
+                "description": "Type of optimization",
+                "enum": [
+                  "cost_reduction",
+                  "compliance",
+                  "usage_efficiency"
+                ]
+              },
+              "threshold_percentage": {
+                "type": "number",
+                "description": "Usage threshold for optimization (default 80)"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "local-sync",
+      "displayName": "Local Sync",
+      "tools": [
+        {
+          "name": "snow_convert_to_es5",
+          "description": "Convert modern JavaScript (ES6+) to ES5 for ServiceNow Rhino engine",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "es5-conversion",
+            "validation",
+            "development"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "JavaScript code to convert to ES5"
+              },
+              "validate_only": {
+                "type": "boolean",
+                "description": "Only validate ES5 compliance without converting",
+                "default": false
+              }
+            },
+            "required": [
+              "code"
+            ]
+          }
+        },
+        {
+          "name": "snow_list_supported_artifacts",
+          "description": "List all ServiceNow artifact types supported by local sync",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "local-sync",
+            "artifact-discovery",
+            "sync-capabilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "include_details": {
+                "type": "boolean",
+                "description": "Include field mappings and sync capabilities",
+                "default": false
+              },
+              "category": {
+                "type": "string",
+                "description": "Filter by artifact category",
+                "enum": [
+                  "ui",
+                  "script",
+                  "flow",
+                  "data",
+                  "integration",
+                  "all"
+                ],
+                "default": "all"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_pull_artifact",
+          "description": "Pull a ServiceNow artifact and return its body fields as files. On stdio also writes them to disk under output_dir; on HTTP returns them inline so the caller can drop them into the portal sandbox via the native `write` tool.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "local-development",
+            "artifact-sync",
+            "editing"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of artifact to pull"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name (optional, will auto-detect if not provided)",
+                "enum": [
+                  "sp_widget",
+                  "sys_ux_page",
+                  "sys_hub_flow",
+                  "sys_script_include"
+                ]
+              },
+              "output_dir": {
+                "type": "string",
+                "description": "[stdio only] Local directory to also write the files into. Default: /tmp/serac-artifacts. Ignored on HTTP transport — use the returned `files` map and the `write` tool to land them in the sandbox."
+              }
+            },
+            "required": [
+              "sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_push_artifact",
+          "description": "Push locally edited artifact files back to ServiceNow with validation",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "local-development",
+            "artifact-sync",
+            "deployment"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of artifact to update"
+              },
+              "directory": {
+                "type": "string",
+                "description": "Directory containing edited artifact files"
+              },
+              "validate": {
+                "type": "boolean",
+                "description": "Validate before pushing (ES5, coherence)",
+                "default": true
+              },
+              "force": {
+                "type": "boolean",
+                "description": "Force push despite validation warnings",
+                "default": false
+              }
+            },
+            "required": [
+              "sys_id",
+              "directory"
+            ]
+          }
+        },
+        {
+          "name": "snow_sync_cleanup",
+          "description": "Clean up local artifact files after sync with retention policies",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cleanup",
+            "maintenance",
+            "local-development"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Artifact sys_id to clean up"
+              },
+              "cleanup_all": {
+                "type": "boolean",
+                "description": "Clean up all synced artifacts",
+                "default": false
+              },
+              "keep_backup": {
+                "type": "boolean",
+                "description": "Keep backup before deletion",
+                "default": true
+              },
+              "max_age_days": {
+                "type": "number",
+                "description": "Clean files older than N days (0 = all)",
+                "default": 0
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_sync_status",
+          "description": "Get status of locally synced artifacts including changes and validation",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "status",
+            "monitoring",
+            "local-development"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Specific artifact sys_id to check"
+              },
+              "check_all": {
+                "type": "boolean",
+                "description": "Check all synced artifacts",
+                "default": false
+              },
+              "include_file_details": {
+                "type": "boolean",
+                "description": "Include file-level details",
+                "default": false
+              },
+              "validate_coherence": {
+                "type": "boolean",
+                "description": "Run coherence validation",
+                "default": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "machine-learning",
+      "displayName": "Machine Learning",
+      "tools": [
+        {
+          "name": "snow_ai_classify",
+          "description": "Classify a piece of text into one of a caller-supplied list of categories, with a confidence score. Use for routing incoming cases/incidents into queues or assignment groups by content.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "text-classification",
+            "ai",
+            "categorization"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to classify"
+              },
+              "categories": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Available categories"
+              }
+            },
+            "required": [
+              "text",
+              "categories"
+            ]
+          }
+        },
+        {
+          "name": "snow_ml_predict",
+          "description": "Make ML prediction using trained model",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "ml-prediction",
+            "machine-learning",
+            "ai"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "model_id": {
+                "type": "string",
+                "description": "ML model ID"
+              },
+              "input_data": {
+                "type": "object",
+                "description": "Input data for prediction"
+              }
+            },
+            "required": [
+              "model_id",
+              "input_data"
+            ]
+          }
+        },
+        {
+          "name": "snow_recommendation_engine",
+          "description": "Generate recommendations based on user behavior",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "recommendations",
+            "personalization",
+            "ai"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id"
+              },
+              "context": {
+                "type": "object",
+                "description": "Context data"
+              },
+              "limit": {
+                "type": "number",
+                "default": 5
+              }
+            },
+            "required": [
+              "user_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "metrics",
+      "displayName": "Metrics",
+      "tools": [
+        {
+          "name": "snow_create_metric",
+          "description": "Define a metric (metric_definition) over a table — count rows, or sum/avg/min/max a numeric field. Stored definition is later sampled by snow_collect_metric or platform schedulers.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "metrics",
+            "analytics",
+            "monitoring"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Metric name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to measure"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field to measure"
+              },
+              "calculation": {
+                "type": "string",
+                "enum": [
+                  "count",
+                  "sum",
+                  "avg",
+                  "min",
+                  "max"
+                ],
+                "default": "count"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_operational_metrics",
+          "description": "Provides operational metrics and analytics including incident trends, resolution times, and performance indicators",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "analytics",
+            "metrics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "timeframe": {
+                "type": "string",
+                "description": "Time period for metrics",
+                "enum": [
+                  "today",
+                  "week",
+                  "month",
+                  "quarter"
+                ],
+                "default": "week"
+              },
+              "metric_types": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Types of metrics to include (leave empty for all)",
+                "examples": [
+                  [
+                    "incidents",
+                    "requests",
+                    "problems"
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "mid-server",
+      "displayName": "Mid Server",
+      "tools": [
+        {
+          "name": "snow_configure_mid_server",
+          "description": "Configure MID Server settings for on-premise integrations and Discovery",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "mid-server",
+            "on-premise",
+            "discovery",
+            "integration"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "status",
+                  "configure",
+                  "validate",
+                  "restart",
+                  "assign_application"
+                ],
+                "description": "Action to perform",
+                "default": "list"
+              },
+              "mid_server_name": {
+                "type": "string",
+                "description": "Name of the MID Server"
+              },
+              "mid_server_id": {
+                "type": "string",
+                "description": "sys_id of the MID Server"
+              },
+              "configuration": {
+                "type": "object",
+                "description": "Configuration settings to apply",
+                "properties": {
+                  "ip_address": {
+                    "type": "string",
+                    "description": "IP address restriction"
+                  },
+                  "max_threads": {
+                    "type": "number",
+                    "description": "Maximum concurrent threads"
+                  },
+                  "max_memory": {
+                    "type": "string",
+                    "description": "Maximum memory allocation (e.g., \"2048m\")"
+                  },
+                  "network_range": {
+                    "type": "string",
+                    "description": "Network range for Discovery"
+                  },
+                  "validated": {
+                    "type": "boolean",
+                    "description": "Validation status"
+                  }
+                }
+              },
+              "application_id": {
+                "type": "string",
+                "description": "Application sys_id for assign_application action"
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive MID Servers",
+                "default": false
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_manage_mid_capabilities",
+          "description": "Manage MID Server capabilities for Discovery, Orchestration, and integrations",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "mid-server",
+            "capabilities",
+            "discovery",
+            "orchestration"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "list_available",
+                  "add",
+                  "remove",
+                  "status",
+                  "recommend"
+                ],
+                "description": "Action to perform",
+                "default": "list"
+              },
+              "mid_server_name": {
+                "type": "string",
+                "description": "Name of the MID Server"
+              },
+              "mid_server_id": {
+                "type": "string",
+                "description": "sys_id of the MID Server"
+              },
+              "capability_name": {
+                "type": "string",
+                "description": "Name of the capability to add/remove"
+              },
+              "capability_id": {
+                "type": "string",
+                "description": "sys_id of the capability to add/remove"
+              },
+              "use_case": {
+                "type": "string",
+                "enum": [
+                  "discovery",
+                  "orchestration",
+                  "integration",
+                  "service_mapping",
+                  "cloud",
+                  "all"
+                ],
+                "description": "Filter capabilities by use case",
+                "default": "all"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_test_mid_connectivity",
+          "description": "Test MID Server connectivity to external endpoints and diagnose network issues",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "mid-server",
+            "connectivity",
+            "troubleshooting",
+            "network"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "test_endpoint",
+                  "test_port",
+                  "ping",
+                  "dns_lookup",
+                  "traceroute",
+                  "full_diagnostic"
+                ],
+                "description": "Type of connectivity test to perform",
+                "default": "test_endpoint"
+              },
+              "mid_server_name": {
+                "type": "string",
+                "description": "Name of the MID Server to test from"
+              },
+              "mid_server_id": {
+                "type": "string",
+                "description": "sys_id of the MID Server to test from"
+              },
+              "target_host": {
+                "type": "string",
+                "description": "Target hostname or IP address"
+              },
+              "target_port": {
+                "type": "number",
+                "description": "Target port number (for port test)",
+                "default": 443
+              },
+              "target_url": {
+                "type": "string",
+                "description": "Full URL to test (for endpoint test)"
+              },
+              "timeout_seconds": {
+                "type": "number",
+                "description": "Timeout for the test in seconds",
+                "default": 30
+              },
+              "protocol": {
+                "type": "string",
+                "enum": [
+                  "tcp",
+                  "udp",
+                  "http",
+                  "https"
+                ],
+                "description": "Protocol to use for port test",
+                "default": "tcp"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "mobile",
+      "displayName": "Mobile",
+      "tools": [
+        {
+          "name": "snow_configure_mobile_app",
+          "description": "Configure ServiceNow mobile app",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "mobile-app",
+            "configuration",
+            "mobile-development"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "app_name": {
+                "type": "string"
+              },
+              "platform": {
+                "type": "string",
+                "enum": [
+                  "ios",
+                  "android"
+                ]
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "app_name",
+              "platform"
+            ]
+          }
+        },
+        {
+          "name": "snow_configure_offline_sync",
+          "description": "Configure offline synchronization settings for mobile applications. Controls which data is available offline.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "offline-sync",
+            "mobile",
+            "data-sync"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name for offline sync"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable offline sync for this table",
+                "default": true
+              },
+              "sync_frequency": {
+                "type": "string",
+                "description": "Sync frequency: manual, hourly, daily, on_launch"
+              },
+              "query": {
+                "type": "string",
+                "description": "Query filter for synced records"
+              },
+              "max_records": {
+                "type": "number",
+                "description": "Maximum records to sync",
+                "default": 100
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Specific fields to sync (all if not specified)"
+              }
+            },
+            "required": [
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_mobile_action",
+          "description": "Creates a mobile action that users can trigger from the mobile app. Actions can navigate, execute scripts, or open forms.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "mobile-actions",
+            "mobile-ui",
+            "user-interactions"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Action name"
+              },
+              "label": {
+                "type": "string",
+                "description": "Action label displayed to users"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table this action applies to"
+              },
+              "action_type": {
+                "type": "string",
+                "description": "Action type: navigate, script, form, workflow"
+              },
+              "icon": {
+                "type": "string",
+                "description": "Icon name for the action"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script to execute (for script type)"
+              },
+              "target_url": {
+                "type": "string",
+                "description": "Target URL (for navigate type)"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition script for action visibility"
+              },
+              "order": {
+                "type": "number",
+                "description": "Display order",
+                "default": 100
+              }
+            },
+            "required": [
+              "name",
+              "label",
+              "table",
+              "action_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_mobile_layout",
+          "description": "Creates a custom mobile layout for forms and lists in the mobile app.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "mobile-layouts",
+            "mobile-ui",
+            "form-layouts"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Layout name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table this layout applies to"
+              },
+              "view": {
+                "type": "string",
+                "description": "View name (default, mobile, etc.)"
+              },
+              "layout_type": {
+                "type": "string",
+                "description": "Layout type: form, list, card"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to display in order"
+              },
+              "sections": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "fields": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "description": "Form sections with fields"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Is layout active",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "layout_type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "monitoring",
+      "displayName": "Monitoring",
+      "tools": [
+        {
+          "name": "snow_check_health",
+          "description": "Check ServiceNow instance health",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "health-check",
+            "monitoring",
+            "diagnostics"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        {
+          "name": "snow_ci_health_check",
+          "description": "Check CI health and compliance status",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "monitoring",
+            "health"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_sys_id": {
+                "type": "string"
+              },
+              "include_metrics": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "ci_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_collect_metric",
+          "description": "Sample a defined metric on-demand: runs the platform MetricBaseCollector against a metric_definition sys_id to write a fresh measurement point. Companion to snow_create_metric.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "metrics",
+            "data-collection",
+            "monitoring"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "metric_sys_id": {
+                "type": "string",
+                "description": "Metric definition sys_id"
+              }
+            },
+            "required": [
+              "metric_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_email_logs",
+          "description": "Retrieve sent/received email logs from sys_email table for monitoring and debugging",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "email",
+            "notifications",
+            "monitoring",
+            "debugging"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "sent",
+                  "received",
+                  "send-ready",
+                  "failed",
+                  "all"
+                ],
+                "description": "Email type/status filter",
+                "default": "all"
+              },
+              "recipient": {
+                "type": "string",
+                "description": "Filter by recipient email address"
+              },
+              "sender": {
+                "type": "string",
+                "description": "Filter by sender email address"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Search in email subject"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of email records to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 500
+              },
+              "since": {
+                "type": "string",
+                "description": "Get emails since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "include_body": {
+                "type": "boolean",
+                "description": "Include email body in response (can be large)",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_flow_execution_logs",
+          "description": "Retrieve Flow Designer execution logs for monitoring flow runs, debugging failures, and analyzing performance",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "flow-designer",
+            "automation",
+            "monitoring",
+            "debugging"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "complete",
+                  "error",
+                  "cancelled",
+                  "in_progress",
+                  "waiting",
+                  "all"
+                ],
+                "description": "Filter by execution status",
+                "default": "all"
+              },
+              "flow_name": {
+                "type": "string",
+                "description": "Filter by flow name (partial match)"
+              },
+              "source_table": {
+                "type": "string",
+                "description": "Filter by source table that triggered the flow (e.g., incident, change_request)"
+              },
+              "source_record": {
+                "type": "string",
+                "description": "Filter by specific source record sys_id"
+              },
+              "trigger_type": {
+                "type": "string",
+                "enum": [
+                  "record",
+                  "scheduled",
+                  "application",
+                  "inbound_email",
+                  "rest",
+                  "all"
+                ],
+                "description": "Filter by trigger type",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of execution records to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 500
+              },
+              "since": {
+                "type": "string",
+                "description": "Get executions since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "errors_only": {
+                "type": "boolean",
+                "description": "Only show failed executions with errors",
+                "default": false
+              },
+              "include_logs": {
+                "type": "boolean",
+                "description": "Include detailed execution logs (can be verbose)",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_inbound_http_logs",
+          "description": "Retrieve inbound REST API transaction logs for monitoring API usage and debugging incoming requests",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "api",
+            "rest",
+            "monitoring",
+            "debugging",
+            "http",
+            "transactions"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "success",
+                  "error",
+                  "all"
+                ],
+                "description": "Filter by response status (success = 2xx, error = 4xx/5xx)",
+                "default": "all"
+              },
+              "url_path": {
+                "type": "string",
+                "description": "Filter by request URL path (partial match)"
+              },
+              "http_method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE",
+                  "all"
+                ],
+                "description": "Filter by HTTP method",
+                "default": "all"
+              },
+              "user": {
+                "type": "string",
+                "description": "Filter by user who made the request"
+              },
+              "source_ip": {
+                "type": "string",
+                "description": "Filter by source IP address"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of log entries to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 500
+              },
+              "since": {
+                "type": "string",
+                "description": "Get logs since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "min_response_time": {
+                "type": "number",
+                "description": "Only show requests slower than this (milliseconds) - useful for performance debugging"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_logs",
+          "description": "Retrieve ServiceNow platform logs with filtering by level, source, and time range. Supports four log tables: 'syslog' (default — system log), 'syslog_app_scope' (scoped-app log), 'syslog_transaction' (HTTP transactions), 'sys_script_execution_history' (background-script execution traces).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "logs",
+            "monitoring",
+            "debugging",
+            "observability"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "log_table": {
+                "type": "string",
+                "enum": [
+                  "syslog",
+                  "syslog_app_scope",
+                  "syslog_transaction",
+                  "sys_script_execution_history"
+                ],
+                "description": "Log table to read. 'syslog' (default) for system log; 'syslog_app_scope' for scoped-app log; 'syslog_transaction' for HTTP transactions; 'sys_script_execution_history' for background-script traces.",
+                "default": "syslog"
+              },
+              "level": {
+                "type": "string",
+                "enum": [
+                  "error",
+                  "warn",
+                  "info",
+                  "debug",
+                  "all"
+                ],
+                "description": "Log level filter (applies to syslog / syslog_app_scope only)",
+                "default": "all"
+              },
+              "source": {
+                "type": "string",
+                "description": "Filter by log source (e.g., widget name, script name) — syslog / syslog_app_scope only"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of log entries to return",
+                "default": 100,
+                "minimum": 1,
+                "maximum": 1000
+              },
+              "since": {
+                "type": "string",
+                "description": "Get logs since this timestamp (ISO 8601 or relative like \"1h\", \"30m\")"
+              },
+              "search": {
+                "type": "string",
+                "description": "Search term in log messages (syslog / syslog_app_scope only)"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_outbound_http_logs",
+          "description": "Retrieve outbound HTTP request logs for monitoring REST/SOAP integrations and external API calls",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "rest",
+            "soap",
+            "monitoring",
+            "debugging",
+            "http"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "success",
+                  "error",
+                  "all"
+                ],
+                "description": "Filter by response status (success = 2xx, error = 4xx/5xx)",
+                "default": "all"
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "Filter by target endpoint URL (partial match)"
+              },
+              "rest_message": {
+                "type": "string",
+                "description": "Filter by REST Message name"
+              },
+              "http_method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE",
+                  "all"
+                ],
+                "description": "Filter by HTTP method",
+                "default": "all"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of log entries to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 500
+              },
+              "since": {
+                "type": "string",
+                "description": "Get logs since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "include_payload": {
+                "type": "boolean",
+                "description": "Include request/response body in output (can be large)",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_scheduled_job_logs",
+          "description": "Retrieve scheduled job execution history and logs for monitoring automation, identifying failures, and tracking performance",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "scheduled-jobs",
+            "automation",
+            "monitoring",
+            "debugging"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "job_name": {
+                "type": "string",
+                "description": "Filter by job name (partial match)"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "ready",
+                  "running",
+                  "complete",
+                  "error",
+                  "cancelled",
+                  "all"
+                ],
+                "description": "Filter by job state",
+                "default": "all"
+              },
+              "job_type": {
+                "type": "string",
+                "enum": [
+                  "scheduled",
+                  "run_once",
+                  "on_demand",
+                  "all"
+                ],
+                "description": "Filter by job type",
+                "default": "all"
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive/disabled jobs",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of jobs to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 200
+              },
+              "since": {
+                "type": "string",
+                "description": "Get jobs that ran since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "failed_only": {
+                "type": "boolean",
+                "description": "Only show jobs that had errors in their last run",
+                "default": false
+              },
+              "include_logs": {
+                "type": "boolean",
+                "description": "Include recent syslog entries for each job",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_slow_queries",
+          "description": "Retrieve slow database query logs for identifying performance issues, optimizing GlideRecord queries, and improving system responsiveness",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "performance",
+            "optimization",
+            "monitoring",
+            "debugging"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Filter by table name (e.g., incident, task, cmdb_ci)"
+              },
+              "min_duration": {
+                "type": "number",
+                "description": "Minimum query duration in milliseconds to include",
+                "default": 1000
+              },
+              "source": {
+                "type": "string",
+                "description": "Filter by source (script name, business rule, etc.)"
+              },
+              "user": {
+                "type": "string",
+                "description": "Filter by user who executed the query"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of slow queries to return",
+                "default": 50,
+                "minimum": 1,
+                "maximum": 500
+              },
+              "since": {
+                "type": "string",
+                "description": "Get queries since this timestamp (ISO 8601 or relative like \"1h\", \"30m\", \"7d\")"
+              },
+              "include_query_text": {
+                "type": "boolean",
+                "description": "Include the actual query/encoded query text",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_monitor_metrics",
+          "description": "Monitor system metrics and performance indicators",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "metrics",
+            "monitoring",
+            "performance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "metric_type": {
+                "type": "string",
+                "enum": [
+                  "cpu",
+                  "memory",
+                  "database",
+                  "transactions"
+                ],
+                "description": "Metric type"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "Time range for metrics"
+              }
+            },
+            "required": [
+              "metric_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_trace_execution",
+          "description": "Set up execution tracing configuration. Creates a trace session that scripts can write to. Use snow_get_script_output to retrieve trace data later.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "tracing",
+            "debugging"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "track_id": {
+                "type": "string",
+                "description": "Unique tracking ID for this trace session"
+              },
+              "include": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "What to track: scripts, rest_calls, errors, queries, all",
+                "default": [
+                  "all"
+                ]
+              },
+              "max_entries": {
+                "type": "number",
+                "description": "Maximum trace entries to store",
+                "default": 1000
+              },
+              "ttl_minutes": {
+                "type": "number",
+                "description": "Time-to-live for trace data in minutes",
+                "default": 60
+              }
+            },
+            "required": [
+              "track_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "notifications",
+      "displayName": "Notifications",
+      "tools": [
+        {
+          "name": "snow_create_email_template",
+          "description": "Create email notification template with HTML/text content and optional SMS alternate",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "email",
+            "templates",
+            "notifications"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Template name (unique identifier)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Associated table name (e.g., incident, change_request)"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject line (supports ${field} substitution)"
+              },
+              "message_html": {
+                "type": "string",
+                "description": "HTML email body content (supports ${field} substitution for dynamic values)"
+              },
+              "message_text": {
+                "type": "string",
+                "description": "Plain text email body (fallback for non-HTML email clients)"
+              },
+              "sms_alternate": {
+                "type": "string",
+                "description": "Short SMS message alternate (for SMS notifications)"
+              },
+              "content_type": {
+                "type": "string",
+                "enum": [
+                  "text/plain",
+                  "text/html"
+                ],
+                "default": "text/html",
+                "description": "Content type of the email template"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the template purpose"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether the template is active"
+              }
+            },
+            "required": [
+              "name",
+              "subject"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_notification",
+          "description": "Configure an event-driven email notification (sysevent_email_action): fires when records on a table match a condition, with recipients, subject, inline message, or a sysevent_email_template (resolved by sys_id or template name).",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "notifications",
+            "automation",
+            "email"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Notification name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to monitor"
+              },
+              "condition": {
+                "type": "string",
+                "description": "When to trigger"
+              },
+              "recipients": {
+                "type": "string",
+                "description": "Who receives notification"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject"
+              },
+              "message": {
+                "type": "string",
+                "description": "Email message"
+              },
+              "template": {
+                "type": "string",
+                "description": "Email template sys_id or name (from sysevent_email_template) - uses template instead of inline message"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "condition"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_notification_template",
+          "description": "Create reusable notification template with multi-channel support",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "templates",
+            "notifications",
+            "multi-channel"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "template_name": {
+                "type": "string",
+                "description": "Template name"
+              },
+              "template_type": {
+                "type": "string",
+                "description": "Template type",
+                "enum": [
+                  "incident",
+                  "change",
+                  "approval",
+                  "alert",
+                  "reminder"
+                ]
+              },
+              "subject_template": {
+                "type": "string",
+                "description": "Subject template with variables (e.g., \"Incident ${number} assigned\")"
+              },
+              "body_template": {
+                "type": "string",
+                "description": "Body template with variables"
+              },
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Supported channels",
+                "default": [
+                  "email"
+                ]
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Template is active",
+                "default": true
+              }
+            },
+            "required": [
+              "template_name",
+              "template_type",
+              "subject_template",
+              "body_template"
+            ]
+          }
+        },
+        {
+          "name": "snow_email_notification_manage",
+          "description": "Manage email notifications (sysevent_email_action): list, get, create, update, delete, enable/disable. Supports all notification fields including triggers, recipients, content, and advanced options.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "notifications",
+            "email",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "enable",
+                  "disable",
+                  "test",
+                  "clone"
+                ],
+                "description": "Action to perform"
+              },
+              "notification_id": {
+                "type": "string",
+                "description": "Notification sys_id or name (required for get, update, delete, enable, disable, test, clone)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name (collection) the notification applies to"
+              },
+              "name": {
+                "type": "string",
+                "description": "Notification name (display name in ServiceNow)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether notification is active",
+                "default": true
+              },
+              "action_insert": {
+                "type": "boolean",
+                "description": "Trigger on record INSERT",
+                "default": false
+              },
+              "action_update": {
+                "type": "boolean",
+                "description": "Trigger on record UPDATE",
+                "default": false
+              },
+              "event_name": {
+                "type": "string",
+                "description": "Event name to trigger on (alternative to action_insert/action_update)"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Encoded query condition for when to send (e.g., \"priority=1^state=2\")"
+              },
+              "advanced_condition": {
+                "type": "string",
+                "description": "Advanced condition script (JavaScript) - runs in addition to condition"
+              },
+              "recipient_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Field names containing recipients (e.g., [\"assigned_to\", \"caller_id\", \"opened_by\"])"
+              },
+              "recipient_groups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Group sys_ids or names to receive notification"
+              },
+              "recipient_users": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "User sys_ids or usernames to receive notification"
+              },
+              "send_self": {
+                "type": "boolean",
+                "description": "Send to user who triggered the notification",
+                "default": false
+              },
+              "exclude_delegates": {
+                "type": "boolean",
+                "description": "Exclude delegate users from receiving notification",
+                "default": false
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject (supports ${field} substitution, e.g., \"Incident ${number} assigned to you\")"
+              },
+              "message_html": {
+                "type": "string",
+                "description": "Email body HTML (supports ${field} substitution)"
+              },
+              "message_text": {
+                "type": "string",
+                "description": "Email body plain text (fallback for non-HTML clients)"
+              },
+              "template": {
+                "type": "string",
+                "description": "Email template sys_id or name - when set, uses template instead of inline message"
+              },
+              "content_type": {
+                "type": "string",
+                "enum": [
+                  "text/html",
+                  "text/plain"
+                ],
+                "description": "Email content type",
+                "default": "text/html"
+              },
+              "from": {
+                "type": "string",
+                "description": "Custom FROM address (leave empty for system default)"
+              },
+              "reply_to": {
+                "type": "string",
+                "description": "Reply-To address"
+              },
+              "importance": {
+                "type": "string",
+                "enum": [
+                  "",
+                  "low",
+                  "normal",
+                  "high"
+                ],
+                "description": "Email importance/priority header"
+              },
+              "include_attachments": {
+                "type": "boolean",
+                "description": "Include record attachments in email",
+                "default": false
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "email",
+                  "sms",
+                  "push"
+                ],
+                "description": "Notification delivery type",
+                "default": "email"
+              },
+              "push_message_only": {
+                "type": "boolean",
+                "description": "Send as push notification only (no email)",
+                "default": false
+              },
+              "sms_alternate": {
+                "type": "string",
+                "description": "SMS message content (when type=sms or as fallback)"
+              },
+              "weight": {
+                "type": "number",
+                "description": "Priority weight for notification ordering (higher = more important)",
+                "default": 0
+              },
+              "order": {
+                "type": "number",
+                "description": "Execution order (lower = runs first)",
+                "default": 100
+              },
+              "force_delivery": {
+                "type": "boolean",
+                "description": "Force delivery even if user has notifications disabled",
+                "default": false
+              },
+              "omit_watermark": {
+                "type": "boolean",
+                "description": "Omit ServiceNow watermark from email",
+                "default": false
+              },
+              "mandatory": {
+                "type": "boolean",
+                "description": "Mark as mandatory notification (cannot be unsubscribed)",
+                "default": false
+              },
+              "subscribable": {
+                "type": "boolean",
+                "description": "Allow users to subscribe/unsubscribe from this notification",
+                "default": false
+              },
+              "category": {
+                "type": "string",
+                "description": "Notification category sys_id or name"
+              },
+              "event_parm_1": {
+                "type": "boolean",
+                "description": "Use event.parm1 as recipient",
+                "default": false
+              },
+              "event_parm_2": {
+                "type": "boolean",
+                "description": "Use event.parm2 as recipient",
+                "default": false
+              },
+              "item": {
+                "type": "string",
+                "description": "Event parameter item (e.g., \"event.parm1\", \"event.parm2\")"
+              },
+              "digestable": {
+                "type": "boolean",
+                "description": "Can be included in digest emails",
+                "default": false
+              },
+              "default_digest": {
+                "type": "boolean",
+                "description": "Include in digest by default",
+                "default": false
+              },
+              "digest_type": {
+                "type": "string",
+                "enum": [
+                  "single",
+                  "digest"
+                ],
+                "description": "Single email or digest mode",
+                "default": "single"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only list active notifications",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results for list action",
+                "default": 50
+              },
+              "new_name": {
+                "type": "string",
+                "description": "Name for cloned notification (required for clone action)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_email_template_manage",
+          "description": "Unified tool for ServiceNow email template lifecycle beyond creation: list, preview, send_test, import, export, clone. Wraps sysevent_email_template.\n\nActions:\n- list — list templates, optionally filtered by table or active flag\n- preview — render the template against a sample record (subject, body, sms — no email sent)\n- send_test — send the rendered template as a real email to a specified address\n- import — create or upsert a template from a JSON payload\n- export — return the full template as a JSON payload suitable for re-import\n- clone — duplicate a template under a new name\n\nUse when: the agent needs to maintain templates after they exist — auditing them, testing rendering against a real record, sending a one-off test email, or moving a template between instances via JSON. For authoring a new template, use snow_create_email_template; for managing the event-to-template binding, use snow_email_notification_manage.\n\nReturns: template records with sys_id, name, subject, content_type, collection (table); preview/test results with rendered subject and body.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "email",
+            "templates",
+            "notifications",
+            "testing",
+            "import-export"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "preview",
+                  "send_test",
+                  "import",
+                  "export",
+                  "clone"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[preview/send_test/export/clone] Template sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "[preview/send_test/export/clone] Template name (used as identifier when sys_id is absent)"
+              },
+              "table": {
+                "type": "string",
+                "description": "[list] Filter by collection (table the template targets)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list] Only return active templates",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list] Comma-separated list of fields to return"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "[preview/send_test] Sample record sys_id to render the template against (uses the template's collection table)"
+              },
+              "sample_record_table": {
+                "type": "string",
+                "description": "[preview/send_test] Override the table the sample record lives on (defaults to the template's collection)"
+              },
+              "test_recipient": {
+                "type": "string",
+                "description": "[send_test] Email address that should receive the rendered email"
+              },
+              "template_data": {
+                "type": "object",
+                "description": "[import] Full template payload (subject, message_html, message_text, content_type, collection, sms_alternate, name)"
+              },
+              "new_name": {
+                "type": "string",
+                "description": "[clone] Name for the cloned template (required)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_emergency_broadcast",
+          "description": "Send emergency broadcast notification to all users or specific groups",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "broadcast",
+            "emergency",
+            "alerts"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "broadcast_type": {
+                "type": "string",
+                "description": "Broadcast type",
+                "enum": [
+                  "system_outage",
+                  "security_alert",
+                  "maintenance",
+                  "emergency"
+                ]
+              },
+              "target_audience": {
+                "type": "string",
+                "description": "Target audience",
+                "enum": [
+                  "all_users",
+                  "it_staff",
+                  "management",
+                  "specific_group"
+                ]
+              },
+              "group_id": {
+                "type": "string",
+                "description": "Group sys_id if target is specific_group"
+              },
+              "message": {
+                "type": "string",
+                "description": "Emergency message"
+              },
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Channels to use for broadcast",
+                "default": [
+                  "email",
+                  "push"
+                ]
+              },
+              "override_preferences": {
+                "type": "boolean",
+                "description": "Override user quiet hours/preferences",
+                "default": true
+              },
+              "require_acknowledgment": {
+                "type": "boolean",
+                "description": "Require user acknowledgment",
+                "default": false
+              }
+            },
+            "required": [
+              "broadcast_type",
+              "target_audience",
+              "message"
+            ]
+          }
+        },
+        {
+          "name": "snow_notification_analytics",
+          "description": "Analyze notification delivery rates, engagement, and effectiveness",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "analytics",
+            "monitoring",
+            "metrics"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "analytics_type": {
+                "type": "string",
+                "description": "Analytics type",
+                "enum": [
+                  "delivery_rates",
+                  "engagement",
+                  "channel_effectiveness",
+                  "template_performance"
+                ]
+              },
+              "time_period": {
+                "type": "string",
+                "description": "Analysis time period",
+                "enum": [
+                  "24_hours",
+                  "7_days",
+                  "30_days",
+                  "90_days"
+                ],
+                "default": "7_days"
+              },
+              "channel_filter": {
+                "type": "string",
+                "description": "Filter by channel"
+              },
+              "template_filter": {
+                "type": "string",
+                "description": "Filter by template sys_id"
+              }
+            },
+            "required": [
+              "analytics_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_notification_preferences",
+          "description": "Manage user notification preferences and routing rules",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "preferences",
+            "user-settings",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id"
+              },
+              "action": {
+                "type": "string",
+                "description": "Action to perform",
+                "enum": [
+                  "get",
+                  "set",
+                  "update"
+                ]
+              },
+              "preferences": {
+                "type": "object",
+                "description": "User notification preferences",
+                "properties": {
+                  "email_enabled": {
+                    "type": "boolean"
+                  },
+                  "sms_enabled": {
+                    "type": "boolean"
+                  },
+                  "push_enabled": {
+                    "type": "boolean"
+                  },
+                  "quiet_hours_start": {
+                    "type": "string",
+                    "description": "HH:MM format"
+                  },
+                  "quiet_hours_end": {
+                    "type": "string",
+                    "description": "HH:MM format"
+                  }
+                }
+              }
+            },
+            "required": [
+              "user_id",
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_schedule_notification",
+          "description": "Schedule future notification delivery with advanced scheduling options",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "scheduling",
+            "notifications",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "recipients": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Recipient user sys_ids"
+              },
+              "template": {
+                "type": "string",
+                "description": "Template sys_id or name"
+              },
+              "schedule_type": {
+                "type": "string",
+                "description": "Schedule type",
+                "enum": [
+                  "once",
+                  "recurring",
+                  "conditional"
+                ]
+              },
+              "schedule_time": {
+                "type": "string",
+                "description": "ISO timestamp for one-time or start of recurring"
+              },
+              "recurrence_pattern": {
+                "type": "string",
+                "description": "Cron expression for recurring notifications (e.g., \"0 9 * * 1-5\" for weekdays at 9am)"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Notification subject"
+              },
+              "message": {
+                "type": "string",
+                "description": "Notification message"
+              },
+              "personalization": {
+                "type": "object",
+                "description": "Template personalization data"
+              }
+            },
+            "required": [
+              "recipients",
+              "schedule_type",
+              "schedule_time"
+            ]
+          }
+        },
+        {
+          "name": "snow_send_email",
+          "description": "Send email notification via sys_email table (supports username, email, or sys_id)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "email",
+            "notifications",
+            "communication"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "to": {
+                "type": "string",
+                "description": "Recipient: username (admin), email (user@example.com), or sys_id"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject"
+              },
+              "body": {
+                "type": "string",
+                "description": "Email body (HTML supported)"
+              },
+              "body_text": {
+                "type": "string",
+                "description": "Plain text email body (alternative to body)"
+              },
+              "from": {
+                "type": "string",
+                "description": "Sender email address"
+              },
+              "reply_to": {
+                "type": "string",
+                "description": "Reply-to email address"
+              },
+              "cc": {
+                "type": "string",
+                "description": "CC recipients (comma-separated)"
+              },
+              "bcc": {
+                "type": "string",
+                "description": "BCC recipients (comma-separated)"
+              },
+              "importance": {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "normal",
+                  "high"
+                ],
+                "default": "normal"
+              }
+            },
+            "required": [
+              "to",
+              "subject"
+            ]
+          }
+        },
+        {
+          "name": "snow_send_notification",
+          "description": "Send an ad-hoc email, SMS, or push notification to a list of user sys_ids with subject and message body. For scheduled/event-driven rules use snow_create_notification instead.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "notifications",
+            "email",
+            "sms"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "users": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "subject": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "email",
+                  "sms",
+                  "push"
+                ]
+              }
+            },
+            "required": [
+              "users",
+              "subject",
+              "message"
+            ]
+          }
+        },
+        {
+          "name": "snow_send_push",
+          "description": "Push a notification (title + body) to one or more registered mobile device IDs via /api/now/v1/push/notification. Use snow_send_notification for the multi-channel email/sms/push wrapper.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "push-notifications",
+            "mobile",
+            "alerts"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "device_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "device_ids",
+              "title",
+              "body"
+            ]
+          }
+        },
+        {
+          "name": "snow_send_push_notification",
+          "description": "Sends a push notification to mobile devices. Can target specific users, groups, or all users.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "push-notifications",
+            "mobile-alerts",
+            "notifications"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Notification title"
+              },
+              "message": {
+                "type": "string",
+                "description": "Notification message"
+              },
+              "target_type": {
+                "type": "string",
+                "description": "Target type: user, group, all"
+              },
+              "target_id": {
+                "type": "string",
+                "description": "Target user or group sys_id (if target_type is user or group)"
+              },
+              "priority": {
+                "type": "string",
+                "description": "Priority: high, normal, low",
+                "default": "normal"
+              },
+              "action_type": {
+                "type": "string",
+                "description": "Action type: open_record, open_url, none"
+              },
+              "action_data": {
+                "type": "object",
+                "description": "Action data (record sys_id, URL, etc.)"
+              },
+              "sound": {
+                "type": "boolean",
+                "description": "Play notification sound",
+                "default": true
+              },
+              "badge": {
+                "type": "boolean",
+                "description": "Update badge count",
+                "default": true
+              }
+            },
+            "required": [
+              "title",
+              "message",
+              "target_type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "oauth",
+      "displayName": "Oauth",
+      "tools": [
+        {
+          "name": "snow_create_oauth_profile",
+          "description": "Create OAuth 2.0 profile for external API authentication (Jira, Azure, Salesforce, etc.)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "oauth",
+            "authentication",
+            "integration",
+            "external-api"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "OAuth profile name (e.g., \"Jira Cloud OAuth\", \"Azure AD\")"
+              },
+              "grant_type": {
+                "type": "string",
+                "enum": [
+                  "authorization_code",
+                  "client_credentials",
+                  "password",
+                  "refresh_token",
+                  "jwt_bearer"
+                ],
+                "description": "OAuth grant type",
+                "default": "client_credentials"
+              },
+              "client_id": {
+                "type": "string",
+                "description": "OAuth client ID"
+              },
+              "client_secret": {
+                "type": "string",
+                "description": "OAuth client secret (stored securely)"
+              },
+              "token_url": {
+                "type": "string",
+                "description": "Token endpoint URL (e.g., https://oauth.provider.com/token)"
+              },
+              "authorization_url": {
+                "type": "string",
+                "description": "Authorization endpoint URL (for authorization_code grant)"
+              },
+              "redirect_url": {
+                "type": "string",
+                "description": "Redirect URL after authorization"
+              },
+              "scope": {
+                "type": "string",
+                "description": "OAuth scopes (space-separated)"
+              },
+              "default_headers": {
+                "type": "object",
+                "description": "Default headers to include in token requests"
+              },
+              "send_credentials": {
+                "type": "string",
+                "enum": [
+                  "header",
+                  "body"
+                ],
+                "description": "How to send client credentials",
+                "default": "header"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the profile is active",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "client_id",
+              "token_url"
+            ]
+          }
+        },
+        {
+          "name": "snow_manage_oauth_tokens",
+          "description": "Manage OAuth tokens: view status, refresh tokens, troubleshoot authentication issues",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "oauth",
+            "tokens",
+            "authentication",
+            "troubleshooting"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "status",
+                  "refresh",
+                  "revoke",
+                  "test"
+                ],
+                "description": "Action to perform",
+                "default": "list"
+              },
+              "oauth_profile_id": {
+                "type": "string",
+                "description": "sys_id of the OAuth profile (required for status/refresh/revoke/test)"
+              },
+              "oauth_profile_name": {
+                "type": "string",
+                "description": "Name of the OAuth profile (alternative to sys_id)"
+              },
+              "include_expired": {
+                "type": "boolean",
+                "description": "Include expired tokens in list",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of tokens to return",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "operations",
+      "displayName": "Operations",
+      "tools": [
+        {
+          "name": "snow_analyze_incident",
+          "description": "Analyzes specific incidents with pattern recognition, similar incident matching, and automated resolution suggestions",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "incidents",
+            "analysis"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "incident_id": {
+                "type": "string",
+                "description": "Incident number or sys_id to analyze"
+              },
+              "include_similar": {
+                "type": "boolean",
+                "description": "Include similar incidents in analysis",
+                "default": true
+              },
+              "suggest_resolution": {
+                "type": "boolean",
+                "description": "Generate automated resolution suggestions",
+                "default": true
+              }
+            },
+            "required": [
+              "incident_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_auto_resolve_incident",
+          "description": "Attempts automated resolution of technical incidents based on known patterns and previous solutions. Includes dry-run mode for safety.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "incidents",
+            "automation"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "incident_id": {
+                "type": "string",
+                "description": "Incident number or sys_id to auto-resolve"
+              },
+              "dry_run": {
+                "type": "boolean",
+                "description": "Preview actions without executing (default: true for safety)",
+                "default": true
+              }
+            },
+            "required": [
+              "incident_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_pa_operate",
+          "description": "Unified PA operations (collect_data, export_report, generate_insights, get_scores)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "performance-analytics",
+            "data-collection",
+            "reporting",
+            "insights"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "PA operation action",
+                "enum": [
+                  "collect_data",
+                  "export_report",
+                  "generate_insights",
+                  "get_scores"
+                ]
+              },
+              "indicator": {
+                "type": "string",
+                "description": "[collect_data] Indicator to collect data for"
+              },
+              "start_date": {
+                "type": "string",
+                "description": "[collect_data] Collection start date"
+              },
+              "end_date": {
+                "type": "string",
+                "description": "[collect_data] Collection end date"
+              },
+              "recalculate": {
+                "type": "boolean",
+                "description": "[collect_data] Recalculate existing data"
+              },
+              "reportName": {
+                "type": "string",
+                "description": "[export_report] Report name to export"
+              },
+              "format": {
+                "type": "string",
+                "description": "[export_report] Export format (CSV, Excel, JSON, XML)"
+              },
+              "includeHeaders": {
+                "type": "boolean",
+                "description": "[export_report] Include column headers"
+              },
+              "maxRows": {
+                "type": "number",
+                "description": "[export_report] Maximum rows to export"
+              },
+              "table": {
+                "type": "string",
+                "description": "[generate_insights] Table to analyze"
+              },
+              "analysisType": {
+                "type": "string",
+                "description": "[generate_insights] Analysis type (trends, patterns, anomalies)"
+              },
+              "timeframe": {
+                "type": "string",
+                "description": "[generate_insights] Time period for analysis"
+              },
+              "generateRecommendations": {
+                "type": "boolean",
+                "description": "[generate_insights] Generate recommendations"
+              },
+              "indicator_sys_id": {
+                "type": "string",
+                "description": "[get_scores] Indicator sys_id"
+              },
+              "time_range": {
+                "type": "string",
+                "description": "[get_scores] Time range for scores"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "optimization",
+      "displayName": "Optimization",
+      "tools": [
+        {
+          "name": "snow_analyze_query",
+          "description": "Analyze and optimize ServiceNow queries for performance",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "performance",
+            "optimization"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name to query"
+              },
+              "query": {
+                "type": "string",
+                "description": "Encoded query string to analyze"
+              },
+              "analyze_indexes": {
+                "type": "boolean",
+                "description": "Check for index usage and recommendations",
+                "default": true
+              },
+              "suggest_optimizations": {
+                "type": "boolean",
+                "description": "Provide query optimization suggestions",
+                "default": true
+              }
+            },
+            "required": [
+              "table",
+              "query"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "orchestration",
+      "displayName": "Orchestration",
+      "tools": [
+        {
+          "name": "snow_orchestrate_development",
+          "description": "Orchestrates complex development workflows with intelligent agent coordination, shared memory, and real-time progress tracking.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "orchestration",
+            "workflow",
+            "coordination"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "objective": {
+                "type": "string",
+                "description": "Development objective (e.g., \"iPhone provisioning workflow\")"
+              },
+              "auto_spawn_agents": {
+                "type": "boolean",
+                "description": "Automatically spawn required agents",
+                "default": true
+              },
+              "shared_memory": {
+                "type": "boolean",
+                "description": "Enable shared memory between agents",
+                "default": true
+              },
+              "parallel_execution": {
+                "type": "boolean",
+                "description": "Enable parallel execution",
+                "default": true
+              },
+              "progress_monitoring": {
+                "type": "boolean",
+                "description": "Real-time progress monitoring",
+                "default": true
+              },
+              "auto_permissions": {
+                "type": "boolean",
+                "description": "Automatic permission escalation",
+                "default": false
+              },
+              "smart_discovery": {
+                "type": "boolean",
+                "description": "Smart artifact discovery and reuse",
+                "default": true
+              },
+              "live_testing": {
+                "type": "boolean",
+                "description": "Enable live testing during development",
+                "default": true
+              },
+              "auto_deploy": {
+                "type": "boolean",
+                "description": "Automatic deployment when ready",
+                "default": false
+              }
+            },
+            "required": [
+              "objective"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "pages",
+      "displayName": "Pages",
+      "tools": [
+        {
+          "name": "snow_uib_page_manage",
+          "description": "Unified UIB page management (create via Builder Toolkit, delete, add_element, remove_element)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "pages",
+            "components"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Page management action",
+                "enum": [
+                  "create",
+                  "delete",
+                  "add_element",
+                  "remove_element"
+                ]
+              },
+              "experience_id": {
+                "type": "string",
+                "description": "[create] Experience sys_id (required for create)"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create] Page name (internal identifier)"
+              },
+              "title": {
+                "type": "string",
+                "description": "[create] Page title (display name)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create] Page description"
+              },
+              "route_type": {
+                "type": "string",
+                "description": "[create] Route type (default: \"template-sow\")"
+              },
+              "template_id": {
+                "type": "string",
+                "description": "[create] Template sys_id for page layout"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[create] Required roles to access page"
+              },
+              "public": {
+                "type": "boolean",
+                "description": "[create] Make page publicly accessible"
+              },
+              "page_id": {
+                "type": "string",
+                "description": "[delete/add_element/remove_element] Page sys_id"
+              },
+              "force": {
+                "type": "boolean",
+                "description": "[delete/remove_element] Force operation ignoring dependencies"
+              },
+              "delete_dependencies": {
+                "type": "boolean",
+                "description": "[delete] Delete associated dependencies"
+              },
+              "component": {
+                "type": "string",
+                "description": "[add_element] Component name or sys_id"
+              },
+              "container_id": {
+                "type": "string",
+                "description": "[add_element] Parent container element ID"
+              },
+              "position": {
+                "type": "number",
+                "description": "[add_element] Element position in container"
+              },
+              "properties": {
+                "type": "object",
+                "description": "[add_element] Component properties"
+              },
+              "data_broker": {
+                "type": "string",
+                "description": "[add_element] Data broker sys_id"
+              },
+              "responsive_config": {
+                "type": "object",
+                "description": "[add_element] Responsive layout config"
+              },
+              "conditional_display": {
+                "type": "string",
+                "description": "[add_element] Condition script for visibility"
+              },
+              "css_classes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[add_element] CSS classes to apply"
+              },
+              "inline_styles": {
+                "type": "object",
+                "description": "[add_element] Inline styles config"
+              },
+              "element_id": {
+                "type": "string",
+                "description": "[remove_element] Page element sys_id to remove"
+              },
+              "check_dependencies": {
+                "type": "boolean",
+                "description": "[remove_element] Check for dependent elements"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "performance",
+      "displayName": "Performance",
+      "tools": [
+        {
+          "name": "snow_cache_get",
+          "description": "Look up a value from the in-memory tool cache by key. Returns null with cached=false on miss. Pairs with snow_cache_set for de-duplicating expensive calls within a session.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "caching",
+            "performance",
+            "optimization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "Cache key"
+              }
+            },
+            "required": [
+              "key"
+            ]
+          }
+        },
+        {
+          "name": "snow_cache_set",
+          "description": "Store a string value in the in-memory tool cache under a key, with a TTL in seconds (default 3600). Read back with snow_cache_get within the same session.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "caching",
+            "performance",
+            "optimization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "Cache key"
+              },
+              "value": {
+                "type": "string",
+                "description": "Value to cache"
+              },
+              "ttl_seconds": {
+                "type": "number",
+                "default": 3600
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ]
+          }
+        },
+        {
+          "name": "snow_rate_limit",
+          "description": "Apply rate limiting to operations",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "rate-limiting",
+            "performance",
+            "optimization"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "requests_per_second": {
+                "type": "number",
+                "default": 10
+              },
+              "burst_size": {
+                "type": "number",
+                "default": 20
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "performance-analytics",
+      "displayName": "Performance Analytics",
+      "tools": [
+        {
+          "name": "snow_pa_indicator_manage",
+          "description": "Unified tool for ServiceNow Performance Analytics indicator definitions and their dimensional breakdowns. Wraps the pa_indicators, pa_breakdowns, pa_indicator_breakdowns (join), pa_widgets, and pa_scores tables on the platform.\n\nActions:\n- list — list indicators, optionally filtered by cube\n- get — retrieve a single indicator by sys_id or name (includes related widget and breakdown counts)\n- create — create a new indicator (name, aggregate, precision, forecast_base_periods, forecast_periods required; cube optional but typical)\n- update — patch indicator fields\n- delete — remove an indicator (and optionally its dependent pa_indicator_breakdowns links)\n- add_breakdown — attach a dimensional breakdown to an indicator (writes pa_breakdowns + pa_indicator_breakdowns join)\n- list_breakdowns — list breakdowns for a given indicator (via pa_indicator_breakdowns) or globally\n\nUse when: the agent needs to manage KPI/indicator definitions, attach dimensional slicers (assignment_group, priority, location, etc.) to existing indicators, or audit which indicators a cube feeds.\n\nReturns: indicator records with sys_id, name, label, cube, aggregate, field, frequency, unit, precision. For breakdowns, returns sys_id, name, facts_table, field, and matrix_source. Companion tools: snow_pa_create for full PA artifact creation (widgets, thresholds, scheduled reports) and snow_pa_operate for collecting and querying PA scores.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "performance-analytics",
+            "kpi",
+            "indicators",
+            "breakdowns",
+            "reporting"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "add_breakdown",
+                  "list_breakdowns"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/update/delete/add_breakdown/list_breakdowns] Indicator sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "[get/create/update] Indicator name (used as identifier when sys_id is absent)"
+              },
+              "label": {
+                "type": "string",
+                "description": "[create/update] Indicator display label (defaults to name on create)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/update] Indicator description"
+              },
+              "cube": {
+                "type": "string",
+                "description": "[create/update] pa_cubes sys_id that defines the indicator's facts table and conditions (the cube is the source/facts wrapper on pa_indicators; use snow_pa_create to author cubes)"
+              },
+              "script": {
+                "type": "string",
+                "description": "[create/update] pa_scripts sys_id when the indicator is scripted"
+              },
+              "aggregate": {
+                "type": "string",
+                "description": "[create/update] Aggregation function (inherited from pa_indicators_definition)",
+                "enum": [
+                  "COUNT",
+                  "SUM",
+                  "AVG",
+                  "MIN",
+                  "MAX",
+                  "COUNT_DISTINCT"
+                ]
+              },
+              "field": {
+                "type": "string",
+                "description": "[create/update] Field on the cube's facts table to aggregate (omit for COUNT)"
+              },
+              "conditions": {
+                "type": "string",
+                "description": "[create/update] Encoded query that filters the facts table rows (inherited from pa_indicators_definition)"
+              },
+              "unit": {
+                "type": "string",
+                "description": "[create/update] Unit of measurement (count, hours, percent, etc.)"
+              },
+              "frequency": {
+                "type": "string",
+                "description": "[create/update] Collection frequency",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "quarterly",
+                  "yearly",
+                  "hourly"
+                ]
+              },
+              "direction": {
+                "type": "string",
+                "description": "[create/update] Whether higher or lower is better",
+                "enum": [
+                  "maximize",
+                  "minimize"
+                ]
+              },
+              "formula": {
+                "type": "string",
+                "description": "[create/update] Formula expression for derived indicators"
+              },
+              "precision": {
+                "type": "number",
+                "description": "[create] Decimal precision (mandatory on pa_indicators)",
+                "default": 0
+              },
+              "forecast_base_periods": {
+                "type": "number",
+                "description": "[create] Number of base periods used for forecasting (mandatory on pa_indicators)",
+                "default": 12
+              },
+              "forecast_periods": {
+                "type": "number",
+                "description": "[create] Number of periods to forecast (mandatory on pa_indicators)",
+                "default": 6
+              },
+              "breakdown_name": {
+                "type": "string",
+                "description": "[add_breakdown] Breakdown name"
+              },
+              "breakdown_table": {
+                "type": "string",
+                "description": "[add_breakdown] Table on which the breakdown is evaluated"
+              },
+              "breakdown_field": {
+                "type": "string",
+                "description": "[add_breakdown] Field used to group the indicator (e.g. assignment_group, priority)"
+              },
+              "related_field": {
+                "type": "string",
+                "description": "[add_breakdown] Related field path for cross-table breakdowns"
+              },
+              "matrix_source": {
+                "type": "boolean",
+                "description": "[add_breakdown] Whether this is a matrix breakdown",
+                "default": false
+              },
+              "cascade": {
+                "type": "boolean",
+                "description": "[delete] Also remove dependent pa_breakdowns rows that reference this indicator",
+                "default": false
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list/list_breakdowns] Only return active records",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_breakdowns] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/list_breakdowns] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "permissions",
+      "displayName": "Permissions",
+      "tools": [
+        {
+          "name": "snow_escalate_permissions",
+          "description": "Escalate user permissions with approval workflow and time-based access controls",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "escalation",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id or username"
+              },
+              "role": {
+                "type": "string",
+                "description": "Role to grant (admin, security_admin, etc.)"
+              },
+              "duration": {
+                "type": "number",
+                "description": "Access duration in hours (0 = permanent)"
+              },
+              "justification": {
+                "type": "string",
+                "description": "Business justification for escalation"
+              },
+              "approver": {
+                "type": "string",
+                "description": "Approver sys_id or username"
+              },
+              "require_approval": {
+                "type": "boolean",
+                "description": "Require approval before granting"
+              }
+            },
+            "required": [
+              "user_id",
+              "role",
+              "justification"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "platform",
+      "displayName": "Platform",
+      "tools": [
+        {
+          "name": "snow_create_business_rule",
+          "description": "Create server-side business rule with full configuration options (ES5 only for scripts!)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "business-rules",
+            "server-side",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Business rule name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name (e.g., incident, task, sys_user)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of what this business rule does"
+              },
+              "when": {
+                "type": "string",
+                "enum": [
+                  "before",
+                  "after",
+                  "async",
+                  "display"
+                ],
+                "default": "before",
+                "description": "When to execute: before (before DB), after (after DB), async (scheduled), display (form load)"
+              },
+              "order": {
+                "type": "number",
+                "default": 100,
+                "description": "Execution order (lower = runs first). Default: 100"
+              },
+              "insert": {
+                "type": "boolean",
+                "default": false,
+                "description": "Run on insert operations"
+              },
+              "update": {
+                "type": "boolean",
+                "default": false,
+                "description": "Run on update operations"
+              },
+              "delete": {
+                "type": "boolean",
+                "default": false,
+                "description": "Run on delete operations"
+              },
+              "query": {
+                "type": "boolean",
+                "default": false,
+                "description": "Run on query operations"
+              },
+              "filter_condition": {
+                "type": "string",
+                "description": "Encoded query filter (e.g., \"active=true^priority=1\"). Record must match this to trigger the rule."
+              },
+              "condition": {
+                "type": "string",
+                "description": "Script condition that must return true (ES5 only!). E.g., \"current.priority == 1\""
+              },
+              "role_conditions": {
+                "type": "string",
+                "description": "Comma-separated role sys_ids. Only users with these roles trigger the rule."
+              },
+              "script": {
+                "type": "string",
+                "description": "Script to execute (ES5 ONLY! No const/let/arrow functions). Use current/previous objects."
+              },
+              "abort_action": {
+                "type": "boolean",
+                "default": false,
+                "description": "Abort the database action (only works with \"before\" rules)"
+              },
+              "add_message": {
+                "type": "boolean",
+                "default": false,
+                "description": "Add an info message to the user"
+              },
+              "message": {
+                "type": "string",
+                "description": "Message text to display (requires add_message=true)"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether the business rule is active"
+              },
+              "access": {
+                "type": "string",
+                "enum": [
+                  "package_private",
+                  "public"
+                ],
+                "default": "package_private",
+                "description": "Access level for the business rule"
+              },
+              "application_scope": {
+                "type": "string",
+                "description": "Application scope sys_id (leave empty for global)"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_choice",
+          "description": "Create choice list value for field",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "choices",
+            "fields",
+            "customization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "element": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "value": {
+                "type": "string",
+                "description": "Choice value"
+              },
+              "label": {
+                "type": "string",
+                "description": "Choice label"
+              },
+              "sequence": {
+                "type": "number",
+                "description": "Display order"
+              },
+              "inactive": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "required": [
+              "table",
+              "element",
+              "value",
+              "label"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_client_script",
+          "description": "Create client-side script for form with type and field targeting",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "client-scripts",
+            "form-scripts",
+            "ui-automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Client Script name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to attach script to"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "onLoad",
+                  "onChange",
+                  "onSubmit",
+                  "onCellEdit"
+                ],
+                "description": "Script type",
+                "default": "onLoad"
+              },
+              "script": {
+                "type": "string",
+                "description": "Client script code (runs in browser, ES5 compatible)"
+              },
+              "field_name": {
+                "type": "string",
+                "description": "Field name (required for onChange/onCellEdit)"
+              },
+              "ui_type": {
+                "type": "string",
+                "enum": [
+                  "desktop",
+                  "mobile",
+                  "both"
+                ],
+                "description": "UI type to run on",
+                "default": "both"
+              },
+              "description": {
+                "type": "string",
+                "description": "Script description"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition script (must return true/false)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate immediately",
+                "default": true
+              },
+              "global": {
+                "type": "boolean",
+                "description": "Apply to all forms (not just current table)",
+                "default": false
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "type",
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_data_policy",
+          "description": "Create a Data Policy (sys_data_policy2) on a table — server-side equivalent of UI Policies, enforced for API/import writes. reverse_if_false re-applies the inverse when the condition turns false. Add field-level rules with snow_create_data_policy_rule.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "data-policies",
+            "validation",
+            "governance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "short_description": {
+                "type": "string",
+                "description": "Policy description"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "condition": {
+                "type": "string",
+                "description": "When to apply"
+              },
+              "reverse_if_false": {
+                "type": "boolean",
+                "default": true
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "short_description",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_data_policy_rule",
+          "description": "Add a field rule to an existing Data Policy: mark the field as mandatory and/or read-only when the parent policy's condition is true. Writes to sys_data_policy_rule.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "data-policies",
+            "rules",
+            "validation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "data_policy_sys_id": {
+                "type": "string",
+                "description": "Data policy sys_id"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "mandatory": {
+                "type": "boolean",
+                "description": "Make mandatory"
+              },
+              "readonly": {
+                "type": "boolean",
+                "description": "Make readonly"
+              }
+            },
+            "required": [
+              "data_policy_sys_id",
+              "field"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_field",
+          "description": "Add a new column to a table by writing to sys_dictionary: column name, label, internal_type (string, integer, reference, etc.), and — for reference fields — the referenced table. Optional max_length and mandatory flag.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "fields",
+            "schema",
+            "customization"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "column_name": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "column_label": {
+                "type": "string",
+                "description": "Field label"
+              },
+              "internal_type": {
+                "type": "string",
+                "description": "Field type (string, integer, reference, etc.)"
+              },
+              "reference": {
+                "type": "string",
+                "description": "Reference table (for reference fields)"
+              },
+              "max_length": {
+                "type": "number",
+                "description": "Maximum length"
+              },
+              "mandatory": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "required": [
+              "table",
+              "column_name",
+              "internal_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_processor",
+          "description": "Create script processor (ES5 only!)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "processors",
+            "scripted-rest",
+            "api"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Processor name"
+              },
+              "path": {
+                "type": "string",
+                "description": "URL path"
+              },
+              "script": {
+                "type": "string",
+                "description": "Processing script (ES5 only!)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "script",
+                  "scripted_rest"
+                ],
+                "default": "script"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "path",
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_script_include",
+          "description": "Create reusable Script Include with client-callable support",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "script-includes",
+            "code-reuse",
+            "api"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Script Include name (CamelCase recommended)"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script code (ES5 only, function constructor pattern)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Script Include description"
+              },
+              "client_callable": {
+                "type": "boolean",
+                "description": "Allow client-side scripts to call this Script Include",
+                "default": false
+              },
+              "access": {
+                "type": "string",
+                "enum": [
+                  "public",
+                  "package_private"
+                ],
+                "description": "Access level",
+                "default": "package_private"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate immediately",
+                "default": true
+              },
+              "api_name": {
+                "type": "string",
+                "description": "API name for client-callable (defaults to name)"
+              },
+              "validate_es5": {
+                "type": "boolean",
+                "description": "Validate ES5 compliance before creation",
+                "default": true
+              },
+              "script_file": {
+                "type": "string",
+                "description": "Path to local script file. File content will be used as the script. Alternative to inline script parameter."
+              },
+              "upsert": {
+                "type": "boolean",
+                "description": "If true and a Script Include with the same name already exists, update it instead of returning an error.",
+                "default": false
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_table",
+          "description": "Create a new table (sys_db_object) with a name and label. Optionally extends a parent table (super_class) for inheritance, and toggles is_extendable. Add columns with snow_create_field.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "tables",
+            "schema",
+            "customization"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "label": {
+                "type": "string",
+                "description": "Table label"
+              },
+              "extends_table": {
+                "type": "string",
+                "description": "Parent table to extend"
+              },
+              "is_extendable": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "label"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ui_action",
+          "description": "Create UI Action (button, context menu, form link) with client/server scripts",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-actions",
+            "buttons",
+            "form-controls"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "UI Action name (button label)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to attach action to"
+              },
+              "action_name": {
+                "type": "string",
+                "description": "Internal action name (alphanumeric, no spaces)"
+              },
+              "script": {
+                "type": "string",
+                "description": "Client or server script to execute"
+              },
+              "description": {
+                "type": "string",
+                "description": "Action description"
+              },
+              "action_type": {
+                "type": "string",
+                "enum": [
+                  "form_button",
+                  "form_link",
+                  "form_context_menu",
+                  "list_choice",
+                  "list_banner_button",
+                  "list_bottom_button"
+                ],
+                "description": "Where the action appears",
+                "default": "form_button"
+              },
+              "client": {
+                "type": "boolean",
+                "description": "Execute as client script",
+                "default": true
+              },
+              "onclick": {
+                "type": "string",
+                "description": "Client-side onclick handler"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition script (must return true/false)"
+              },
+              "order": {
+                "type": "number",
+                "description": "Display order",
+                "default": 100
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate immediately",
+                "default": true
+              },
+              "show_insert": {
+                "type": "boolean",
+                "description": "Show on new record forms",
+                "default": true
+              },
+              "show_update": {
+                "type": "boolean",
+                "description": "Show on existing record forms",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "action_name",
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ui_page",
+          "description": "Create custom UI Page with Jelly/HTML template and processing script",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-pages",
+            "custom-ui",
+            "jelly-templates"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "UI Page name (alphanumeric with underscores)"
+              },
+              "html": {
+                "type": "string",
+                "description": "HTML/Jelly template content"
+              },
+              "description": {
+                "type": "string",
+                "description": "Page description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Page category for organization"
+              },
+              "processing_script": {
+                "type": "string",
+                "description": "Server-side processing script (ES5)"
+              },
+              "client_script": {
+                "type": "string",
+                "description": "Client-side JavaScript"
+              },
+              "direct": {
+                "type": "boolean",
+                "description": "Direct rendering (skip standard UI)",
+                "default": false
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate immediately",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "html"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ui_policy",
+          "description": "Create UI Policy for form field control (visibility, mandatory, readonly)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-policies",
+            "form-control",
+            "declarative-logic"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "UI Policy name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to attach policy to"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition (encoded query or script)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Policy description"
+              },
+              "on_load": {
+                "type": "boolean",
+                "description": "Run on form load",
+                "default": true
+              },
+              "reverse_if_false": {
+                "type": "boolean",
+                "description": "Reverse actions when condition is false",
+                "default": true
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate immediately",
+                "default": true
+              },
+              "actions": {
+                "type": "array",
+                "description": "UI Policy actions. Each action controls one field.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string",
+                      "description": "Field to control (ServiceNow column name, e.g. 'close_notes'). Alias: 'field_name'."
+                    },
+                    "visible": {
+                      "type": "boolean",
+                      "description": "Set visibility. true = visible, false = hidden. Omit to leave unchanged."
+                    },
+                    "mandatory": {
+                      "type": "boolean",
+                      "description": "Set mandatory state. true = required, false = optional. Omit to leave unchanged."
+                    },
+                    "readonly": {
+                      "type": "boolean",
+                      "description": "Set read-only state. true = read-only, false = editable. Omit to leave unchanged."
+                    },
+                    "cleared": {
+                      "type": "boolean",
+                      "description": "Clear the field value when the policy condition is true. Default: false."
+                    }
+                  },
+                  "required": [
+                    "field"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "actions"
+            ]
+          }
+        },
+        {
+          "name": "snow_disable_business_rule",
+          "description": "Flip a business rule's active flag to false by sys_id (patches sys_script). Disabling stops it from firing without deleting the rule — pair with the same patch toggling active=true to re-enable.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "business-rules",
+            "management",
+            "configuration"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "rule_sys_id": {
+                "type": "string",
+                "description": "Business rule sys_id"
+              }
+            },
+            "required": [
+              "rule_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "playbooks",
+      "displayName": "Playbooks",
+      "tools": [
+        {
+          "name": "snow_execute_security_playbook",
+          "description": "Execute automated security response playbook with orchestrated actions",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "execution",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "playbook_id": {
+                "type": "string",
+                "description": "Security playbook sys_id"
+              },
+              "incident_id": {
+                "type": "string",
+                "description": "Related security incident sys_id"
+              },
+              "execution_mode": {
+                "type": "string",
+                "description": "Execution mode",
+                "enum": [
+                  "automatic",
+                  "semi_automatic",
+                  "manual_approval"
+                ]
+              },
+              "parameters": {
+                "type": "object",
+                "description": "Playbook execution parameters"
+              }
+            },
+            "required": [
+              "playbook_id",
+              "incident_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_sir_playbook_orchestrate",
+          "description": "Unified tool for orchestrating Security Incident Response (SIR) playbooks on sn_si_playbook and sn_si_playbook_task. Drives a playbook step-by-step against an incident, tracking task instance state from pending through complete.\n\nActions:\n- list_playbooks — list playbook definitions on sn_si_playbook (catalogue of available procedures)\n- start — start a playbook against an incident (creates the run-time task instances and marks the first step in_progress)\n- list_running — list currently running playbook task instances, optionally filtered by incident\n- get_status — get the full step list for a running playbook on an incident with each step's state\n- advance_step — mark the current step complete (optionally skip) and move the next pending step to in_progress\n- cancel — cancel all remaining pending/in-progress steps for a playbook on an incident\n\nUse when: the agent needs full step-by-step state management around a SOAR playbook rather than the fire-and-forget behaviour of snow_execute_security_playbook. Companion tools: snow_execute_security_playbook (trigger only), snow_sir_incident_manage (manage the parent incident), snow_sir_evidence_manage (attach evidence to the incident).\n\nPlugin gating: requires com.snc.security_incident. A 404 on sn_si_playbook is surfaced with the required plugin name.\n\nReturns: action-specific data. list_playbooks returns playbook definitions with sys_id, name, description, category. start returns the created task instances with their order. get_status returns each step's sys_id, name, state, assigned_to, started_at, completed_at. advance_step / cancel return the post-update state snapshot.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sir",
+            "soar",
+            "playbooks",
+            "orchestration",
+            "incident-response"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Orchestration action to perform",
+                "enum": [
+                  "list_playbooks",
+                  "start",
+                  "list_running",
+                  "get_status",
+                  "advance_step",
+                  "cancel"
+                ]
+              },
+              "playbook_sys_id": {
+                "type": "string",
+                "description": "[start] sys_id of the playbook definition on sn_si_playbook"
+              },
+              "playbook_name": {
+                "type": "string",
+                "description": "[start] Name of the playbook (alternative to playbook_sys_id)"
+              },
+              "incident_sys_id": {
+                "type": "string",
+                "description": "[start/list_running/get_status/advance_step/cancel] sys_id of the parent SIR incident (sn_si_incident)"
+              },
+              "incident_number": {
+                "type": "string",
+                "description": "[start/get_status/advance_step/cancel] SIR incident number (e.g. SIR0010001), alternative to incident_sys_id"
+              },
+              "task_sys_id": {
+                "type": "string",
+                "description": "[advance_step] sys_id of the specific task instance to advance (optional — defaults to the current in-progress step)"
+              },
+              "category": {
+                "type": "string",
+                "description": "[list_playbooks] Filter playbooks by category"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_playbooks] Only return active playbooks",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_playbooks/list_running] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_playbooks/list_running/get_status] Comma-separated list of fields to return"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[start] sys_user sys_id assigned to drive the playbook (defaults to incident's assignee)"
+              },
+              "skip": {
+                "type": "boolean",
+                "description": "[advance_step] Skip the current step instead of marking it complete",
+                "default": false
+              },
+              "step_note": {
+                "type": "string",
+                "description": "[advance_step] Work note attached to the completed/skipped step"
+              },
+              "cancel_reason": {
+                "type": "string",
+                "description": "[cancel] Reason for cancelling the playbook run"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "policies",
+      "displayName": "Policies",
+      "tools": [
+        {
+          "name": "snow_create_security_policy",
+          "description": "Creates security policies for access control and data protection. Configures enforcement levels, scope, and rule sets.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "configuration",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Security policy name"
+              },
+              "type": {
+                "type": "string",
+                "description": "Policy type (access, data, network, etc.)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Policy description"
+              },
+              "enforcement": {
+                "type": "string",
+                "description": "Enforcement level (strict, moderate, advisory)"
+              },
+              "scope": {
+                "type": "string",
+                "description": "Policy scope (global, application, table)"
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Security rules and conditions"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Policy active status"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "rules"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_security_policies",
+          "description": "Lists existing security policies and rules with filtering by category and active status.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "security-audit",
+            "policy-discovery",
+            "compliance"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "type": "string",
+                "description": "Policy category filter"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Filter by active status"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_grc_policy_manage",
+          "description": "Unified tool for ServiceNow GRC policy authoring and linkage. Wraps the sn_compliance_policy, sn_compliance_policy_statement, sn_compliance_control_objective, and sn_compliance_control tables that ship with the GRC: Policy and Compliance Management plugin.\n\nActions:\n- list_policies — list policies, optionally filtered by state, type, or framework\n- get_policy — retrieve a single policy by sys_id (includes counts of linked statements)\n- create_policy — draft a new policy with owner, type, and effective date\n- create_statement — add a policy statement (clause / requirement) to an existing policy\n- link_to_control — link a policy statement to a control objective, attaching the policy intent to the control framework\n- list_controls — list controls, optionally filtered by objective or active flag\n\nUse when: the agent needs to draft a new GRC policy, break it into statements, and connect those statements to the control objectives that operationalise them. For the downstream exception / evidence / attestation flow on individual controls, use snow_compliance_manage; for the generic security policy record, use snow_create_security_policy.\n\nReturns: policy rows with sys_id, owner, type, state, effective_date; statement rows with sys_id, policy reference, statement_text; control objective and control rows with sys_id, name, and reference linkage. GRC plugin gating: the first call against these tables will surface a clear error if the GRC: Policy and Compliance Management plugin is not active on the target instance.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "grc",
+            "policy",
+            "compliance",
+            "controls",
+            "statements"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_policies",
+                  "get_policy",
+                  "create_policy",
+                  "create_statement",
+                  "link_to_control",
+                  "list_controls"
+                ]
+              },
+              "policy_sys_id": {
+                "type": "string",
+                "description": "[get_policy/create_statement] Policy sys_id"
+              },
+              "statement_sys_id": {
+                "type": "string",
+                "description": "[link_to_control] Statement sys_id (sn_compliance_policy_statement)"
+              },
+              "objective_sys_id": {
+                "type": "string",
+                "description": "[link_to_control/list_controls] Control objective sys_id (sn_compliance_control_objective)"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_policies] Filter by policy state",
+                "enum": [
+                  "draft",
+                  "review",
+                  "approved",
+                  "published",
+                  "retired"
+                ]
+              },
+              "policy_type": {
+                "type": "string",
+                "description": "[list_policies] Filter by policy type label"
+              },
+              "framework": {
+                "type": "string",
+                "description": "[list_policies] Filter by compliance framework (SOX, GDPR, HIPAA, ISO27001, etc.)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_policies/list_controls] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_policies/get_policy/list_controls] Comma-separated list of fields to return"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create_policy] Policy name / title (required)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create_policy] Policy description / scope"
+              },
+              "owner": {
+                "type": "string",
+                "description": "[create_policy] Policy owner sys_user sys_id"
+              },
+              "type": {
+                "type": "string",
+                "description": "[create_policy] Policy type label (information_security, privacy, operational, hr, financial, custom)"
+              },
+              "effective_date": {
+                "type": "string",
+                "description": "[create_policy] ISO date string (YYYY-MM-DD) when the policy takes effect"
+              },
+              "review_date": {
+                "type": "string",
+                "description": "[create_policy] ISO date string (YYYY-MM-DD) when the policy is next due for review"
+              },
+              "statement_text": {
+                "type": "string",
+                "description": "[create_statement] Statement / clause text"
+              },
+              "statement_short_description": {
+                "type": "string",
+                "description": "[create_statement] Short description for the statement"
+              },
+              "statement_number": {
+                "type": "string",
+                "description": "[create_statement] Optional clause number or identifier (e.g. 4.1.2)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_controls] Only return active controls",
+                "default": false
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "prediction",
+      "displayName": "Prediction",
+      "tools": [
+        {
+          "name": "snow_predictive_analysis",
+          "description": "Provides predictive analysis for incident volumes, system failures, and resource issues based on historical patterns",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "prediction",
+            "analytics"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "prediction_type": {
+                "type": "string",
+                "description": "Type of prediction",
+                "enum": [
+                  "incident_volume",
+                  "system_failure",
+                  "resource_exhaustion",
+                  "user_impact"
+                ]
+              },
+              "timeframe": {
+                "type": "string",
+                "description": "Prediction timeframe",
+                "enum": [
+                  "day",
+                  "week",
+                  "month"
+                ],
+                "default": "week"
+              }
+            },
+            "required": [
+              "prediction_type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "predictive-intelligence",
+      "displayName": "Predictive Intelligence",
+      "tools": [
+        {
+          "name": "snow_activate_pi_solution",
+          "description": "✅ Activate trained ServiceNow Predictive Intelligence solution for production use. Enables predictions on records.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "activation",
+            "native-ml",
+            "production"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "solution_id": {
+                "type": "string",
+                "description": "Solution sys_id or name to activate"
+              },
+              "auto_apply": {
+                "type": "boolean",
+                "description": "Automatically apply predictions to new records",
+                "default": false
+              },
+              "confidence_threshold": {
+                "type": "number",
+                "description": "Minimum confidence for auto-apply (0.0-1.0)",
+                "default": 0.7
+              }
+            },
+            "required": [
+              "solution_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_pi_solution",
+          "description": "🤖 Create native ServiceNow Predictive Intelligence solution definition. Builds ML models that run INSIDE ServiceNow (requires PI license). Use for classification, regression, similarity, or clustering.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "creation",
+            "native-ml",
+            "solution-definition"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Solution name (e.g., \"Incident Category Predictor\")"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to train on (e.g., \"incident\", \"change_request\")"
+              },
+              "solution_type": {
+                "type": "string",
+                "enum": [
+                  "classification",
+                  "regression",
+                  "similarity",
+                  "clustering"
+                ],
+                "description": "Type of ML solution",
+                "default": "classification"
+              },
+              "output_field": {
+                "type": "string",
+                "description": "Field to predict (e.g., \"category\", \"assignment_group\", \"priority\")"
+              },
+              "input_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to use as inputs (e.g., [\"short_description\", \"description\", \"urgency\"])"
+              },
+              "training_filter": {
+                "type": "string",
+                "description": "Query to filter training data (e.g., \"stateIN1,2,3^sys_created_on>=javascript:gs.daysAgoStart(90)\")",
+                "default": "active=true"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of what this solution does"
+              },
+              "auto_retrain": {
+                "type": "boolean",
+                "description": "Enable automatic retraining",
+                "default": true
+              },
+              "retrain_frequency": {
+                "type": "string",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly"
+                ],
+                "description": "How often to retrain automatically",
+                "default": "weekly"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "output_field",
+              "input_fields"
+            ]
+          }
+        },
+        {
+          "name": "snow_list_pi_solutions",
+          "description": "📋 List all ServiceNow Predictive Intelligence solutions with status and metrics.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "listing",
+            "discovery",
+            "monitoring"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active solutions",
+                "default": false
+              },
+              "include_metrics": {
+                "type": "boolean",
+                "description": "Include detailed metrics for each solution",
+                "default": true
+              },
+              "solution_type": {
+                "type": "string",
+                "enum": [
+                  "all",
+                  "classification",
+                  "regression",
+                  "similarity",
+                  "clustering"
+                ],
+                "description": "Filter by solution type",
+                "default": "all"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_monitor_pi_training",
+          "description": "📊 Monitor ServiceNow Predictive Intelligence training progress. Shows status, metrics, and completion estimate.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "monitoring",
+            "training",
+            "metrics"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "solution_id": {
+                "type": "string",
+                "description": "Solution sys_id or name to monitor"
+              },
+              "include_metrics": {
+                "type": "boolean",
+                "description": "Include detailed training metrics",
+                "default": true
+              }
+            },
+            "required": [
+              "solution_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_train_pi_solution",
+          "description": "🎯 Train native ServiceNow Predictive Intelligence solution. Starts ML training INSIDE ServiceNow (requires PI license). Training typically takes 10-30 minutes.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "training",
+            "native-ml",
+            "model-building"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "solution_id": {
+                "type": "string",
+                "description": "Solution sys_id or name to train"
+              },
+              "force_retrain": {
+                "type": "boolean",
+                "description": "Force retraining even if already trained",
+                "default": false
+              },
+              "training_row_limit": {
+                "type": "number",
+                "description": "Maximum rows to use for training (default: 10000)",
+                "default": 10000
+              },
+              "validation_split": {
+                "type": "number",
+                "description": "Percentage of data for validation (0.0-1.0)",
+                "default": 0.2
+              }
+            },
+            "required": [
+              "solution_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "procurement",
+      "displayName": "Procurement",
+      "tools": [
+        {
+          "name": "snow_approve_procurement",
+          "description": "Mark a procurement request (proc_request) as approved, with optional comments. Use after the request has been reviewed — advances it toward purchase-order creation.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "procurement",
+            "approvals",
+            "purchasing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "request_sys_id": {
+                "type": "string"
+              },
+              "comments": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "request_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_purchase_order",
+          "description": "Open a purchase order (proc_po) against a vendor, with optional requested_by user and total_cost. Captures the buy-side step after a procurement request has been approved.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "purchase-orders",
+            "procurement",
+            "vendor-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "vendor": {
+                "type": "string"
+              },
+              "requested_by": {
+                "type": "string"
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "total_cost": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "vendor"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "project-management",
+      "displayName": "Project Management",
+      "tools": [
+        {
+          "name": "snow_create_project",
+          "description": "Create a PPM project (pm_project) with name, description, planned start/end dates, and a project manager (sys_user). Container for project tasks created via snow_create_project_task.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "project-management",
+            "ppm",
+            "project-creation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "start_date": {
+                "type": "string"
+              },
+              "end_date": {
+                "type": "string"
+              },
+              "project_manager": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_project_task",
+          "description": "Add a task to an existing PPM project (pm_project_task) with short description, optional assignee, and planned_hours. Use snow_create_project to make the parent project first.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "project-tasks",
+            "ppm",
+            "task-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "project": {
+                "type": "string"
+              },
+              "short_description": {
+                "type": "string"
+              },
+              "assigned_to": {
+                "type": "string"
+              },
+              "planned_hours": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "project",
+              "short_description"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "properties",
+      "displayName": "Properties",
+      "tools": [
+        {
+          "name": "snow_property_bulk",
+          "description": "Bulk system property operations (get/set multiple)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "properties",
+            "bulk-operations",
+            "batch"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Bulk action to perform",
+                "enum": [
+                  "get",
+                  "set"
+                ]
+              },
+              "names": {
+                "type": "array",
+                "description": "[get] Array of property names to retrieve",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "properties": {
+                "type": "array",
+                "description": "[set] Array of properties to set",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_property_io",
+          "description": "System property I/O operations (import, export, history)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "properties",
+            "backup",
+            "migration",
+            "audit"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "I/O action to perform",
+                "enum": [
+                  "import",
+                  "export",
+                  "history"
+                ]
+              },
+              "properties": {
+                "type": "array",
+                "description": "[import] Array of properties to import",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "pattern": {
+                "type": "string",
+                "description": "[export] Property name pattern (exports matching properties)"
+              },
+              "suffix": {
+                "type": "string",
+                "description": "[export] Filter by suffix"
+              },
+              "property_name": {
+                "type": "string",
+                "description": "[history] Property name to get history for"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[history] Maximum history records",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_property_manage",
+          "description": "Unified tool for system property management (get, set, delete, validate)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "properties",
+            "configuration",
+            "system-settings"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "get",
+                  "set",
+                  "delete",
+                  "validate"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "Property name (e.g., glide.servlet.uri)"
+              },
+              "include_metadata": {
+                "type": "boolean",
+                "description": "[get] Include full property metadata",
+                "default": false
+              },
+              "value": {
+                "type": "string",
+                "description": "[set/validate] Property value"
+              },
+              "description": {
+                "type": "string",
+                "description": "[set] Property description"
+              },
+              "type": {
+                "type": "string",
+                "description": "[set] Property type (string, boolean, integer, etc.)",
+                "default": "string"
+              },
+              "choices": {
+                "type": "string",
+                "description": "[set] Comma-separated list of valid choices"
+              },
+              "is_private": {
+                "type": "boolean",
+                "description": "[set] Mark property as private",
+                "default": false
+              },
+              "suffix": {
+                "type": "string",
+                "description": "[set] Property suffix/scope"
+              },
+              "confirm": {
+                "type": "boolean",
+                "description": "[delete] Confirmation flag (must be true)",
+                "default": false
+              }
+            },
+            "required": [
+              "action",
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_property_query",
+          "description": "Query system properties (list, search, categories)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "properties",
+            "discovery",
+            "search"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Query action to perform",
+                "enum": [
+                  "list",
+                  "search",
+                  "categories"
+                ]
+              },
+              "pattern": {
+                "type": "string",
+                "description": "[search] Search pattern (property name pattern)"
+              },
+              "suffix": {
+                "type": "string",
+                "description": "[list] Filter by suffix/scope"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/search] Maximum results",
+                "default": 100
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "query",
+      "displayName": "Query",
+      "tools": [
+        {
+          "name": "snow_get_ci_details",
+          "description": "Retrieve Configuration Item details including relationships and history",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "query",
+            "details"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_id": {
+                "type": "string",
+                "description": "CI sys_id or name"
+              },
+              "include_relationships": {
+                "type": "boolean",
+                "description": "Include CI relationships",
+                "default": true
+              },
+              "include_history": {
+                "type": "boolean",
+                "description": "Include change history",
+                "default": false
+              }
+            },
+            "required": [
+              "ci_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_search_cmdb",
+          "description": "Search the CMDB for Configuration Items with various filters",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "search",
+            "query"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query for CI name"
+              },
+              "ci_class": {
+                "type": "string",
+                "description": "Filter by CI class"
+              },
+              "operational_status": {
+                "type": "string",
+                "description": "Filter by operational status"
+              },
+              "location": {
+                "type": "string",
+                "description": "Filter by location"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results to return",
+                "default": 50
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "queues",
+      "displayName": "Queues",
+      "tools": [
+        {
+          "name": "snow_create_queue",
+          "description": "Define an assignment queue (sys_queue) — a saved filter on a table, optionally tied to an assignment group. Work items matching the condition show up in the group's work list via snow_get_queue_items.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "assignment-queues",
+            "work-distribution",
+            "routing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Queue name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Queue filter condition"
+              },
+              "group": {
+                "type": "string",
+                "description": "Assignment group sys_id"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_queue_items",
+          "description": "List up to N records (default 50) currently in a queue by sys_id. Reads the queue's table and condition from sys_queue, then runs the matching query against the target table.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "queue-items",
+            "work-list",
+            "assignment"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "queue_sys_id": {
+                "type": "string",
+                "description": "Queue sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "default": 50
+              }
+            },
+            "required": [
+              "queue_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "reconciliation",
+      "displayName": "Reconciliation",
+      "tools": [
+        {
+          "name": "snow_reconcile_ci",
+          "description": "Reconcile CI data from multiple sources",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "reconciliation",
+            "data-quality"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_sys_id": {
+                "type": "string",
+                "description": "CI to reconcile"
+              },
+              "source_data": {
+                "type": "object",
+                "description": "Source data to reconcile"
+              },
+              "reconciliation_rule": {
+                "type": "string",
+                "description": "Reconciliation rule",
+                "default": "merge"
+              }
+            },
+            "required": [
+              "ci_sys_id",
+              "source_data"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "relationships",
+      "displayName": "Relationships",
+      "tools": [
+        {
+          "name": "snow_create_ci_relationship",
+          "description": "Create relationship between Configuration Items",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "relationships",
+            "dependencies"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "parent_ci": {
+                "type": "string",
+                "description": "Parent CI sys_id"
+              },
+              "child_ci": {
+                "type": "string",
+                "description": "Child CI sys_id"
+              },
+              "relationship_type": {
+                "type": "string",
+                "description": "Relationship type sys_id"
+              }
+            },
+            "required": [
+              "parent_ci",
+              "child_ci",
+              "relationship_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_ci_relationships",
+          "description": "Get all relationships for a Configuration Item",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "relationships",
+            "mapping"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ci_sys_id": {
+                "type": "string",
+                "description": "CI sys_id"
+              },
+              "depth": {
+                "type": "number",
+                "description": "Relationship depth",
+                "default": 1
+              }
+            },
+            "required": [
+              "ci_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "reporting",
+      "displayName": "Reporting",
+      "tools": [
+        {
+          "name": "snow_asset_compliance_report",
+          "description": "Generate comprehensive asset compliance reports for auditing",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "compliance",
+            "reporting",
+            "auditing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "report_type": {
+                "type": "string",
+                "description": "Type of compliance report",
+                "enum": [
+                  "license_usage",
+                  "asset_inventory",
+                  "warranty_expiration",
+                  "cost_analysis"
+                ]
+              },
+              "date_range": {
+                "type": "string",
+                "description": "Report date range",
+                "enum": [
+                  "30_days",
+                  "90_days",
+                  "1_year",
+                  "all_time"
+                ]
+              },
+              "include_details": {
+                "type": "boolean",
+                "description": "Include detailed breakdown"
+              },
+              "export_format": {
+                "type": "string",
+                "description": "Export format",
+                "enum": [
+                  "json",
+                  "csv",
+                  "pdf"
+                ]
+              }
+            },
+            "required": [
+              "report_type"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "reports",
+      "displayName": "Reports",
+      "tools": [
+        {
+          "name": "snow_create_report",
+          "description": "Create a sys_report against a table with a chart type (bar / pie / line / list) and optional encoded-query filter. Defines the report definition only — runs/scheduling is handled separately.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "reporting",
+            "visualization",
+            "analytics"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "table": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bar",
+                  "pie",
+                  "line",
+                  "list"
+                ]
+              },
+              "filter": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "table",
+              "type"
+            ]
+          }
+        },
+        {
+          "name": "snow_report_manage",
+          "description": "Unified tool for ServiceNow report lifecycle beyond creation: list, get, run, schedule, share, and export. Wraps sys_report, sysauto_report, and sys_report_users_groups.\n\nActions:\n- list — list sys_report definitions, optionally filtered by table or owner\n- get — retrieve a single report (sys_id or title)\n- run — execute the report ad-hoc and return rows from the configured table using the report filter\n- schedule — create or update a sysauto_report row (recurrence, time, recipients)\n- share — share a report with users or groups via sys_report_users_groups\n- export — export the report's underlying rows as JSON or CSV (server-side rendered PDF/XLSX is out of scope; use schedule for delivery)\n\nUse when: the agent needs to manage reports after they exist — running them on demand, scheduling delivery, or controlling who can view them. For authoring a new sys_report row, use snow_create_report instead.\n\nReturns: report records with sys_id, title, table, type, filter; schedule rows with run_time and recipients; share rows with user_or_group references.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "reporting",
+            "reports",
+            "scheduling",
+            "sharing",
+            "exports"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "run",
+                  "schedule",
+                  "share",
+                  "export"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/run/schedule/share/export] Report sys_id"
+              },
+              "title": {
+                "type": "string",
+                "description": "[get/run/schedule/share/export] Report title (used as identifier when sys_id is absent)"
+              },
+              "table": {
+                "type": "string",
+                "description": "[list] Filter by source table (e.g. incident, change_request)"
+              },
+              "owner": {
+                "type": "string",
+                "description": "[list] Filter by sys_user sys_id (report owner/user field)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[run/list/export] Maximum rows to return",
+                "default": 100
+              },
+              "display_value": {
+                "type": "boolean",
+                "description": "[run/export] Return display values rather than raw references",
+                "default": true
+              },
+              "run_time": {
+                "type": "string",
+                "description": "[schedule] Local time of day to run, HH:MM:SS (ServiceNow stores as a glide_time)"
+              },
+              "run_dayofmonth": {
+                "type": "number",
+                "description": "[schedule] Day of month (1-31) for monthly recurrence"
+              },
+              "run_dayofweek": {
+                "type": "number",
+                "description": "[schedule] Day of week (1=Mon … 7=Sun) for weekly recurrence"
+              },
+              "run_type": {
+                "type": "string",
+                "description": "[schedule] Recurrence type",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "periodically",
+                  "once"
+                ]
+              },
+              "recipients": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[schedule] sys_user sys_ids or email addresses to receive the scheduled report"
+              },
+              "schedule_sys_id": {
+                "type": "string",
+                "description": "[schedule] Existing sysauto_report sys_id to update; omit to create a new row"
+              },
+              "schedule_active": {
+                "type": "boolean",
+                "description": "[schedule] Whether the schedule is active",
+                "default": true
+              },
+              "user": {
+                "type": "string",
+                "description": "[share] sys_user sys_id to grant view access"
+              },
+              "group": {
+                "type": "string",
+                "description": "[share] sys_user_group sys_id to grant view access (alternative to user)"
+              },
+              "format": {
+                "type": "string",
+                "description": "[export] Export format",
+                "enum": [
+                  "json",
+                  "csv"
+                ],
+                "default": "json"
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get/run/export] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "rest",
+      "displayName": "Rest",
+      "tools": [
+        {
+          "name": "snow_create_rest_message",
+          "description": "Create REST message for external API integration",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "rest",
+            "api"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "REST message name"
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "Base URL endpoint"
+              },
+              "description": {
+                "type": "string",
+                "description": "REST message description"
+              },
+              "authentication": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "basic",
+                  "oauth2",
+                  "api_key"
+                ],
+                "description": "Authentication type",
+                "default": "none"
+              },
+              "use_mid_server": {
+                "type": "boolean",
+                "description": "Route through MID Server",
+                "default": false
+              },
+              "mid_server": {
+                "type": "string",
+                "description": "MID Server name if use_mid_server is true"
+              },
+              "methods": {
+                "type": "array",
+                "description": "HTTP methods to create",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "http_method": {
+                      "type": "string",
+                      "enum": [
+                        "GET",
+                        "POST",
+                        "PUT",
+                        "PATCH",
+                        "DELETE"
+                      ]
+                    },
+                    "endpoint_path": {
+                      "type": "string"
+                    },
+                    "headers": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "name",
+              "endpoint"
+            ]
+          }
+        },
+        {
+          "name": "snow_rest_message_manage",
+          "description": "Universal REST Message management tool. CRUD operations for:\n• REST Messages (list, get, create, update, delete)\n• HTTP Methods (list_methods, get_method, create_method, update_method, delete_method)\n• Message-level Headers - apply to ALL methods (list_message_headers, create_message_header, delete_message_header)\n• Method-level Headers - apply to specific method (list_method_headers, create_method_header, delete_method_header)\n• Query Parameters (list_parameters, create_parameter, delete_parameter)\n• Testing (test) - generates ES5-compatible test script for snow_execute_script",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "rest",
+            "api",
+            "crud",
+            "headers",
+            "parameters",
+            "testing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "list_methods",
+                  "get_method",
+                  "create_method",
+                  "update_method",
+                  "delete_method",
+                  "list_message_headers",
+                  "create_message_header",
+                  "delete_message_header",
+                  "list_method_headers",
+                  "create_method_header",
+                  "delete_method_header",
+                  "list_parameters",
+                  "create_parameter",
+                  "delete_parameter",
+                  "test"
+                ],
+                "description": "Action to perform"
+              },
+              "filter": {
+                "type": "string",
+                "description": "Filter for list action (e.g., \"nameLIKEopenai\" or \"active=true\")"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results to return",
+                "default": 50
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of REST message or method"
+              },
+              "name": {
+                "type": "string",
+                "description": "Name of REST message (alternative to sys_id for lookup)"
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "Base URL endpoint for REST message"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the REST message"
+              },
+              "authentication_type": {
+                "type": "string",
+                "enum": [
+                  "no_authentication",
+                  "basic",
+                  "oauth2",
+                  "api_key",
+                  "mutual_auth"
+                ],
+                "description": "Authentication type",
+                "default": "no_authentication"
+              },
+              "basic_auth_profile": {
+                "type": "string",
+                "description": "Basic auth profile sys_id (if authentication_type is basic)"
+              },
+              "oauth_profile": {
+                "type": "string",
+                "description": "OAuth profile sys_id (if authentication_type is oauth2)"
+              },
+              "use_mid_server": {
+                "type": "boolean",
+                "description": "Route through MID Server",
+                "default": false
+              },
+              "mid_server": {
+                "type": "string",
+                "description": "MID Server name or sys_id"
+              },
+              "rest_message_sys_id": {
+                "type": "string",
+                "description": "Parent REST message sys_id (for method operations)"
+              },
+              "method_sys_id": {
+                "type": "string",
+                "description": "Method sys_id (for method update/delete)"
+              },
+              "http_method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "description": "HTTP method type",
+                "default": "GET"
+              },
+              "relative_path": {
+                "type": "string",
+                "description": "Relative endpoint path for method (e.g., \"/v1/completions\")"
+              },
+              "request_body": {
+                "type": "string",
+                "description": "Request body template (for POST/PUT/PATCH)"
+              },
+              "header_name": {
+                "type": "string",
+                "description": "Header name"
+              },
+              "header_value": {
+                "type": "string",
+                "description": "Header value"
+              },
+              "header_sys_id": {
+                "type": "string",
+                "description": "Header sys_id (for delete operations)"
+              },
+              "headers": {
+                "type": "object",
+                "description": "Multiple headers as key-value pairs"
+              },
+              "parameter_name": {
+                "type": "string",
+                "description": "Query parameter name"
+              },
+              "parameter_value": {
+                "type": "string",
+                "description": "Query parameter value"
+              },
+              "parameter_sys_id": {
+                "type": "string",
+                "description": "Parameter sys_id (for delete operations)"
+              },
+              "parameters": {
+                "type": "object",
+                "description": "Multiple query parameters as key-value pairs"
+              },
+              "test_params": {
+                "type": "object",
+                "description": "Parameters for testing the REST message"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_test_rest_connection",
+          "description": "Test REST API connection with timeout and response validation",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "rest",
+            "testing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "rest_message_name": {
+                "type": "string",
+                "description": "Name of REST message to test"
+              },
+              "method_name": {
+                "type": "string",
+                "description": "HTTP method name to test"
+              },
+              "test_payload": {
+                "type": "object",
+                "description": "Test payload data (for POST/PUT/PATCH)"
+              },
+              "timeout_seconds": {
+                "type": "number",
+                "description": "Request timeout in seconds",
+                "default": 30,
+                "maximum": 60
+              },
+              "validate_ssl": {
+                "type": "boolean",
+                "description": "Validate SSL certificate",
+                "default": true
+              }
+            },
+            "required": [
+              "rest_message_name",
+              "method_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "rest-api",
+      "displayName": "Rest Api",
+      "tools": [
+        {
+          "name": "snow_scripted_rest_api",
+          "description": "Invoke a Scripted REST API resource at /api/<namespace>/<path> with chosen method (GET/POST/PUT/PATCH/DELETE) and optional JSON body. Use for instance-defined REST endpoints; for stock table API use snow_custom_api.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "rest",
+            "api",
+            "integration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "api_namespace": {
+                "type": "string",
+                "description": "API namespace"
+              },
+              "api_path": {
+                "type": "string",
+                "description": "API path"
+              },
+              "method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE"
+                ],
+                "default": "GET"
+              },
+              "body": {
+                "type": "object",
+                "description": "Request body"
+              }
+            },
+            "required": [
+              "api_namespace",
+              "api_path"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "risk-assessment",
+      "displayName": "Risk Assessment",
+      "tools": [
+        {
+          "name": "snow_security_risk_assessment",
+          "description": "Perform comprehensive security risk assessment analyzing access controls, vulnerabilities, and security posture",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "security",
+            "risk",
+            "assessment"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "assessment_type": {
+                "type": "string",
+                "description": "Type of security assessment",
+                "enum": [
+                  "access_control",
+                  "vulnerability",
+                  "configuration",
+                  "full"
+                ],
+                "default": "full"
+              },
+              "target_scope": {
+                "type": "string",
+                "description": "Assessment scope",
+                "enum": [
+                  "instance",
+                  "application",
+                  "table",
+                  "user"
+                ],
+                "default": "instance"
+              },
+              "target_id": {
+                "type": "string",
+                "description": "Target identifier (app sys_id, table name, or user sys_id)"
+              },
+              "risk_threshold": {
+                "type": "string",
+                "description": "Minimum risk level to report",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low"
+                ],
+                "default": "medium"
+              }
+            },
+            "required": [
+              "assessment_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_vulnerability_risk_assessment",
+          "description": "Assess vulnerability risk with automated CVSS scoring and remediation planning",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "vulnerabilities",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cve_id": {
+                "type": "string",
+                "description": "CVE identifier (e.g., CVE-2024-1234)"
+              },
+              "affected_assets": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of affected asset sys_ids"
+              },
+              "assessment_type": {
+                "type": "string",
+                "description": "Assessment type",
+                "enum": [
+                  "automated",
+                  "manual",
+                  "hybrid"
+                ]
+              },
+              "business_context": {
+                "type": "string",
+                "description": "Business context for risk calculation"
+              }
+            },
+            "required": [
+              "cve_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "risk-management",
+      "displayName": "Risk Management",
+      "tools": [
+        {
+          "name": "snow_grc_risk_manage",
+          "description": "Unified tool for ServiceNow GRC Advanced Risk register lifecycle: registering risks, scoring them, attaching treatment plans, and assigning ownership. Wraps the sn_risk_advanced_risk, sn_risk_risk_treatment, and sn_risk_risk_owner tables that ship with the GRC: Advanced Risk plugin.\n\nActions:\n- list — list risks, optionally filtered by category, state, or owner\n- get — retrieve a single risk by sys_id (includes counts of treatments and owners)\n- create — register a new risk with category, inherent score, and owner\n- assess — update the risk's inherent or residual likelihood/impact scores\n- treat — attach a treatment plan (accept, mitigate, transfer, avoid) with target date\n- assign_owner — assign or transfer the risk owner (writes sn_risk_risk_owner)\n\nUse when: the agent needs to manage the risk register itself — registering newly identified risks, refreshing inherent/residual scoring after an assessment, choosing a treatment strategy, and naming an accountable owner. For security-specific scoring use snow_security_risk_assessment; for vendor third-party risk use snow_grc_vendor_risk_manage.\n\nReturns: risk rows with sys_id, number, name, category, inherent and residual scores, state; treatment rows with strategy, target date, and owner; ownership rows with sys_user reference and role. GRC plugin gating: the first call against the risk tables will surface a clear error if the GRC: Advanced Risk plugin is not active on the target instance.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "grc",
+            "risk",
+            "risk-register",
+            "treatment",
+            "ownership"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "assess",
+                  "treat",
+                  "assign_owner"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get/assess/treat/assign_owner] Risk sys_id"
+              },
+              "category": {
+                "type": "string",
+                "description": "[list/create] Risk category (operational, financial, strategic, compliance, security, third_party)"
+              },
+              "state": {
+                "type": "string",
+                "description": "[list/create/assess] Risk state",
+                "enum": [
+                  "draft",
+                  "assessed",
+                  "in_treatment",
+                  "monitored",
+                  "closed"
+                ]
+              },
+              "owner": {
+                "type": "string",
+                "description": "[list] Filter by current owner sys_user sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/get] Comma-separated list of fields to return"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create] Risk name / title (required)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create] Risk description / scenario detail"
+              },
+              "inherent_likelihood": {
+                "type": "number",
+                "description": "[create/assess] Inherent likelihood score (1-5 scale, instance-configurable)"
+              },
+              "inherent_impact": {
+                "type": "number",
+                "description": "[create/assess] Inherent impact score (1-5 scale, instance-configurable)"
+              },
+              "residual_likelihood": {
+                "type": "number",
+                "description": "[assess] Residual likelihood score after existing controls (1-5 scale)"
+              },
+              "residual_impact": {
+                "type": "number",
+                "description": "[assess] Residual impact score after existing controls (1-5 scale)"
+              },
+              "assessment_note": {
+                "type": "string",
+                "description": "[assess] Optional work note describing the assessment rationale"
+              },
+              "treatment_strategy": {
+                "type": "string",
+                "description": "[treat] Treatment strategy",
+                "enum": [
+                  "accept",
+                  "mitigate",
+                  "transfer",
+                  "avoid"
+                ]
+              },
+              "treatment_description": {
+                "type": "string",
+                "description": "[treat] Description of the treatment plan"
+              },
+              "treatment_target_date": {
+                "type": "string",
+                "description": "[treat] ISO date string (YYYY-MM-DD) for target completion"
+              },
+              "treatment_owner": {
+                "type": "string",
+                "description": "[treat] sys_user sys_id of the treatment owner"
+              },
+              "assigned_user": {
+                "type": "string",
+                "description": "[assign_owner] sys_user sys_id of the new owner (required)"
+              },
+              "owner_role": {
+                "type": "string",
+                "description": "[assign_owner] Owner role label (risk_owner, control_owner, accountable, responsible)",
+                "default": "risk_owner"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "routing",
+      "displayName": "Routing",
+      "tools": [
+        {
+          "name": "snow_create_uib_page_registry",
+          "description": "Configure URL routing and access control for UI Builder pages",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "routing",
+            "access-control"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Target page sys_id"
+              },
+              "route": {
+                "type": "string",
+                "description": "URL route (e.g., \"/my-page\")"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Required roles to access page",
+                "default": []
+              },
+              "public": {
+                "type": "boolean",
+                "description": "Make page publicly accessible",
+                "default": false
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active state",
+                "default": true
+              }
+            },
+            "required": [
+              "page_id",
+              "route"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "rules",
+      "displayName": "Rules",
+      "tools": [
+        {
+          "name": "snow_create_escalation_rule",
+          "description": "Creates escalation rules for time-based actions. Defines escalation timing, conditions, and automated responses.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "escalation",
+            "rules"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Escalation Rule name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to monitor"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Escalation condition"
+              },
+              "escalationTime": {
+                "type": "number",
+                "description": "Escalation time in minutes"
+              },
+              "escalationScript": {
+                "type": "string",
+                "description": "Escalation action script (ES5 only!)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Rule active status",
+                "default": true
+              },
+              "order": {
+                "type": "number",
+                "description": "Execution order",
+                "default": 100
+              },
+              "description": {
+                "type": "string",
+                "description": "Rule description"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "condition",
+              "escalationTime",
+              "escalationScript"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_event_rule",
+          "description": "Creates event-driven automation rules. Triggers scripts based on system events with conditional logic.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "events",
+            "rules"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Event Rule name"
+              },
+              "eventName": {
+                "type": "string",
+                "description": "Registered event NAME to listen for, e.g. 'incident.commented' or 'x_app.my_event' — the 'event_name' string from sysevent_register. This is NOT the sys_id and NOT a reference: a Script Action matches fired events by name, so a 32-char hex sys_id will store but never fire. Use snow_discover_events to find the name."
+              },
+              "condition": {
+                "type": "string",
+                "description": "Event condition script (ES5 only!)"
+              },
+              "script": {
+                "type": "string",
+                "description": "🚨 ES5 ONLY! Action script to execute (no const/let/arrows/templates - Rhino engine)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Rule description"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Rule active status",
+                "default": true
+              },
+              "order": {
+                "type": "number",
+                "description": "Execution order",
+                "default": 100
+              }
+            },
+            "required": [
+              "name",
+              "eventName",
+              "script"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "scheduled-jobs",
+      "displayName": "Scheduled Jobs",
+      "tools": [
+        {
+          "name": "snow_job_status",
+          "description": "Unified read-only visibility into ServiceNow background work. Spans sys_trigger (scheduled-job triggers), sys_progress_worker (background workers for transforms, imports, large operations), and sys_execution_tracker (fix-script and async-operation trackers).\n\nActions:\n- list_active — list currently running/queued work across triggers, workers, and trackers\n- get_status — fetch the full record for a single job/worker/tracker by sys_id\n- get_history — historical runs for a specific scheduled job (sys_trigger), bounded by limit and time window\n- get_errors — surface recent failed/errored runs across the three sources\n\nUse when: the agent needs real-time situational awareness of what is running on the instance, debugging a slow transform, or auditing why a scheduled job did not fire. Companion to snow_trigger_scheduled_job for starting jobs and snow_scheduled_job_manage for defining them.\n\nReturns: per-source arrays of normalized records with sys_id, name, state, progress, started_at, completed_at, and source-specific fields. All operations are read-only Table API queries.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "admin",
+            "stakeholder"
+          ],
+          "useCases": [
+            "monitoring",
+            "scheduled-jobs",
+            "background-jobs",
+            "debugging",
+            "observability"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Status-query action to perform",
+                "enum": [
+                  "list_active",
+                  "get_status",
+                  "get_history",
+                  "get_errors"
+                ]
+              },
+              "source": {
+                "type": "string",
+                "description": "[list_active/get_status/get_errors] Which source to query. Defaults to 'all' which queries trigger, worker, and tracker in parallel.",
+                "enum": [
+                  "all",
+                  "trigger",
+                  "worker",
+                  "tracker"
+                ],
+                "default": "all"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[get_status/get_history] Record sys_id to inspect"
+              },
+              "job_name": {
+                "type": "string",
+                "description": "[get_history] Scheduled job name (alternative to sys_id, queries sys_trigger by name)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_active/get_history/get_errors] Maximum records to return per source",
+                "default": 50
+              },
+              "since_hours": {
+                "type": "number",
+                "description": "[list_active/get_history/get_errors] Only include records updated within the last N hours",
+                "default": 24
+              },
+              "fields": {
+                "type": "string",
+                "description": "[get_status] Comma-separated list of fields to return for the specific record"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_scheduled_job_manage",
+          "description": "Manage scheduled jobs: list, get details, create, update, delete, enable/disable, run now, get history",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "scheduled-jobs",
+            "automation",
+            "background-processing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "enable",
+                  "disable",
+                  "run_now",
+                  "get_history",
+                  "get_next_run"
+                ],
+                "description": "Action to perform"
+              },
+              "job_id": {
+                "type": "string",
+                "description": "Job sys_id or name (required for get, update, delete, enable, disable, run_now, get_history)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Job name (for create/update)"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script to execute (ES5 JavaScript)"
+              },
+              "run_type": {
+                "type": "string",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "periodically",
+                  "once",
+                  "on_demand"
+                ],
+                "description": "How often to run"
+              },
+              "run_time": {
+                "type": "string",
+                "description": "Time to run (HH:MM:SS format for daily/weekly/monthly)"
+              },
+              "run_dayofweek": {
+                "type": "number",
+                "description": "Day of week (1=Sunday, 7=Saturday) for weekly jobs"
+              },
+              "run_dayofmonth": {
+                "type": "number",
+                "description": "Day of month (1-31) for monthly jobs"
+              },
+              "run_period": {
+                "type": "string",
+                "description": "Period for periodic jobs (e.g., \"00:05:00\" for every 5 minutes)"
+              },
+              "run_start": {
+                "type": "string",
+                "description": "Start date/time for one-time jobs (YYYY-MM-DD HH:MM:SS)"
+              },
+              "conditional": {
+                "type": "boolean",
+                "description": "Whether job has a condition script",
+                "default": false
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition script (job only runs if this returns true)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether job is active",
+                "default": true
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only list active jobs",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results for list/get_history",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "schedules",
+      "displayName": "Schedules",
+      "tools": [
+        {
+          "name": "snow_oncall_manage",
+          "description": "Unified tool for ServiceNow On-Call Scheduling. Operates over cmn_rota (rotations), cmn_rota_member (members in a rotation), and cmn_rota_roster (shift assignments) to manage who covers which group at which time.\n\nActions:\n- list_rotations — list rotations, optionally filtered by assignment group\n- get_current_oncall — resolve who is on call right now for a given rotation (queries cmn_rota_roster against the current GlideDateTime via a server-side helper)\n- list_shifts — list upcoming shifts/rosters for a rotation within a time window\n- swap_shift — reassign a roster entry from one rotation member to another\n\nUse when: ITSM teams need visibility into on-call coverage, the agent must page the correct person, or a user requests a one-time shift swap. Companion to snow_create_schedule for the underlying schedule definitions.\n\nReturns: action-specific structures. list_rotations returns rotation records with assignment_group and schedule references. get_current_oncall returns the active rotation member (sys_user link) plus the roster row that grants coverage. list_shifts returns roster rows ordered by start time. swap_shift returns the updated roster record.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "on-call",
+            "scheduling",
+            "itsm",
+            "rosters",
+            "rotation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "On-call action to perform",
+                "enum": [
+                  "list_rotations",
+                  "get_current_oncall",
+                  "list_shifts",
+                  "swap_shift"
+                ]
+              },
+              "rotation_sys_id": {
+                "type": "string",
+                "description": "[get_current_oncall/list_shifts/swap_shift] sys_id of the cmn_rota rotation"
+              },
+              "rotation_name": {
+                "type": "string",
+                "description": "[get_current_oncall/list_shifts] Rotation name (alternative to rotation_sys_id)"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[list_rotations] Filter rotations by assignment group sys_id or name"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_rotations] Only return active rotations",
+                "default": true
+              },
+              "start_time": {
+                "type": "string",
+                "description": "[list_shifts] Window start in ServiceNow datetime format (YYYY-MM-DD HH:MM:SS, UTC). Defaults to now."
+              },
+              "end_time": {
+                "type": "string",
+                "description": "[list_shifts] Window end in ServiceNow datetime format. Defaults to start_time + 7 days."
+              },
+              "roster_sys_id": {
+                "type": "string",
+                "description": "[swap_shift] sys_id of the cmn_rota_member row whose member assignment is being swapped (the per-window assignment record)"
+              },
+              "from_member_sys_id": {
+                "type": "string",
+                "description": "[swap_shift] sys_user sys_id currently assigned in the member row (used as a guard)"
+              },
+              "to_member_sys_id": {
+                "type": "string",
+                "description": "[swap_shift] sys_user sys_id taking the shift"
+              },
+              "reason": {
+                "type": "string",
+                "description": "[swap_shift] Optional reason; not persisted on cmn_rota_member (the table has no override/reason columns) but echoed in the response"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_rotations/list_shifts] Maximum records to return",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "scheduling",
+      "displayName": "Scheduling",
+      "tools": [
+        {
+          "name": "snow_add_schedule_entry",
+          "description": "Add a span (cmn_schedule_span) to a schedule that either includes or excludes a window of time. Use to model holidays, blackout periods, or extra coverage hours on top of a base cmn_schedule.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "schedules",
+            "work-hours",
+            "calendar"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "schedule_sys_id": {
+                "type": "string",
+                "description": "Schedule sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Entry name"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "include",
+                  "exclude"
+                ],
+                "default": "include"
+              },
+              "start_date_time": {
+                "type": "string",
+                "description": "Start date time"
+              },
+              "end_date_time": {
+                "type": "string",
+                "description": "End date time"
+              }
+            },
+            "required": [
+              "schedule_sys_id",
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_schedule",
+          "description": "Define a schedule (cmn_schedule) — weekly/monthly/custom recurrence and a time zone. Used downstream by SLAs, on-call shifts, and business-hours calculations. Add spans via snow_add_schedule_entry.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "schedules",
+            "work-hours",
+            "sla"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Schedule name"
+              },
+              "time_zone": {
+                "type": "string",
+                "description": "Time zone"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "weekly",
+                  "monthly",
+                  "custom"
+                ],
+                "default": "weekly"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_schedule_job",
+          "description": "Create scheduled job with cron expression or repeat interval",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "scheduling",
+            "jobs"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Job name"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script to execute (ES5 only)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Job description"
+              },
+              "schedule_type": {
+                "type": "string",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "periodically",
+                  "run_once",
+                  "on_demand"
+                ],
+                "description": "Schedule type",
+                "default": "periodically"
+              },
+              "repeat_interval": {
+                "type": "number",
+                "description": "Repeat interval in seconds (for periodically type)",
+                "default": 3600
+              },
+              "time": {
+                "type": "string",
+                "description": "Time to run (HH:MM:SS format for daily/weekly/monthly)"
+              },
+              "day_of_week": {
+                "type": "string",
+                "description": "Day of week for weekly schedule (1=Monday, 7=Sunday)"
+              },
+              "day_of_month": {
+                "type": "number",
+                "description": "Day of month for monthly schedule (1-31)",
+                "minimum": 1,
+                "maximum": 31
+              },
+              "conditional_script": {
+                "type": "string",
+                "description": "Condition script that must return true to execute (ES5)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Activate the job immediately",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_schedule_report_delivery",
+          "description": "Schedule automated report delivery via email",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "scheduling",
+            "automation",
+            "delivery"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "report_name": {
+                "type": "string",
+                "description": "Source report name or sys_id"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "Schedule frequency",
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "quarterly"
+                ]
+              },
+              "recipients": {
+                "type": "array",
+                "description": "Email recipients",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "format": {
+                "type": "string",
+                "description": "Report format",
+                "enum": [
+                  "PDF",
+                  "Excel",
+                  "CSV"
+                ]
+              },
+              "conditions": {
+                "type": "string",
+                "description": "Additional conditions"
+              },
+              "subject": {
+                "type": "string",
+                "description": "Email subject"
+              },
+              "message": {
+                "type": "string",
+                "description": "Email message"
+              }
+            },
+            "required": [
+              "report_name",
+              "schedule",
+              "recipients"
+            ]
+          }
+        },
+        {
+          "name": "snow_trigger_scheduled_job",
+          "description": "⚠️ UNRELIABLE: Attempts to trigger a scheduled job via sys_trigger, but CANNOT guarantee execution. The job runs asynchronously when the ServiceNow scheduler picks it up — this frequently times out. Do NOT rely on this for verification or testing. Only use when you need to trigger a specific existing scheduled job and can accept that it may not run.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "job-execution",
+            "testing",
+            "manual-trigger"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "job_sys_id": {
+                "type": "string",
+                "description": "Scheduled job sys_id (from sysauto_script table)"
+              },
+              "wait_for_completion": {
+                "type": "boolean",
+                "description": "Wait and poll for job completion (max 60 seconds)",
+                "default": false
+              }
+            },
+            "required": [
+              "job_sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "schema",
+      "displayName": "Schema",
+      "tools": [
+        {
+          "name": "snow_discover_table_fields",
+          "description": "Discover table schema with fields, types, relationships, and metadata",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "discovery",
+            "schema"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name to discover schema for"
+              },
+              "include_relationships": {
+                "type": "boolean",
+                "description": "Include field relationships (reference fields)",
+                "default": true
+              },
+              "include_acls": {
+                "type": "boolean",
+                "description": "Include ACL information",
+                "default": false
+              },
+              "include_indexes": {
+                "type": "boolean",
+                "description": "Include index information",
+                "default": false
+              }
+            },
+            "required": [
+              "table_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "script-execution",
+      "displayName": "Script Execution",
+      "tools": [
+        {
+          "name": "snow_confirm_script_execution",
+          "description": "⚡ Confirms and schedules script after user approval (use after snow_execute_script with requireConfirmation=true). Note: Uses same scheduled job approach.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "scripts",
+            "execution"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "script": {
+                "type": "string",
+                "description": "The approved script to execute (ES5 only)"
+              },
+              "executionId": {
+                "type": "string",
+                "description": "Execution ID from confirmation request"
+              },
+              "userConfirmed": {
+                "type": "boolean",
+                "description": "User confirmation (must be true)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of what the script does",
+                "default": "Confirmed script execution"
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Timeout in milliseconds for polling execution results",
+                "default": 30000
+              }
+            },
+            "required": [
+              "script",
+              "executionId",
+              "userConfirmed"
+            ]
+          }
+        },
+        {
+          "name": "snow_execute_script",
+          "description": "Execute server-side JavaScript on ServiceNow. Primary: synchronous execution via Scripted REST API (~1-3s). Fallback: scheduled job if endpoint unavailable. Auto-deploys the executor endpoint on first use. ES5 only (Rhino engine)!",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "scripts",
+            "scheduled-jobs",
+            "debugging",
+            "verification"
+          ],
+          "complexity": "advanced",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "script": {
+                "type": "string",
+                "description": "ES5 ONLY! JavaScript code to execute (no const/let/arrows/templates - Rhino engine)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Clear description of what the script does (required if requireConfirmation=true)"
+              },
+              "scope": {
+                "type": "string",
+                "description": "Scope to execute in",
+                "default": "global",
+                "enum": [
+                  "global",
+                  "rhino"
+                ]
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Timeout in milliseconds for polling execution results (fallback mode only)",
+                "default": 30000
+              },
+              "validate_es5": {
+                "type": "boolean",
+                "description": "Validate ES5 syntax before execution",
+                "default": true
+              },
+              "requireConfirmation": {
+                "type": "boolean",
+                "description": "Require user confirmation before execution (shows security analysis)",
+                "default": false
+              },
+              "autoConfirm": {
+                "type": "boolean",
+                "description": "Skip user confirmation even if requireConfirmation would normally be required",
+                "default": false
+              },
+              "allowDataModification": {
+                "type": "boolean",
+                "description": "Whether script is allowed to modify data (for security analysis)",
+                "default": false
+              },
+              "runAsUser": {
+                "type": "string",
+                "description": "User to execute script as (optional, defaults to current user)"
+              }
+            },
+            "required": [
+              "script"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_script_output",
+          "description": "Retrieve output from previously executed script using execution ID",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "scripts",
+            "output-retrieval"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "execution_id": {
+                "type": "string",
+                "description": "Execution ID from previous script run"
+              },
+              "cleanup": {
+                "type": "boolean",
+                "description": "Clean up temporary output after retrieval",
+                "default": true
+              }
+            },
+            "required": [
+              "execution_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_redeploy_script_endpoint",
+          "description": "Force-redeploy the Serac scripted REST executor endpoint (/api/snow_flow_exec/execute). Use when snow_execute_script / UI policy tools fail with 'Requested URI does not represent any resource'. Clears the in-memory cache and runs the auto-deploy with full diagnostics. Set hard_reset=true to delete and recreate the existing definition + operation records.",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "endpoint-redeploy",
+            "diagnostics",
+            "script-execution"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "hard_reset": {
+                "type": "boolean",
+                "description": "If true, deletes the existing sys_ws_definition + sys_ws_operation records before redeploying. Use only when a soft redeploy (default) doesn't recover the endpoint.",
+                "default": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "scripting",
+      "displayName": "Scripting",
+      "tools": [
+        {
+          "name": "snow_create_uib_client_script",
+          "description": "Create client-side JavaScript for UI Builder pages",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "scripts",
+            "client-side"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "string",
+                "description": "Target page sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Client script name"
+              },
+              "script": {
+                "type": "string",
+                "description": "JavaScript code to execute"
+              },
+              "event": {
+                "type": "string",
+                "description": "Event trigger (e.g., \"onLoad\", \"onChange\")",
+                "default": "onLoad"
+              },
+              "order": {
+                "type": "number",
+                "description": "Execution order",
+                "default": 100
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active state",
+                "default": true
+              }
+            },
+            "required": [
+              "page_id",
+              "name",
+              "script"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "search",
+      "displayName": "Search",
+      "tools": [
+        {
+          "name": "snow_code_search",
+          "description": "Search for a term across every ServiceNow table that stores scripts (business rules, script includes, client scripts, UI scripts, widgets, scripted REST operations, UI actions, ACLs, scheduled jobs, transform maps, notifications, record producers, UX/UI-Builder scripts, etc.). Returns grouped matches per table with a short context snippet. Use when you need to find where a function, table name, or pattern is referenced across the instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "code-search",
+            "refactoring",
+            "impact-analysis",
+            "dependency-tracing"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Substring to search for (case-insensitive, ServiceNow LIKE operator)."
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Optional whitelist of table names to search. Default: all supported script-bearing tables."
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only search active records where the 'active' field is present. Default: true.",
+                "default": true
+              },
+              "per_table_limit": {
+                "type": "number",
+                "description": "Max matches returned per table. Default: 25, max: 100.",
+                "default": 25
+              },
+              "context_window": {
+                "type": "number",
+                "description": "Characters of context around each match in the snippet. Default: 120.",
+                "default": 120
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        },
+        {
+          "name": "snow_fuzzy_search",
+          "description": "Perform fuzzy search across tables with relevance scoring. Returns sys_id + name + relevance_score for each match. Uses LIKE/CONTAINS queries and ranks by similarity.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "fuzzy-search",
+            "text-search",
+            "search",
+            "find-similar"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query - will match against name, label, and description fields"
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tables to search (e.g., [\"sys_db_object\", \"sys_script_include\"])"
+              },
+              "search_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to search within each table (default: name, label, description)",
+                "default": [
+                  "name",
+                  "label",
+                  "description"
+                ]
+              },
+              "threshold": {
+                "type": "number",
+                "default": 0.3,
+                "description": "Minimum similarity score (0-1) to include in results. Lower = more results."
+              },
+              "limit": {
+                "type": "number",
+                "default": 20,
+                "description": "Maximum results per table"
+              }
+            },
+            "required": [
+              "query",
+              "tables"
+            ]
+          }
+        },
+        {
+          "name": "snow_memory_search",
+          "description": "Searches cached ServiceNow artifacts in local memory for instant results without API calls.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "search",
+            "cache",
+            "offline"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "widget",
+                  "flow",
+                  "script",
+                  "application"
+                ],
+                "description": "Artifact type"
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        },
+        {
+          "name": "snow_search_artifacts",
+          "description": "Search ServiceNow development artifacts (widgets, pages, scripts, flows, UI actions, client scripts). For data/table searches, use snow_query_table or snow_fuzzy_search instead.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "artifact-search",
+            "development-search",
+            "find-widget",
+            "find-script"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query - matches against name, title, and description fields"
+              },
+              "types": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "widget",
+                    "page",
+                    "flow",
+                    "script_include",
+                    "business_rule",
+                    "client_script",
+                    "ui_action",
+                    "ui_policy",
+                    "ui_page",
+                    "scheduled_job",
+                    "all"
+                  ]
+                },
+                "description": "Artifact types to search (default: all)",
+                "default": [
+                  "all"
+                ]
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results per artifact type (default: 10)",
+                "default": 10,
+                "minimum": 1,
+                "maximum": 50
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive/disabled artifacts",
+                "default": false
+              },
+              "search_tables": {
+                "type": "boolean",
+                "description": "Also search sys_db_object for matching table definitions (slower)",
+                "default": false
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "security",
+      "displayName": "Security",
+      "tools": [
+        {
+          "name": "snow_impersonate_user",
+          "description": "Generate a ServiceNow impersonation deep-link for ACL / role debugging. Verifies the caller has the 'admin' role, resolves the target user (by sys_id or username), appends an audit entry to ~/.serac/audit/impersonations.jsonl, and returns an /impersonate.do URL the admin opens in the browser to actually switch session. Does NOT modify the OAuth session itself — ServiceNow's impersonation endpoint is cookie-based.",
+          "permission": "admin",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "debugging",
+            "acl",
+            "impersonation",
+            "testing-permissions"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string",
+                "description": "Target user: sys_id (32-char hex) or user_name. Example: '6816f79cc0a8016401c5a33be04be441' or 'abel.tuter'."
+              },
+              "reason": {
+                "type": "string",
+                "description": "Why the impersonation is needed — written to the audit log. Example: 'Verify ACL on incident form for end-user role'."
+              }
+            },
+            "required": [
+              "target"
+            ]
+          }
+        },
+        {
+          "name": "snow_jwt_decode",
+          "description": "Decode a JWT into its header and payload (base64-URL → JSON). Does NOT verify the signature — useful for inspecting claims, not for trusting them. Local operation, no ServiceNow call.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "jwt",
+            "token-decode",
+            "authentication"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "token": {
+                "type": "string",
+                "description": "JWT token"
+              }
+            },
+            "required": [
+              "token"
+            ]
+          }
+        },
+        {
+          "name": "snow_kms_manage",
+          "description": "Unified tool for the ServiceNow Key Management Framework. Covers KMF modules (sys_kmf_module), cryptographic modules (sys_kmf_crypto_module), and keys (sys_kmf_key) for use in PII/PCI encryption flows and Edge Encryption.\n\nActions:\n- list_modules — list KMF modules (sys_kmf_module) and their crypto modules\n- create_key — create a new key under a KMF module (writes sys_kmf_key)\n- encrypt — encrypt a plaintext payload using the named key\n- decrypt — decrypt a ciphertext payload using the named key\n- list_keys — list keys, optionally filtered by module\n- rotate_key — generate a new active version of a key and deactivate the previous one\n\nUse when: managing KMF modules and keys for sensitive data, rotating keys on schedule, or wrapping/unwrapping payloads through the platform. Encrypt and decrypt invoke a server-side helper Script Include rather than the Table API; falls back to a scripted-execution path if the dedicated endpoint is absent.\n\nReturns: action-specific data. List operations return arrays of KMF records (sys_id, name, module, type, active, key_format). Create/rotate return the new key record. Encrypt/decrypt return the wrapped/unwrapped payload as a string. Plaintext and ciphertext are never logged in error metadata.",
+          "permission": "write",
+          "allowedRoles": [
+            "admin"
+          ],
+          "useCases": [
+            "security",
+            "encryption",
+            "kms",
+            "key-management",
+            "pii",
+            "compliance"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "KMS action to perform",
+                "enum": [
+                  "list_modules",
+                  "create_key",
+                  "encrypt",
+                  "decrypt",
+                  "list_keys",
+                  "rotate_key"
+                ]
+              },
+              "module_sys_id": {
+                "type": "string",
+                "description": "[create_key/list_keys/rotate_key] sys_id of the KMF module (sys_kmf_module)"
+              },
+              "key_sys_id": {
+                "type": "string",
+                "description": "[rotate_key/encrypt/decrypt] sys_id of the key (sys_kmf_key)"
+              },
+              "key_name": {
+                "type": "string",
+                "description": "[create_key/encrypt/decrypt/rotate_key] Logical name of the key (alternative to key_sys_id)"
+              },
+              "algorithm": {
+                "type": "string",
+                "description": "[create_key] Symmetric algorithm",
+                "enum": [
+                  "AES-128",
+                  "AES-256",
+                  "RSA-2048",
+                  "RSA-4096",
+                  "HMAC-SHA-256"
+                ]
+              },
+              "key_purpose": {
+                "type": "string",
+                "description": "[create_key] Intended purpose",
+                "enum": [
+                  "encryption",
+                  "signing",
+                  "wrapping"
+                ]
+              },
+              "label": {
+                "type": "string",
+                "description": "[create_key] Display label"
+              },
+              "plaintext": {
+                "type": "string",
+                "description": "[encrypt] Plaintext payload to encrypt (never logged in error output)"
+              },
+              "ciphertext": {
+                "type": "string",
+                "description": "[decrypt] Base64-encoded ciphertext payload to decrypt (never logged in error output)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_modules/list_keys] Only return active records",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_modules/list_keys] Maximum records to return",
+                "default": 50
+              },
+              "retire_previous": {
+                "type": "boolean",
+                "description": "[rotate_key] Mark the previous active key as inactive after creating the new version",
+                "default": true
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "service-catalog",
+      "displayName": "Service Catalog",
+      "tools": [
+        {
+          "name": "snow_catalog_manage",
+          "description": "Unified tool for ServiceNow Service Catalog structure: order guides, record producers, categories, and the item-to-category junction. Wraps the sc_cat_item_guide, sc_cat_item_producer, sc_category, and sc_cat_item_category tables.\n\nActions:\n- create_order_guide — create a new order guide (sc_cat_item_guide) that bundles related catalog items into a single guided flow\n- list_order_guides — list order guides, optionally filtered by catalog\n- create_record_producer — create a record producer (sc_cat_item_producer) that surfaces as a catalog item but writes to a non-request target table (incident, change_request, etc.)\n- list_record_producers — list record producers, optionally filtered by target table\n- list_categories — list catalog categories (sc_category), optionally filtered by catalog or parent\n- create_category — create a catalog category to organize items into a navigable tree\n- link_item_to_category — attach a catalog item to a category through the sc_cat_item_category junction (items can live in multiple categories)\n\nUse when: the agent needs to organize catalog items into guides or categories, or expose a record-creation form (record producer) outside the standard requested-item flow. For the catalog items themselves use snow_create_catalog_item; for ordering an existing item use snow_order_catalog_item.\n\nReturns: created or queried records with sys_id, name, and the relevant references (sc_catalogs, category, table_name). Junction inserts return the sc_cat_item_category link sys_id so it can be removed later.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "service-catalog",
+            "order-guides",
+            "record-producers",
+            "categories"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Catalog structure action to perform",
+                "enum": [
+                  "create_order_guide",
+                  "list_order_guides",
+                  "create_record_producer",
+                  "list_record_producers",
+                  "list_categories",
+                  "create_category",
+                  "link_item_to_category"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "[create_order_guide/create_record_producer/create_category] Display name"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create_order_guide/create_record_producer/create_category] Short description shown on the catalog tile"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create_order_guide/create_record_producer/create_category] Long description / overview"
+              },
+              "sc_catalogs": {
+                "type": "string",
+                "description": "[create_order_guide/create_record_producer/create_category/list_*] Catalog sys_id (sc_catalog) to attach to or filter by"
+              },
+              "category": {
+                "type": "string",
+                "description": "[create_order_guide/create_record_producer] Initial sc_category sys_id (use link_item_to_category to add more later)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[create_order_guide/create_record_producer/create_category] Whether the record is active",
+                "default": true
+              },
+              "include_items": {
+                "type": "boolean",
+                "description": "[create_order_guide] Whether items are pre-selected for the requester (sc_cat_item_guide.include_items)",
+                "default": true
+              },
+              "table_name": {
+                "type": "string",
+                "description": "[create_record_producer/list_record_producers] Target table the producer writes to (e.g. incident, change_request, problem)"
+              },
+              "script": {
+                "type": "string",
+                "description": "[create_record_producer] Server-side script that maps producer variables to the target record. ES5 only — use var, function(), and string concatenation; no const/let/arrow/template literals"
+              },
+              "parent": {
+                "type": "string",
+                "description": "[create_category/list_categories] Parent sc_category sys_id (for nested categories) or filter"
+              },
+              "title": {
+                "type": "string",
+                "description": "[create_category] Category display title (defaults to name)"
+              },
+              "homepage_renderer": {
+                "type": "string",
+                "description": "[create_category] sys_id of the sc_homepage_renderer used to render the category. Mandatory on sc_category — defaults to the OOB Default Renderer if omitted."
+              },
+              "cat_item": {
+                "type": "string",
+                "description": "[link_item_to_category] Catalog item sys_id (sc_cat_item) to link"
+              },
+              "category_sys_id": {
+                "type": "string",
+                "description": "[link_item_to_category] Category sys_id (sc_category) to link the item to"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_*] Only return active records",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_*] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_*] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_catalog_client_script",
+          "description": "Creates client scripts for catalog items to add custom JavaScript behavior to forms.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog",
+            "client-scripts",
+            "form-behavior"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cat_item": {
+                "type": "string",
+                "description": "Catalog item sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Script name"
+              },
+              "script": {
+                "type": "string",
+                "description": "JavaScript code"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type: onLoad, onChange, onSubmit, onCellEdit"
+              },
+              "applies_to": {
+                "type": "string",
+                "description": "Applies to: item, set, variable"
+              },
+              "variable": {
+                "type": "string",
+                "description": "Variable name (for onChange)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active status",
+                "default": true
+              }
+            },
+            "required": [
+              "cat_item",
+              "name",
+              "script",
+              "type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_catalog_item",
+          "description": "Publish a Service Catalog item (sc_cat_item) with name, short/long descriptions, category, and price. The item becomes orderable; attach question variables with snow_create_catalog_variable.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog",
+            "create",
+            "service-catalog"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "short_description": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "price": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_catalog_ui_policy",
+          "description": "Creates comprehensive UI policies for catalog items with conditions and actions to control form behavior dynamically.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog",
+            "ui-policies",
+            "form-control"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cat_item": {
+                "type": "string",
+                "description": "Catalog item sys_id"
+              },
+              "short_description": {
+                "type": "string",
+                "description": "Policy name"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Legacy condition script (optional if conditions array provided)"
+              },
+              "applies_to": {
+                "type": "string",
+                "description": "Applies to: item, set, or variable"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active status",
+                "default": true
+              },
+              "on_load": {
+                "type": "boolean",
+                "description": "Run on form load",
+                "default": true
+              },
+              "reverse_if_false": {
+                "type": "boolean",
+                "description": "Reverse actions if false",
+                "default": true
+              },
+              "conditions": {
+                "type": "array",
+                "description": "Array of condition objects for dynamic policy evaluation",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Condition type (catalog_variable, javascript)",
+                      "default": "catalog_variable"
+                    },
+                    "catalog_variable": {
+                      "type": "string",
+                      "description": "Target catalog variable sys_id or name"
+                    },
+                    "operation": {
+                      "type": "string",
+                      "description": "Comparison operation: is, is_not, is_empty, is_not_empty, contains, does_not_contain",
+                      "default": "is"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "Comparison value"
+                    },
+                    "and_or": {
+                      "type": "string",
+                      "description": "Logical operator with next condition: AND, OR",
+                      "default": "AND"
+                    }
+                  },
+                  "required": [
+                    "catalog_variable",
+                    "operation"
+                  ]
+                }
+              },
+              "actions": {
+                "type": "array",
+                "description": "Array of action objects to execute when conditions are met",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action type: set_mandatory, set_visible, set_readonly, set_value",
+                      "default": "set_visible"
+                    },
+                    "catalog_variable": {
+                      "type": "string",
+                      "description": "Target catalog variable sys_id or name"
+                    },
+                    "mandatory": {
+                      "type": "boolean",
+                      "description": "Set field as mandatory (for set_mandatory type)"
+                    },
+                    "visible": {
+                      "type": "boolean",
+                      "description": "Set field visibility (for set_visible type)"
+                    },
+                    "readonly": {
+                      "type": "boolean",
+                      "description": "Set field as readonly (for set_readonly type)"
+                    },
+                    "cleared": {
+                      "type": "boolean",
+                      "description": "Clear the variable value"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "Value to set (for set_value type)"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "catalog_variable"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "cat_item",
+              "short_description"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_catalog_variable",
+          "description": "Add an input variable to a catalog item (item_option_new) with name, question text, and input type (single/multi-line text, multiple_choice, select_box). Mostly equivalent to snow_create_variable but with a narrower type list.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "catalog",
+            "variables",
+            "forms"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cat_item": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "question_text": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "single_line_text",
+                  "multi_line_text",
+                  "multiple_choice",
+                  "select_box"
+                ]
+              }
+            },
+            "required": [
+              "cat_item",
+              "name",
+              "question_text",
+              "type"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_catalogs",
+          "description": "Discovers available service catalogs and their categories in the ServiceNow instance.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "discovery",
+            "catalogs",
+            "categories"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "include_categories": {
+                "type": "boolean",
+                "description": "Include category tree",
+                "default": true
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active catalogs",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_catalog_item_details",
+          "description": "Gets detailed information about a catalog item including variables, pricing, and availability.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "catalog",
+            "retrieval",
+            "details"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Catalog item sys_id"
+              },
+              "include_variables": {
+                "type": "boolean",
+                "description": "Include all variables",
+                "default": true
+              },
+              "include_ui_policies": {
+                "type": "boolean",
+                "description": "Include UI policies",
+                "default": false
+              },
+              "include_client_scripts": {
+                "type": "boolean",
+                "description": "Include client scripts",
+                "default": false
+              }
+            },
+            "required": [
+              "sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_order_catalog_item",
+          "description": "Orders a catalog item programmatically, creating a request (RITM) with specified variable values.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ordering",
+            "automation",
+            "ritm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "cat_item": {
+                "type": "string",
+                "description": "Catalog item sys_id"
+              },
+              "requested_for": {
+                "type": "string",
+                "description": "User sys_id or username"
+              },
+              "variables": {
+                "type": "object",
+                "description": "Variable name-value pairs"
+              },
+              "quantity": {
+                "type": "number",
+                "description": "Quantity to order",
+                "default": 1
+              },
+              "delivery_address": {
+                "type": "string",
+                "description": "Delivery address"
+              },
+              "special_instructions": {
+                "type": "string",
+                "description": "Special instructions"
+              }
+            },
+            "required": [
+              "cat_item",
+              "requested_for"
+            ]
+          }
+        },
+        {
+          "name": "snow_search_catalog",
+          "description": "Searches service catalog for items, categories, or catalogs. Returns available items for ordering.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "search",
+            "catalog",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Search query"
+              },
+              "category": {
+                "type": "string",
+                "description": "Filter by category"
+              },
+              "catalog": {
+                "type": "string",
+                "description": "Filter by catalog"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active items",
+                "default": true
+              },
+              "include_variables": {
+                "type": "boolean",
+                "description": "Include item variables",
+                "default": false
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum results",
+                "default": 20
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "service-portal",
+      "displayName": "Service Portal",
+      "tools": [
+        {
+          "name": "snow_create_sp_page",
+          "description": "Create a Service Portal page (sp_page) with a stable id, display title, and public flag (anonymous access). Page becomes accessible at /sp?id=<id> once placed in a portal layout.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "portal-pages",
+            "service-portal",
+            "page-creation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "public": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "required": [
+              "id",
+              "title"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_sp_widget",
+          "description": "Create a Service Portal widget (sp_widget) bundling AngularJS template, client_script, server_script, and CSS under a stable id. Widgets are placed on pages via the portal page editor.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "portal-widgets",
+            "service-portal",
+            "widget-creation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "template": {
+                "type": "string"
+              },
+              "client_script": {
+                "type": "string"
+              },
+              "server_script": {
+                "type": "string"
+              },
+              "css": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_sp_page_manage",
+          "description": "Unified tool for ServiceNow Service Portal page lifecycle beyond creation: list, update, delete, clone, add_widget_instance. Wraps sp_page and sp_instance.\n\nActions:\n- list — list sp_page rows, optionally filtered by portal id, public flag, or title fragment\n- update — patch sp_page fields (title, public, draft, css, internal)\n- delete — delete an sp_page row (does not cascade widget instances)\n- clone — duplicate an sp_page with a new id and title (optionally copying widget instances)\n- add_widget_instance — place an sp_widget on the page by creating an sp_instance row\n\nUse when: the agent needs to maintain Service Portal pages — renaming, retiring, duplicating layouts, or wiring widgets onto a page. For authoring a new sp_page, use snow_create_sp_page; for authoring a new sp_widget, use snow_create_sp_widget.\n\nReturns: sp_page rows with sys_id, id, title, public, draft; widget instance rows with sys_id, sp_widget reference, and column placement.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "service-portal",
+            "portal-pages",
+            "widget-instances",
+            "page-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "update",
+                  "delete",
+                  "clone",
+                  "add_widget_instance"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[update/delete/clone/add_widget_instance] Page sys_id"
+              },
+              "id": {
+                "type": "string",
+                "description": "[update/delete/clone/add_widget_instance] Page stable id (used as identifier when sys_id is absent)"
+              },
+              "title_like": {
+                "type": "string",
+                "description": "[list] Filter by title substring"
+              },
+              "public_only": {
+                "type": "boolean",
+                "description": "[list] Only return pages with public=true",
+                "default": false
+              },
+              "include_drafts": {
+                "type": "boolean",
+                "description": "[list] Include pages with draft=true",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list] Comma-separated list of fields to return"
+              },
+              "title": {
+                "type": "string",
+                "description": "[update/clone] Page display title"
+              },
+              "public": {
+                "type": "boolean",
+                "description": "[update] Whether the page is accessible without login"
+              },
+              "draft": {
+                "type": "boolean",
+                "description": "[update] Whether the page is a draft"
+              },
+              "css": {
+                "type": "string",
+                "description": "[update] Page-level CSS"
+              },
+              "internal": {
+                "type": "boolean",
+                "description": "[update] Whether the page is internal (not surfaced in the portal nav)"
+              },
+              "new_id": {
+                "type": "string",
+                "description": "[clone] Stable id for the cloned page (required)"
+              },
+              "copy_widget_instances": {
+                "type": "boolean",
+                "description": "[clone] Also copy sp_instance rows attached to the source page",
+                "default": true
+              },
+              "widget_id": {
+                "type": "string",
+                "description": "[add_widget_instance] sp_widget sys_id or stable id to place on the page"
+              },
+              "column_sys_id": {
+                "type": "string",
+                "description": "[add_widget_instance] sp_column sys_id to attach the instance to (preferred). Omit to attach to the page directly."
+              },
+              "instance_title": {
+                "type": "string",
+                "description": "[add_widget_instance] Optional title override for the widget instance"
+              },
+              "order": {
+                "type": "number",
+                "description": "[add_widget_instance] Display order within the column"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_sp_theme_manage",
+          "description": "Unified tool for ServiceNow Service Portal theming. Operates over sp_theme (theme definitions), sp_brand (per-portal branding records such as logo and favicon), sp_css (theme-scoped stylesheets), and sp_portal (the portal records that reference a theme).\n\nActions:\n- list_themes — list all sp_theme records with their name, header, footer, and CSS variable bundle\n- create_theme — create a new sp_theme with name, css_variables, header, and footer\n- update_branding — upsert an sp_brand row (logo, favicon, color tokens) for a given portal; existing brand rows are patched in place, otherwise a new row is inserted\n- clone_theme — duplicate an existing sp_theme (and its sp_css children) under a new name so a per-tenant variant can be edited independently of the source\n- apply_theme_to_portal — set sp_portal.theme to a given theme sys_id so the portal renders with the new look on the next page load\n\nUse when: rolling out white-labeled portals per tenant, building a base theme + per-customer overlays, or migrating an existing portal onto a redesigned theme without rewriting the underlying widgets. Companion tools: snow_create_sp_widget for content, snow_create_sp_page for page composition.\n\nReturns: action-specific structures. list_themes returns theme rows with related CSS counts. create_theme and clone_theme return the new sys_id plus the copied sp_css rows. update_branding indicates whether the row was inserted or patched. apply_theme_to_portal returns the updated sp_portal record.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "service-portal",
+            "theming",
+            "branding",
+            "white-label",
+            "multi-tenant"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Theme management action to perform",
+                "enum": [
+                  "list_themes",
+                  "create_theme",
+                  "update_branding",
+                  "clone_theme",
+                  "apply_theme_to_portal"
+                ]
+              },
+              "theme_sys_id": {
+                "type": "string",
+                "description": "[clone_theme/apply_theme_to_portal] sys_id of the source or target sp_theme"
+              },
+              "theme_name": {
+                "type": "string",
+                "description": "[clone_theme/apply_theme_to_portal] Theme name (used when theme_sys_id is not provided)"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create_theme/clone_theme] Name for the new theme"
+              },
+              "css_variables": {
+                "type": "string",
+                "description": "[create_theme] CSS variables block (e.g. --brand-primary: #ff6600;) compiled into the theme"
+              },
+              "header": {
+                "type": "string",
+                "description": "[create_theme] Header widget id or HTML reference (defaults to OOB stock-header)"
+              },
+              "footer": {
+                "type": "string",
+                "description": "[create_theme] Footer widget id or HTML reference (defaults to OOB stock-footer)"
+              },
+              "copy_css": {
+                "type": "boolean",
+                "description": "[clone_theme] Also copy the source theme's sp_css children",
+                "default": true
+              },
+              "portal": {
+                "type": "string",
+                "description": "[update_branding/apply_theme_to_portal] sp_portal sys_id (or unique URL suffix) to brand or to apply the theme to"
+              },
+              "logo": {
+                "type": "string",
+                "description": "[update_branding] Logo image URL or sys_attachment sys_id"
+              },
+              "favicon": {
+                "type": "string",
+                "description": "[update_branding] Favicon URL or sys_attachment sys_id"
+              },
+              "primary_color": {
+                "type": "string",
+                "description": "[update_branding] Primary brand color (hex, e.g. #1f6feb)"
+              },
+              "secondary_color": {
+                "type": "string",
+                "description": "[update_branding] Secondary brand color (hex)"
+              },
+              "brand_name": {
+                "type": "string",
+                "description": "[update_branding] Display brand name shown in headers and tab titles"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_themes] Maximum themes to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_themes] Comma-separated list of fields to return"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "session",
+      "displayName": "Session",
+      "tools": [
+        {
+          "name": "snow_session_context",
+          "description": "Dump the current ServiceNow session context for the authenticated user: sys_id, username, email, roles (with inherited flag), current update set, domain, timezone, locale. One call instead of 3-4 scattered queries. Use this to ground ACL / role-based reasoning before running a script or diagnosing permissions.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "debugging",
+            "acl",
+            "roles",
+            "update-sets",
+            "session-inspection"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "include_inherited_roles": {
+                "type": "boolean",
+                "description": "Return inherited roles in addition to directly granted ones. Default: true.",
+                "default": true
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "sla",
+      "displayName": "Sla",
+      "tools": [
+        {
+          "name": "snow_calculate_sla_duration",
+          "description": "Calculate SLA duration with schedule",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "sla-calculation",
+            "time-tracking",
+            "duration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "start_time": {
+                "type": "string",
+                "description": "Start datetime"
+              },
+              "end_time": {
+                "type": "string",
+                "description": "End datetime"
+              },
+              "schedule_sys_id": {
+                "type": "string",
+                "description": "Schedule sys_id"
+              }
+            },
+            "required": [
+              "start_time",
+              "end_time"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_sla",
+          "description": "Create Service Level Agreement",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sla-management",
+            "service-level",
+            "agreements"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "SLA name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "duration": {
+                "type": "string",
+                "description": "Duration (e.g., \"4 Hours\")"
+              },
+              "condition": {
+                "type": "string",
+                "description": "When SLA applies"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "Schedule sys_id"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "duration"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_sla_definition",
+          "description": "Creates Service Level Agreement definitions. Sets duration targets, business schedules, and breach conditions.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "sla",
+            "service-levels"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "SLA Definition name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to apply SLA to"
+              },
+              "condition": {
+                "type": "string",
+                "description": "SLA condition script"
+              },
+              "duration": {
+                "type": "string",
+                "description": "Duration specification (e.g., \"8:00:00\" for 8 hours)"
+              },
+              "durationType": {
+                "type": "string",
+                "description": "Duration type (business, calendar)",
+                "default": "business"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "Schedule to use (sys_id or name)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "SLA active status",
+                "default": true
+              },
+              "description": {
+                "type": "string",
+                "description": "SLA description"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "condition",
+              "duration"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_sla_status",
+          "description": "List all task_sla rows attached to a task record (incident, request, etc.) by record sys_id. Returns display values: SLA name, business %, breached flag, time-left — one row per applicable SLA.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "sla-monitoring",
+            "status-check",
+            "service-level"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              }
+            },
+            "required": [
+              "table",
+              "record_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_sla_manage",
+          "description": "Unified tool for ServiceNow SLA and OLA lifecycle beyond view-only status checks: list, update, breach_response, pause, resume, list_breaches. Wraps contract_sla (definitions, including OLAs) and task_sla (running instances).\n\nActions:\n- list — list contract_sla definitions, optionally filtered by table or SLA type (SLA or OLA)\n- update — patch contract_sla fields (duration, condition, schedule, active, retroactive flags)\n- breach_response — append a work note and optional escalation to a task_sla row that has breached\n- pause — pause a running task_sla row (sets stage to paused with a reason)\n- resume — resume a paused task_sla row\n- list_breaches — list task_sla rows where has_breached=true, optionally scoped to a table or assignment_group\n\nUse when: the agent needs to maintain SLA definitions, react to breaches, or pause/resume in-flight SLAs on individual records. For creating a new contract_sla, use snow_create_sla; for a read-only status of one task's SLAs, use snow_get_sla_status.\n\nReturns: contract_sla rows with sys_id, name, duration, collection, type; task_sla rows with stage, has_breached, business_percentage; breach lists scoped by table and group.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sla-management",
+            "ola",
+            "service-level",
+            "breaches"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list",
+                  "update",
+                  "breach_response",
+                  "pause",
+                  "resume",
+                  "list_breaches"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[update] contract_sla sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "[update] contract_sla name (used as identifier when sys_id is absent)"
+              },
+              "task_sla_sys_id": {
+                "type": "string",
+                "description": "[breach_response/pause/resume] task_sla sys_id"
+              },
+              "table": {
+                "type": "string",
+                "description": "[list/list_breaches] Filter by table (e.g. incident, change_request)"
+              },
+              "sla_type": {
+                "type": "string",
+                "description": "[list] Filter by SLA type",
+                "enum": [
+                  "SLA",
+                  "OLA"
+                ]
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list] Only return active SLA definitions",
+                "default": false
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "[list_breaches] Filter by sys_user_group sys_id"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list/list_breaches] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list/list_breaches] Comma-separated list of fields to return"
+              },
+              "duration": {
+                "type": "string",
+                "description": "[update] Duration in HH:MM:SS or human-readable form (e.g. \"4 Hours\")"
+              },
+              "condition": {
+                "type": "string",
+                "description": "[update] Encoded query for when the SLA applies"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "[update] Schedule sys_id (cmn_schedule)"
+              },
+              "pause_condition": {
+                "type": "string",
+                "description": "[update] Encoded query that pauses the SLA when true"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[update] Whether the SLA definition is active"
+              },
+              "retroactive": {
+                "type": "boolean",
+                "description": "[update] Whether the SLA is retroactive (apply to existing tasks)"
+              },
+              "retroactive_pause": {
+                "type": "boolean",
+                "description": "[update] Whether retroactive pause is allowed"
+              },
+              "response_note": {
+                "type": "string",
+                "description": "[breach_response] Work note to append explaining the breach response"
+              },
+              "escalate": {
+                "type": "boolean",
+                "description": "[breach_response] Also raise the parent task's escalation level by 1",
+                "default": false
+              },
+              "pause_reason": {
+                "type": "string",
+                "description": "[pause] Reason for the pause (stored in the work_notes journal on the task_sla)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "soap",
+      "displayName": "Soap",
+      "tools": [
+        {
+          "name": "snow_create_web_service",
+          "description": "Create SOAP web service integration from WSDL definition",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "soap",
+            "web-service"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Web Service name"
+              },
+              "wsdlUrl": {
+                "type": "string",
+                "description": "WSDL URL or location"
+              },
+              "description": {
+                "type": "string",
+                "description": "Web Service description"
+              },
+              "authType": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "basic",
+                  "wsse",
+                  "oauth2"
+                ],
+                "description": "Authentication type",
+                "default": "none"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Service namespace"
+              },
+              "username": {
+                "type": "string",
+                "description": "Username for basic/WSSE authentication"
+              },
+              "password": {
+                "type": "string",
+                "description": "Password for basic/WSSE authentication"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Active flag",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "wsdlUrl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "specialized",
+      "displayName": "Specialized",
+      "tools": [
+        {
+          "name": "snow_create_devops_pipeline",
+          "description": "Create DevOps pipeline for CI/CD automation",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "devops"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Pipeline name"
+              },
+              "repository": {
+                "type": "string",
+                "description": "Source repository"
+              },
+              "branch": {
+                "type": "string",
+                "description": "Branch to build"
+              },
+              "stages": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Pipeline stages"
+              },
+              "triggers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Pipeline triggers"
+              },
+              "environment": {
+                "type": "string",
+                "description": "Target environment"
+              }
+            },
+            "required": [
+              "name",
+              "repository",
+              "branch"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "state-management",
+      "displayName": "State Management",
+      "tools": [
+        {
+          "name": "snow_create_uib_client_state",
+          "description": "Create client state for UI Builder pages via Builder Toolkit API. Client state is managed as state_properties on the page macroponent.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "state",
+            "persistence"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "macroponent_id": {
+                "type": "string",
+                "description": "Page macroponent sys_id (from page creation response)"
+              },
+              "name": {
+                "type": "string",
+                "description": "State variable name"
+              },
+              "initial_value": {
+                "type": "string",
+                "description": "Initial state value (JSON string, default: \"{}\")"
+              },
+              "type": {
+                "type": "string",
+                "description": "State property type (e.g., \"STRING\", \"OBJECT\", \"BOOLEAN\", \"NUMBER\")"
+              }
+            },
+            "required": [
+              "macroponent_id",
+              "name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "synchronization",
+      "displayName": "Synchronization",
+      "tools": [
+        {
+          "name": "snow_sync_data_consistency",
+          "description": "Synchronizes cached data with ServiceNow, validates sys_id mappings, and repairs consistency issues. Includes automatic cache refresh and reindexing.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sync",
+            "consistency",
+            "cache-refresh"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "refresh_cache",
+                  "validate_sysids",
+                  "reindex_artifacts",
+                  "full_sync"
+                ],
+                "description": "Type of sync operation"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Specific sys_id to validate (optional)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Specific table to sync (optional)"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "table-analysis",
+      "displayName": "Table Analysis",
+      "tools": [
+        {
+          "name": "snow_blast_radius_table_configs",
+          "description": "Find every configuration running on a specific table. Use to inventory artifacts scoped to a table, understand the configuration landscape before making changes, or filter by config type, scope, or active status.\n\nExample: \"What configs run on the incident table?\"\n\nCoverage: by default searches a curated set of 13 main config types — business rules, client scripts, UI actions, UI policies (+ actions), data policies (+ rules), ACLs, email notifications, metric definitions, inbound email actions, transform entries, plus global-but-table-mentioning script includes. Pass an explicit `config_types` array to query any of the 26 supported types from ARTIFACT_SPECS.\n\nParent tables are walked via sys_db_object.super_class (opt-out).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "impact-analysis",
+            "table-audit",
+            "governance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table_name": {
+                "type": "string",
+                "description": "Table name (e.g., 'incident', 'change_request')"
+              },
+              "config_types": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "business_rules",
+                    "client_scripts",
+                    "ui_actions",
+                    "ui_policies",
+                    "ui_policy_actions",
+                    "data_policies",
+                    "data_policy_rules",
+                    "acls",
+                    "email_notifications",
+                    "metric_definitions",
+                    "dictionary_dependent",
+                    "script_includes",
+                    "scheduled_jobs",
+                    "fix_scripts",
+                    "script_actions",
+                    "transform_scripts",
+                    "transform_entries",
+                    "processors",
+                    "ui_scripts",
+                    "scripted_rest_resources",
+                    "email_scripts",
+                    "inbound_email_actions",
+                    "portal_widgets",
+                    "catalog_client_scripts",
+                    "catalog_ui_policies",
+                    "atf_steps"
+                  ]
+                },
+                "description": "Filter to specific artifact types. Default: a curated set of 13 main config types (TABLE_CONFIG_TYPES); pass an explicit list to access any of the 26 supported types."
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include inactive configurations (default: false)",
+                "default": false
+              },
+              "include_scripts": {
+                "type": "boolean",
+                "description": "Include script bodies in results (larger payload, default: false)",
+                "default": false
+              },
+              "include_parent_tables": {
+                "type": "boolean",
+                "description": "Walk sys_db_object.super_class to include parent-table artifacts. Default: true.",
+                "default": true
+              },
+              "scope": {
+                "type": "string",
+                "description": "Filter by application scope sys_id"
+              },
+              "limit_per_type": {
+                "type": "number",
+                "description": "Maximum configs per type (default: 50)",
+                "default": 50
+              }
+            },
+            "required": [
+              "table_name"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "task-management",
+      "displayName": "Task Management",
+      "tools": [
+        {
+          "name": "snow_assign_task",
+          "description": "Assign task to user or group with workload balancing and skill matching",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "task-assignment",
+            "workload"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Task table (incident, change_request, sc_task, etc.)",
+                "default": "task"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Task sys_id or number"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "User sys_id or username to assign to"
+              },
+              "assignment_group": {
+                "type": "string",
+                "description": "Group sys_id or name to assign to"
+              },
+              "auto_assign": {
+                "type": "boolean",
+                "description": "Auto-assign to available group member with lowest workload",
+                "default": false
+              },
+              "check_availability": {
+                "type": "boolean",
+                "description": "Check user availability before assignment",
+                "default": false
+              },
+              "work_notes": {
+                "type": "string",
+                "description": "Work notes to add with assignment"
+              }
+            },
+            "required": [
+              "sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "templates",
+      "displayName": "Templates",
+      "tools": [
+        {
+          "name": "snow_create_template",
+          "description": "Save a record template (sys_template) — a named, reusable set of pre-filled field values for a given table that users can apply with one click when creating new records.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "template-creation",
+            "record-templates",
+            "automation"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Template name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "template": {
+                "type": "object",
+                "description": "Template field values"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "template"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "testing",
+      "displayName": "Testing",
+      "tools": [
+        {
+          "name": "snow_cleanup_test_artifacts",
+          "description": "Safely cleanup test artifacts from ServiceNow (dry-run enabled by default for safety)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "cleanup"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "artifact_type": {
+                "type": "string",
+                "description": "Type of artifacts to clean up",
+                "enum": [
+                  "incidents",
+                  "requests",
+                  "test_data",
+                  "all"
+                ]
+              },
+              "name_pattern": {
+                "type": "string",
+                "description": "Pattern to match artifact names (e.g., \"TEST\", \"DEMO\")",
+                "default": "TEST"
+              },
+              "dry_run": {
+                "type": "boolean",
+                "description": "Preview cleanup without executing (default: true for safety)",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of records to clean up",
+                "default": 10,
+                "maximum": 100
+              }
+            },
+            "required": [
+              "artifact_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_atf_test",
+          "description": "Create Automated Test Framework (ATF) test for automated testing",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Test name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Test description"
+              },
+              "testFor": {
+                "type": "string",
+                "description": "What to test (form, list, service_portal, api, workflow)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table to test (if applicable)"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Test active status",
+                "default": true
+              },
+              "category": {
+                "type": "string",
+                "description": "Test category (regression, smoke, integration)"
+              }
+            },
+            "required": [
+              "name",
+              "testFor"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_atf_test_step",
+          "description": "Adds a test step to an existing ATF test. Steps define the actions and assertions for testing using the sys_atf_step table.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "test-steps"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "testId": {
+                "type": "string",
+                "description": "Parent test sys_id or name"
+              },
+              "stepType": {
+                "type": "string",
+                "description": "Step type (e.g., form_submission, impersonate, assert_condition, open_form, server_script)"
+              },
+              "order": {
+                "type": "number",
+                "description": "Step execution order"
+              },
+              "description": {
+                "type": "string",
+                "description": "Step description"
+              },
+              "stepConfig": {
+                "type": "object",
+                "description": "Step configuration (varies by type)"
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Step timeout in seconds",
+                "default": 30
+              }
+            },
+            "required": [
+              "testId",
+              "stepType",
+              "order"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_atf_test_suite",
+          "description": "Creates an ATF test suite to group and run multiple tests together using sys_atf_test_suite table.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "test-suites"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Test suite name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Suite description"
+              },
+              "tests": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Test IDs or names to include"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Suite active status",
+                "default": true
+              },
+              "runParallel": {
+                "type": "boolean",
+                "description": "Run tests in parallel",
+                "default": false
+              }
+            },
+            "required": [
+              "name",
+              "tests"
+            ]
+          }
+        },
+        {
+          "name": "snow_dev_test_connection",
+          "description": "Developer-only tool for testing ServiceNow connections, OAuth credentials, and table/column accessibility against a live instance. Use during tool development to validate assumptions (table existence, field names, query shape) before shipping production tools.\n\nActions:\n- oauth — test arbitrary OAuth credentials (instance + grant_type + client_id + secret, optional username/password for password grant). Returns redacted token info on success.\n- connection — verify the current authenticated context is healthy via a sys_user lookup.\n- table — verify a table exists and is accessible (sys_db_object lookup). Returns table label, parent class, and scope.\n- columns — list a table's column definitions from sys_dictionary. Critical for validating field-name TODOs in newly-built tools. Optional fields filter to limit response size.\n- query — dry-run an encoded query against a table with limit=1 to confirm result shape.\n\nUse when: building new tools that target unfamiliar tables, validating TODO-marked column names from recent PRs, sanity-checking OAuth setup on a new instance, or troubleshooting \"tool returns 404\" errors. Companion to snow_test_connection (production smoke test) and snow_validate_live_connection — this is the developer-time variant with finer-grained verification actions.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "development",
+            "testing",
+            "oauth-debugging",
+            "schema-verification",
+            "tool-validation",
+            "column-name-verification"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Test action to perform",
+                "enum": [
+                  "oauth",
+                  "connection",
+                  "table",
+                  "columns",
+                  "query"
+                ]
+              },
+              "instance_url": {
+                "type": "string",
+                "description": "[oauth] Instance hostname or URL (e.g. dev380262.service-now.com or https://dev380262.service-now.com)"
+              },
+              "grant_type": {
+                "type": "string",
+                "enum": [
+                  "client_credentials",
+                  "password"
+                ],
+                "default": "client_credentials",
+                "description": "[oauth] OAuth grant type. password requires username + password."
+              },
+              "client_id": {
+                "type": "string",
+                "description": "[oauth] OAuth client_id from System OAuth > Application Registry"
+              },
+              "client_secret": {
+                "type": "string",
+                "description": "[oauth] OAuth client_secret"
+              },
+              "username": {
+                "type": "string",
+                "description": "[oauth/password grant] Username of the service account"
+              },
+              "password": {
+                "type": "string",
+                "description": "[oauth/password grant] Password of the service account"
+              },
+              "table": {
+                "type": "string",
+                "description": "[table/columns/query] Target table name (e.g. pa_indicators, sn_si_incident, wm_order)"
+              },
+              "sysparm_query": {
+                "type": "string",
+                "description": "[query] Encoded query string (e.g. active=true^state=1)"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "[query/columns] Optional field name list to limit response size or scope the columns query"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_atf_tests",
+          "description": "Discovers ATF tests in the instance with filtering and search capabilities.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "discovery"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "type": "string",
+                "description": "Filter by test category"
+              },
+              "table": {
+                "type": "string",
+                "description": "Filter by table name"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Filter by active status"
+              },
+              "nameContains": {
+                "type": "string",
+                "description": "Search by name pattern"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum number of tests to return",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_execute_atf_test",
+          "description": "Executes an ATF test or test suite and returns the results. Tests run asynchronously in ServiceNow using sys_atf_test_result table.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "execution"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "testId": {
+                "type": "string",
+                "description": "Test sys_id or name to execute"
+              },
+              "suiteId": {
+                "type": "string",
+                "description": "Test suite sys_id or name (alternative to testId)"
+              },
+              "async": {
+                "type": "boolean",
+                "description": "Run asynchronously",
+                "default": true
+              },
+              "waitForResult": {
+                "type": "boolean",
+                "description": "Wait for test completion",
+                "default": false
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_generate_records",
+          "description": "Generate multiple test records",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "test-data",
+            "data-generation",
+            "testing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "count": {
+                "type": "number",
+                "description": "Number of records to generate",
+                "default": 10
+              },
+              "template": {
+                "type": "object",
+                "description": "Template for generated records"
+              }
+            },
+            "required": [
+              "table",
+              "template"
+            ]
+          }
+        },
+        {
+          "name": "snow_get_atf_results",
+          "description": "Retrieves ATF test execution results including pass/fail status, error details, and execution time from sys_atf_test_result table.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "testing",
+            "atf",
+            "results"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "executionId": {
+                "type": "string",
+                "description": "Test execution ID"
+              },
+              "testId": {
+                "type": "string",
+                "description": "Test ID to get latest results"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Number of recent results to retrieve",
+                "default": 10
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_rest_message_test_suite",
+          "description": "Comprehensive testing suite for REST messages including authentication, endpoints, headers, and response validation.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "rest",
+            "testing"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "restMessageId": {
+                "type": "string",
+                "description": "REST message sys_id or name"
+              },
+              "testAuthentication": {
+                "type": "boolean",
+                "description": "Test authentication",
+                "default": true
+              },
+              "testEndpoints": {
+                "type": "boolean",
+                "description": "Test all endpoints",
+                "default": true
+              },
+              "testHeaders": {
+                "type": "boolean",
+                "description": "Test header configuration",
+                "default": true
+              },
+              "validateResponses": {
+                "type": "boolean",
+                "description": "Validate response structures",
+                "default": true
+              }
+            },
+            "required": [
+              "restMessageId"
+            ]
+          }
+        },
+        {
+          "name": "snow_test_integration",
+          "description": "Test REST/SOAP integrations and external connections with validation",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "testing",
+            "validation"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "integration_type": {
+                "type": "string",
+                "description": "Type of integration to test",
+                "enum": [
+                  "rest",
+                  "soap",
+                  "data_source",
+                  "email",
+                  "ldap"
+                ],
+                "default": "rest"
+              },
+              "integration_id": {
+                "type": "string",
+                "description": "Integration sys_id or name"
+              },
+              "method": {
+                "type": "string",
+                "description": "HTTP method for REST (GET, POST, etc.)",
+                "default": "GET"
+              },
+              "test_payload": {
+                "type": "object",
+                "description": "Test payload for POST/PUT requests"
+              },
+              "validate_response": {
+                "type": "boolean",
+                "description": "Validate response format",
+                "default": true
+              },
+              "timeout": {
+                "type": "number",
+                "description": "Timeout in seconds",
+                "default": 30
+              }
+            },
+            "required": [
+              "integration_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "threat-intelligence",
+      "displayName": "Threat Intelligence",
+      "tools": [
+        {
+          "name": "snow_analyze_threat_intelligence",
+          "description": "Correlate an indicator of compromise (IOC) — IP, domain, file hash, URL, or email — against threat intel feeds and the existing sn_si_threat_intel store. Returns risk level (LOW/MEDIUM/HIGH), per-feed match confidence, and recommended response posture.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "analysis",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ioc_value": {
+                "type": "string"
+              },
+              "ioc_type": {
+                "type": "string",
+                "enum": [
+                  "ip",
+                  "domain",
+                  "hash_md5",
+                  "hash_sha1",
+                  "hash_sha256",
+                  "url",
+                  "email"
+                ]
+              },
+              "threat_feed_sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "correlation_timeframe": {
+                "type": "string",
+                "enum": [
+                  "1_hour",
+                  "24_hours",
+                  "7_days",
+                  "30_days"
+                ]
+              }
+            },
+            "required": [
+              "ioc_value",
+              "ioc_type"
+            ]
+          }
+        },
+        {
+          "name": "snow_sir_indicator_manage",
+          "description": "Unified tool for the Indicator of Compromise (IOC) lifecycle on sn_ti_observable, sn_ti_indicator, and the SIR observable join table. Manages persistent IOC records — distinct from snow_analyze_threat_intelligence, which only correlates a single IOC against feeds without persisting state.\n\nActions:\n- create_ioc — create a new IOC record (value, type, finding required) on sn_ti_observable\n- list_iocs — list IOCs, optionally filtered by type, state, source, or seen-since\n- link_to_incident — link an existing IOC to a SIR incident via the observable-incident join table\n- mark_active — mark an IOC active (re-open after resolution)\n- mark_resolved — mark an IOC resolved (closed, no longer interesting)\n- search_by_value — find IOCs by exact or fragment match on value (IP, domain, hash, URL, email)\n\nUse when: the agent needs to manage persistent IOC records — open a new IOC after triage, attach existing IOCs to a new incident, search for prior sightings of a value, or close out an IOC after eradication. Companion tools: snow_analyze_threat_intelligence (one-shot feed correlation), snow_sir_incident_manage (parent incident lifecycle), snow_sir_evidence_manage (evidence chain of custody).\n\nTable-name volatility: the IOC table name varies by SN release (sn_ti_observable / sn_ti_indicator / sn_si_observable). This tool defaults to sn_ti_observable and falls back to sn_si_observable if the primary table is absent.\n\nPlugin gating: requires either Threat Intelligence or the Security Incident Response plugin (com.snc.security_incident). A 404 on both fallback tables is surfaced with the required plugin name.\n\nReturns: action-specific data. create_ioc returns the created record. list_iocs / search_by_value return arrays of IOCs with value, type, state, source, last_seen. link_to_incident returns the join-row sys_id. mark_active / mark_resolved return the updated record.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "sir",
+            "threat-intelligence",
+            "ioc",
+            "indicators",
+            "security"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Indicator management action to perform",
+                "enum": [
+                  "create_ioc",
+                  "list_iocs",
+                  "link_to_incident",
+                  "mark_active",
+                  "mark_resolved",
+                  "search_by_value"
+                ]
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "[link_to_incident/mark_active/mark_resolved] sys_id of the IOC observable record"
+              },
+              "incident_sys_id": {
+                "type": "string",
+                "description": "[link_to_incident] sys_id of the SIR incident the IOC should be attached to"
+              },
+              "incident_number": {
+                "type": "string",
+                "description": "[link_to_incident] SIR incident number (e.g. SIR0010001), alternative to incident_sys_id"
+              },
+              "ioc_value": {
+                "type": "string",
+                "description": "[create_ioc/search_by_value] The IOC value (IP, domain, hash, URL, email, file path)"
+              },
+              "ioc_type": {
+                "type": "string",
+                "description": "[create_ioc/list_iocs/search_by_value] IOC type",
+                "enum": [
+                  "ip",
+                  "domain",
+                  "url",
+                  "email",
+                  "hash_md5",
+                  "hash_sha1",
+                  "hash_sha256",
+                  "file_path",
+                  "user_agent",
+                  "registry_key"
+                ]
+              },
+              "finding": {
+                "type": "string",
+                "description": "[create_ioc] Why this IOC is interesting (one-line finding / context)"
+              },
+              "source": {
+                "type": "string",
+                "description": "[create_ioc/list_iocs] Source of the IOC (SIEM, EDR, threat feed name, manual)"
+              },
+              "confidence": {
+                "type": "string",
+                "description": "[create_ioc] Confidence level",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "tlp": {
+                "type": "string",
+                "description": "[create_ioc] Traffic Light Protocol marking",
+                "enum": [
+                  "white",
+                  "green",
+                  "amber",
+                  "red"
+                ]
+              },
+              "state_filter": {
+                "type": "string",
+                "description": "[list_iocs] Filter by IOC state",
+                "enum": [
+                  "active",
+                  "resolved"
+                ]
+              },
+              "seen_since": {
+                "type": "string",
+                "description": "[list_iocs] Filter by last-seen date (encoded query date >= YYYY-MM-DD)"
+              },
+              "match_mode": {
+                "type": "string",
+                "description": "[search_by_value] How to match the value",
+                "enum": [
+                  "exact",
+                  "contains",
+                  "starts_with"
+                ],
+                "default": "exact"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_iocs/search_by_value] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_iocs/search_by_value] Comma-separated list of fields to return"
+              },
+              "note": {
+                "type": "string",
+                "description": "[mark_active/mark_resolved] Optional work note describing the state change"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "threat-response",
+      "displayName": "Threat Response",
+      "tools": [
+        {
+          "name": "snow_automate_threat_response",
+          "description": "Execute a tiered incident response playbook (contain / isolate / eradicate / recover) for a known threat ID. Either runs the action set automatically and notifies the listed groups, or queues each action for security-team approval.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "threat_id": {
+                "type": "string"
+              },
+              "response_level": {
+                "type": "string",
+                "enum": [
+                  "contain",
+                  "isolate",
+                  "eradicate",
+                  "recover"
+                ]
+              },
+              "automated_actions": {
+                "type": "boolean"
+              },
+              "notification_groups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "threat_id",
+              "response_level"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ui",
+      "displayName": "Ui",
+      "tools": [
+        {
+          "name": "snow_add_list_column",
+          "description": "Add a column (field) to the default list layout of a table by writing to sys_ui_list_element, with optional position and pixel width. Changes how the list shows up in the UI.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "lists",
+            "views",
+            "ui-customization"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "element": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "position": {
+                "type": "number",
+                "description": "Column position"
+              },
+              "width": {
+                "type": "number",
+                "description": "Column width"
+              }
+            },
+            "required": [
+              "table",
+              "element"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_list_layout",
+          "description": "Create a complete list layout with multiple columns for any ServiceNow table",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "lists",
+            "list-layouts",
+            "views",
+            "ui-customization",
+            "columns"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name this layout applies to (e.g., \"incident\", \"change_request\")"
+              },
+              "view": {
+                "type": "string",
+                "description": "View name - use \"\" (empty string) for default view, \"mobile\" for mobile view, or custom view name",
+                "default": ""
+              },
+              "columns": {
+                "type": "array",
+                "description": "Array of column definitions with field names, positions, and optional widths",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string",
+                      "description": "Field name to display (e.g., \"number\", \"short_description\", \"priority\")"
+                    },
+                    "position": {
+                      "type": "number",
+                      "description": "Column position (0 = first column, 1 = second, etc.)"
+                    },
+                    "width": {
+                      "type": "number",
+                      "description": "Column width in pixels (optional, defaults to auto)"
+                    }
+                  },
+                  "required": [
+                    "field",
+                    "position"
+                  ]
+                }
+              },
+              "relationship": {
+                "type": "string",
+                "description": "For related lists, specify the relationship field (e.g., \"parent\" for child records)"
+              },
+              "parent": {
+                "type": "string",
+                "description": "For related lists, specify the parent table name"
+              }
+            },
+            "required": [
+              "table",
+              "columns"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_list_view",
+          "description": "Create a named list view (sys_ui_list) on a table with a comma-joined field list and an optional default filter. Lets users switch into a curated column set instead of the table default.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "lists",
+            "views",
+            "ui-customization"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "View name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Fields to display"
+              },
+              "filter": {
+                "type": "string",
+                "description": "Default filter"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_menu",
+          "description": "Create a top-level application menu (sys_app_module) with title, owning application, and display order. Container for navigation items added via snow_create_menu_item.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "menu-creation",
+            "navigation",
+            "ui-development"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Menu title"
+              },
+              "application": {
+                "type": "string",
+                "description": "Application sys_id"
+              },
+              "order": {
+                "type": "number",
+                "description": "Menu order"
+              },
+              "active": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_menu_item",
+          "description": "Add a navigation item (sys_app_module) under a parent menu, opening a list / new record / detail / home view on a target table. Order controls placement within the parent.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "menu-items",
+            "navigation",
+            "ui-development"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "description": "Item title"
+              },
+              "parent": {
+                "type": "string",
+                "description": "Parent menu sys_id"
+              },
+              "link_type": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "new",
+                  "detail",
+                  "home"
+                ],
+                "default": "list"
+              },
+              "table": {
+                "type": "string",
+                "description": "Target table"
+              },
+              "order": {
+                "type": "number",
+                "description": "Item order"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_related_list",
+          "description": "Surface a related table under a parent table's form view (sys_ui_related_list) — e.g. show related Tasks below an Incident. Use relationship_field for non-standard joins.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "lists",
+            "relationships",
+            "forms"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Related list name"
+              },
+              "parent_table": {
+                "type": "string",
+                "description": "Parent table"
+              },
+              "related_table": {
+                "type": "string",
+                "description": "Related table"
+              },
+              "relationship_field": {
+                "type": "string",
+                "description": "Field linking tables"
+              }
+            },
+            "required": [
+              "name",
+              "parent_table",
+              "related_table"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_saved_filter",
+          "description": "Create a saved filter for any ServiceNow table that appears in the filter dropdown",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "filters",
+            "saved-filters",
+            "list-views",
+            "ui-customization"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Filter name that appears in the dropdown (e.g., \"My Active High Priority Items\")"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name this filter applies to (e.g., \"incident\", \"change_request\")"
+              },
+              "filter": {
+                "type": "string",
+                "description": "Encoded query string (e.g., \"active=true^priority=1\")"
+              },
+              "user": {
+                "type": "string",
+                "description": "User sys_id or username - leave empty for global filter visible to all users"
+              },
+              "roles": {
+                "type": "string",
+                "description": "Comma-separated role names required to see this filter (e.g., \"itil,admin\")"
+              },
+              "order": {
+                "type": "number",
+                "description": "Sort order in the filter dropdown (lower numbers appear first)",
+                "default": 100
+              },
+              "active": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether the filter is active and visible"
+              }
+            },
+            "required": [
+              "name",
+              "table",
+              "filter"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ui-builder",
+      "displayName": "Ui Builder",
+      "tools": [
+        {
+          "name": "snow_uib_component_manage",
+          "description": "Unified UIB component management (create, clone)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "component-creation",
+            "component-cloning",
+            "ui-builder"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Component management action",
+                "enum": [
+                  "create",
+                  "clone"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "[create/clone] Component name (internal identifier)"
+              },
+              "label": {
+                "type": "string",
+                "description": "[create/clone] Component label (display name)"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/clone] Component description"
+              },
+              "category": {
+                "type": "string",
+                "description": "[create/clone] Component category"
+              },
+              "source_code": {
+                "type": "string",
+                "description": "[create] Component JavaScript source code"
+              },
+              "template": {
+                "type": "string",
+                "description": "[create] Component HTML template"
+              },
+              "styles": {
+                "type": "string",
+                "description": "[create] Component CSS styles"
+              },
+              "properties": {
+                "type": "object",
+                "description": "[create] Component properties schema"
+              },
+              "version": {
+                "type": "string",
+                "description": "[create/clone] Component version"
+              },
+              "source_component_id": {
+                "type": "string",
+                "description": "[clone] Source component sys_id to clone"
+              },
+              "new_name": {
+                "type": "string",
+                "description": "[clone] Name for cloned component"
+              },
+              "new_label": {
+                "type": "string",
+                "description": "[clone] Label for cloned component"
+              },
+              "modifications": {
+                "type": "object",
+                "description": "[clone] Specific modifications to apply"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_uib_discover",
+          "description": "Unified UI Builder discovery (pages, components, routes, page_usage)",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "ui-builder",
+            "discovery",
+            "components",
+            "pages"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Discovery action to perform",
+                "enum": [
+                  "pages",
+                  "components",
+                  "routes",
+                  "page_usage"
+                ]
+              },
+              "search": {
+                "type": "string",
+                "description": "[pages/components] Search names and titles"
+              },
+              "experience": {
+                "type": "string",
+                "description": "[pages] Filter by experience sys_id"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[pages] Return only active pages",
+                "default": true
+              },
+              "include_routes": {
+                "type": "boolean",
+                "description": "[pages] Include route information",
+                "default": true
+              },
+              "category": {
+                "type": "string",
+                "description": "[components] Filter by category"
+              },
+              "include_custom": {
+                "type": "boolean",
+                "description": "[components] Include custom components",
+                "default": true
+              },
+              "include_builtin": {
+                "type": "boolean",
+                "description": "[components] Include built-in components",
+                "default": true
+              },
+              "experience_sys_id": {
+                "type": "string",
+                "description": "[routes] Experience sys_id to get routes"
+              },
+              "page_sys_id": {
+                "type": "string",
+                "description": "[page_usage] Page sys_id to analyze"
+              },
+              "days_back": {
+                "type": "number",
+                "description": "[page_usage] Days of usage history",
+                "default": 30
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "ui-policies",
+      "displayName": "Ui Policies",
+      "tools": [
+        {
+          "name": "snow_create_ui_policy_action",
+          "description": "Create a UI policy action to control field behavior (visible/mandatory/readonly) when a UI policy condition is met. Requires the parent UI policy sys_id and the target table name.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "ui-policy-actions",
+            "form-control",
+            "ui-automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "ui_policy_sys_id": {
+                "type": "string",
+                "description": "sys_id of the parent UI policy (sys_ui_policy)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name the UI policy applies to (e.g. 'incident', 'change_request'). Must match the table on the parent UI policy."
+              },
+              "field": {
+                "type": "string",
+                "description": "Field name to control (e.g. 'close_notes', 'assignment_group')"
+              },
+              "visible": {
+                "type": "boolean",
+                "description": "Set field visibility. true = visible, false = hidden. Omit to leave unchanged ('ignore')."
+              },
+              "mandatory": {
+                "type": "boolean",
+                "description": "Set field mandatory state. true = required, false = optional. Omit to leave unchanged ('ignore')."
+              },
+              "readonly": {
+                "type": "boolean",
+                "description": "Set field read-only state. true = read-only, false = editable. Omit to leave unchanged ('ignore')."
+              },
+              "cleared": {
+                "type": "boolean",
+                "description": "Clear the field value when the policy condition is true. Default: false."
+              }
+            },
+            "required": [
+              "ui_policy_sys_id",
+              "table",
+              "field"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "update-sets",
+      "displayName": "Update Sets",
+      "tools": [
+        {
+          "name": "snow_ensure_active_update_set",
+          "description": "Ensure Update Set is active and optionally set as current for user",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "update-sets",
+            "activation",
+            "change-tracking"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Update Set name (creates if doesn't exist)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description for new Update Set"
+              },
+              "sync_with_user": {
+                "type": "boolean",
+                "description": "Set this as user's current Update Set in ServiceNow",
+                "default": true
+              },
+              "create_if_missing": {
+                "type": "boolean",
+                "description": "Create Update Set if it doesn't exist",
+                "default": true
+              },
+              "application_scope": {
+                "type": "string",
+                "description": "Application scope for the Update Set. Use \"global\" (default) for global scope, or provide a scoped application sys_id or scope name.",
+                "default": "global"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_update_set_manage",
+          "description": "Unified tool for Update Set management. Actions: create, switch, complete, ignore, export, preview, add_artifact, current.\n\nHow tracking works:\nUpdate Sets must be \"current\" for the user making changes — and via API the user is the OAuth service account. With auto_switch=true (default), the new Update Set is set as current for the service account so subsequent changes are tracked. auto_switch=false skips this and changes are NOT tracked.\n\nApplication scope:\nPass application_scope to create the Update Set within a scoped application — supply an application sys_id or scope name (e.g. \"x_myco_hr_portal\"). Default is \"global\". Update Sets in a scoped app only track changes to artifacts in that scope.\n\nUI visibility:\nThe Update Set being current for the service account does not make it appear current in your own ServiceNow UI. Pass the optional servicenow_username to also set it as current for that user — this only affects UI visibility, not tracking.\n\nRecommended: always use auto_switch=true for development; add servicenow_username when you want to see the Update Set as current in your own UI; use application_scope for scoped-app development; only set auto_switch=false for non-development read-only operations.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "update-sets",
+            "change-tracking",
+            "deployment"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "create",
+                  "switch",
+                  "complete",
+                  "ignore",
+                  "export",
+                  "preview",
+                  "add_artifact",
+                  "current"
+                ]
+              },
+              "update_set_id": {
+                "type": "string",
+                "description": "Update Set sys_id (required for switch/complete/export/preview, optional for add_artifact)"
+              },
+              "name": {
+                "type": "string",
+                "description": "[create] Update Set name (e.g., \"STORY-123: Add incident widget\")"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create/complete] Description or completion notes"
+              },
+              "user_story": {
+                "type": "string",
+                "description": "[create] User story or ticket number"
+              },
+              "release_date": {
+                "type": "string",
+                "description": "[create] Target release date"
+              },
+              "servicenow_username": {
+                "type": "string",
+                "description": "[create/switch] Optional: ServiceNow username to ALSO set Update Set as current for (e.g., \"john.doe\"). This makes the Update Set visible as current in YOUR ServiceNow UI. The Update Set is ALWAYS set as current for the OAuth service account to enable change tracking."
+              },
+              "auto_switch": {
+                "type": "boolean",
+                "description": "[create] Automatically switch to created Update Set for the service account (default: true). MUST be true for automatic change tracking. Only set to false if you are NOT making development changes.",
+                "default": true
+              },
+              "application_scope": {
+                "type": "string",
+                "description": "[create] Application scope for this Update Set. Use \"global\" (default) for global scope, or provide a scoped application sys_id or scope name (e.g., \"x_myco_hr_portal\"). When set to a scoped application, the Update Set will only track changes to artifacts within that application scope.",
+                "default": "global"
+              },
+              "notes": {
+                "type": "string",
+                "description": "[complete] Completion notes or testing instructions"
+              },
+              "include_preview": {
+                "type": "boolean",
+                "description": "[export/preview] Include change preview information",
+                "default": true
+              },
+              "include_payload": {
+                "type": "boolean",
+                "description": "[preview] Include XML payload details",
+                "default": false
+              },
+              "artifact_type": {
+                "type": "string",
+                "description": "[add_artifact] Artifact type (widget, flow, script, etc.)"
+              },
+              "artifact_sys_id": {
+                "type": "string",
+                "description": "[add_artifact] ServiceNow sys_id of the artifact"
+              },
+              "artifact_name": {
+                "type": "string",
+                "description": "[add_artifact] Artifact name for tracking"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_update_set_query",
+          "description": "Query Update Sets (get current or list multiple)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "update-sets",
+            "query",
+            "status"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Query action to perform",
+                "enum": [
+                  "current",
+                  "list"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "description": "[list] Filter by state",
+                "enum": [
+                  "in progress",
+                  "complete",
+                  "released"
+                ]
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum number of results",
+                "default": 10
+              },
+              "order_by": {
+                "type": "string",
+                "description": "[list] Order by field",
+                "default": "sys_created_on"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "user-admin",
+      "displayName": "User Admin",
+      "tools": [
+        {
+          "name": "snow_get_user_roles",
+          "description": "Get all roles assigned to user",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "roles",
+            "users",
+            "query"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id"
+              }
+            },
+            "required": [
+              "user_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_role_group_manage",
+          "description": "Unified role and group management (create_role, assign_role, create_group)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "roles",
+            "groups",
+            "permissions",
+            "user-admin"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Role/group management action",
+                "enum": [
+                  "create_role",
+                  "assign_role",
+                  "create_group"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "[create_role/create_group] Role or group name"
+              },
+              "description": {
+                "type": "string",
+                "description": "[create_role/create_group] Description"
+              },
+              "requires_subscription": {
+                "type": "string",
+                "description": "[create_role] Required subscription"
+              },
+              "role": {
+                "type": "string",
+                "description": "[assign_role] Role sys_id"
+              },
+              "user": {
+                "type": "string",
+                "description": "[assign_role] User sys_id (user or group required)"
+              },
+              "group": {
+                "type": "string",
+                "description": "[assign_role/create_group] Group sys_id or manager sys_id"
+              },
+              "inherited": {
+                "type": "boolean",
+                "description": "[assign_role] Inherited assignment",
+                "default": false
+              },
+              "manager": {
+                "type": "string",
+                "description": "[create_group] Manager sys_id"
+              },
+              "type": {
+                "type": "string",
+                "description": "[create_group] Group type"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[create_group] Active status",
+                "default": true
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
+          "name": "snow_user_manage",
+          "description": "Unified user management (create, deactivate)",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "users",
+            "user-admin",
+            "accounts"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "User management action",
+                "enum": [
+                  "create",
+                  "deactivate"
+                ]
+              },
+              "user_name": {
+                "type": "string",
+                "description": "[create] Username"
+              },
+              "first_name": {
+                "type": "string",
+                "description": "[create] First name"
+              },
+              "last_name": {
+                "type": "string",
+                "description": "[create] Last name"
+              },
+              "email": {
+                "type": "string",
+                "description": "[create] Email address"
+              },
+              "department": {
+                "type": "string",
+                "description": "[create] Department sys_id"
+              },
+              "manager": {
+                "type": "string",
+                "description": "[create] Manager sys_id"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "[create] Active status",
+                "default": true
+              },
+              "user_id": {
+                "type": "string",
+                "description": "[deactivate] User sys_id"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "user-management",
+      "displayName": "User Management",
+      "tools": [
+        {
+          "name": "snow_manage_group_membership",
+          "description": "Manage group memberships: add/remove users, list members",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "user-management",
+            "access-control",
+            "group-administration"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Operation: add, remove, or list",
+                "enum": [
+                  "add",
+                  "remove",
+                  "list"
+                ]
+              },
+              "user_identifier": {
+                "type": "string",
+                "description": "User sys_id, username, or email"
+              },
+              "group_identifier": {
+                "type": "string",
+                "description": "Group sys_id or name"
+              },
+              "include_details": {
+                "type": "boolean",
+                "description": "Include user details (list only)",
+                "default": true
+              }
+            },
+            "required": [
+              "action",
+              "group_identifier"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "utilities",
+      "displayName": "Utilities",
+      "tools": [
+        {
+          "name": "snow_autocomplete",
+          "description": "Suggest values for an autocomplete UX: fetches the top N values of a field from a table where the field LIKE the query string. Useful for typeahead inputs without building a full reference field.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "autocomplete",
+            "search",
+            "ux"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "query": {
+                "type": "string",
+                "description": "Search query"
+              },
+              "limit": {
+                "type": "number",
+                "default": 10
+              }
+            },
+            "required": [
+              "table",
+              "field",
+              "query"
+            ]
+          }
+        },
+        {
+          "name": "snow_convert_es6_to_es5",
+          "description": "Convert ES6+ JavaScript to ES5 for ServiceNow compatibility. Use this when debugging SyntaxErrors.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "es5-conversion",
+            "debugging",
+            "syntax-fix",
+            "servicenow-compatibility"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "The JavaScript code to convert from ES6+ to ES5"
+              },
+              "analyze_only": {
+                "type": "boolean",
+                "description": "Only analyze for ES6+ features, do not convert",
+                "default": false
+              },
+              "show_diff": {
+                "type": "boolean",
+                "description": "Show differences between original and converted code",
+                "default": true
+              }
+            },
+            "required": [
+              "code"
+            ]
+          }
+        },
+        {
+          "name": "snow_decode_base64",
+          "description": "Decode a Base64-encoded string back to UTF-8 text. Local operation — no ServiceNow call. Pair with snow_encode_base64 for round-tripping.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "encoding",
+            "decoding",
+            "base64"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "encoded": {
+                "type": "string",
+                "description": "Base64 encoded string"
+              }
+            },
+            "required": [
+              "encoded"
+            ]
+          }
+        },
+        {
+          "name": "snow_decode_url",
+          "description": "URL-decode a percent-encoded string (decodeURIComponent). Local operation — no ServiceNow call. Pair with snow_encode_url to round-trip query params.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "encoding",
+            "decoding",
+            "url"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "encoded": {
+                "type": "string",
+                "description": "URL encoded string"
+              }
+            },
+            "required": [
+              "encoded"
+            ]
+          }
+        },
+        {
+          "name": "snow_encode_base64",
+          "description": "Encode a UTF-8 string as Base64. Local operation — no ServiceNow call. Handy for embedding binary-ish data in JSON payloads (e.g. attachment uploads).",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "encoding",
+            "base64",
+            "conversion"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to encode"
+              }
+            },
+            "required": [
+              "text"
+            ]
+          }
+        },
+        {
+          "name": "snow_encode_url",
+          "description": "URL-encode a string for safe use in query parameters (encodeURIComponent). Local operation — no ServiceNow call.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "encoding",
+            "url",
+            "conversion"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to encode"
+              }
+            },
+            "required": [
+              "text"
+            ]
+          }
+        },
+        {
+          "name": "snow_format_date",
+          "description": "Format a date string in one of four shapes: ISO date (YYYY-MM-DD), ISO datetime, ISO time, or human-readable relative (e.g. '5 minutes ago'). Local operation — no ServiceNow call.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "formatting",
+            "dates",
+            "conversion"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "date": {
+                "type": "string",
+                "description": "Date to format"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "date",
+                  "datetime",
+                  "time",
+                  "relative"
+                ],
+                "default": "datetime"
+              }
+            },
+            "required": [
+              "date"
+            ]
+          }
+        },
+        {
+          "name": "snow_format_number",
+          "description": "Format a number as a decimal, currency (with code prefix), or percent, with a configurable decimal precision (default 2). Local operation — no ServiceNow call.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "formatting",
+            "numbers",
+            "conversion"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "number": {
+                "type": "number",
+                "description": "Number to format"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "decimal",
+                  "currency",
+                  "percent"
+                ],
+                "default": "decimal"
+              },
+              "decimals": {
+                "type": "number",
+                "default": 2
+              },
+              "currency": {
+                "type": "string",
+                "default": "USD"
+              }
+            },
+            "required": [
+              "number"
+            ]
+          }
+        },
+        {
+          "name": "snow_format_text",
+          "description": "Format text with various transformations",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "formatting",
+            "text",
+            "transformation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to format"
+              },
+              "transform": {
+                "type": "string",
+                "enum": [
+                  "uppercase",
+                  "lowercase",
+                  "titlecase",
+                  "camelcase",
+                  "snakecase"
+                ],
+                "default": "lowercase"
+              }
+            },
+            "required": [
+              "text"
+            ]
+          }
+        },
+        {
+          "name": "snow_generate_guid",
+          "description": "Generate a unique identifier in one of three shapes: ServiceNow sys_id (32-char hex, no dashes), uppercase GUID, or lowercase UUID. Uses crypto.randomUUID — safe for IDs but not for secrets.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "guid-generation",
+            "identifiers",
+            "utilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "uuid",
+                  "guid",
+                  "sys_id"
+                ],
+                "default": "sys_id"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_hash_string",
+          "description": "Hash string using various algorithms",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "hashing",
+            "cryptography",
+            "security"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Text to hash"
+              },
+              "algorithm": {
+                "type": "string",
+                "enum": [
+                  "md5",
+                  "sha1",
+                  "sha256",
+                  "sha512"
+                ],
+                "default": "sha256"
+              }
+            },
+            "required": [
+              "text"
+            ]
+          }
+        },
+        {
+          "name": "snow_merge_objects",
+          "description": "Merge an array of objects left-to-right via spread (later keys win). Note: this is a shallow merge despite the name — nested objects are overwritten, not merged recursively. Local operation.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "object-merging",
+            "data-utilities",
+            "utilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "objects": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "description": "Objects to merge"
+              }
+            },
+            "required": [
+              "objects"
+            ]
+          }
+        },
+        {
+          "name": "snow_random_string",
+          "description": "Generate a cryptographically-secure random string of a given length (default 16) from an alphanumeric, alpha-only, numeric, or hex charset. Uses crypto.randomBytes with rejection sampling — safe for tokens.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "random-generation",
+            "strings",
+            "utilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "length": {
+                "type": "number",
+                "default": 16
+              },
+              "charset": {
+                "type": "string",
+                "enum": [
+                  "alphanumeric",
+                  "alpha",
+                  "numeric",
+                  "hex"
+                ],
+                "default": "alphanumeric"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_retry_operation",
+          "description": "Retry failed operation with backoff",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "retry",
+            "error-handling",
+            "resilience"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation_id": {
+                "type": "string",
+                "description": "Operation ID to retry"
+              },
+              "max_retries": {
+                "type": "number",
+                "default": 3
+              },
+              "backoff_ms": {
+                "type": "number",
+                "default": 1000
+              }
+            },
+            "required": [
+              "operation_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_sanitize_input",
+          "description": "Escape a user-supplied string against html, sql, or script-injection contexts. Note: prefer parameterized queries for SQL — sanitization is a fallback, not the primary defense.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "input-sanitization",
+            "security",
+            "validation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "Input to sanitize"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "html",
+                  "sql",
+                  "script"
+                ],
+                "default": "html"
+              }
+            },
+            "required": [
+              "input"
+            ]
+          }
+        },
+        {
+          "name": "snow_sleep",
+          "description": "Sleep for specified milliseconds",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "delay",
+            "timing",
+            "utilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "milliseconds": {
+                "type": "number",
+                "description": "Sleep duration in ms",
+                "default": 1000
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_timestamp",
+          "description": "Get current timestamp in various formats",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "timestamps",
+            "time",
+            "utilities"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "iso",
+                  "unix",
+                  "unix_ms",
+                  "date",
+                  "time"
+                ],
+                "default": "iso"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_url_doctor",
+          "description": "Decode or construct ServiceNow URLs. Mode 'decode' parses an existing URL (nav_to.do, TABLE.do, workspace URLs) and extracts table, sys_id, view, and every sysparm_* parameter. Mode 'build' constructs a canonical form or list URL from table + sys_id/filter/view. Handy when agents need to hand the user a deep-link or reason about URL parameters.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "urls",
+            "deep-links",
+            "navigation",
+            "debugging"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "decode",
+                  "build"
+                ],
+                "description": "'decode' parses a URL; 'build' constructs one"
+              },
+              "url": {
+                "type": "string",
+                "description": "URL to decode (required for mode=decode)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name for mode=build (e.g. 'incident', 'sys_user')"
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "Record sys_id for mode=build. Use '-1' for a new-record form. Omit for list view."
+              },
+              "query": {
+                "type": "string",
+                "description": "sysparm_query filter for mode=build (list view). Example: 'state=1^assigned_to=javascript:gs.getUserID()'"
+              },
+              "view": {
+                "type": "string",
+                "description": "Form/list view name for mode=build"
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "validation",
+      "displayName": "Validation",
+      "tools": [
+        {
+          "name": "snow_validate_field",
+          "description": "Look up a field's dictionary definition (sys_dictionary) for a given table.field and verify the value fits its internal_type. Returns the resolved field_type along with a valid flag.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "field-validation",
+            "data-validation",
+            "validation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "field": {
+                "type": "string",
+                "description": "Field name"
+              },
+              "value": {
+                "type": "string",
+                "description": "Value to validate"
+              }
+            },
+            "required": [
+              "table",
+              "field",
+              "value"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_record",
+          "description": "Validate record against business rules",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "record-validation",
+            "business-rules",
+            "validation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table name"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id"
+              }
+            },
+            "required": [
+              "table",
+              "record_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_sysid",
+          "description": "Validates sys_id existence and consistency across tables. Maintains artifact tracking for deployment integrity and rollback capabilities.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "sysid-validation",
+            "integrity-check",
+            "validation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Sys ID to validate"
+              },
+              "table": {
+                "type": "string",
+                "description": "Expected table name"
+              },
+              "name": {
+                "type": "string",
+                "description": "Expected artifact name"
+              },
+              "type": {
+                "type": "string",
+                "description": "Expected artifact type"
+              }
+            },
+            "required": [
+              "sys_id",
+              "table"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_widget_coherence",
+          "description": "Validates widget coherence by analyzing server/client/HTML component communication. Checks data bindings, action handlers, and method implementations to ensure all parts work together correctly.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "widget-validation",
+            "coherence-check",
+            "testing"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Widget sys_id to validate (optional if providing code)"
+              },
+              "template": {
+                "type": "string",
+                "description": "HTML template code (optional if using sys_id)"
+              },
+              "css": {
+                "type": "string",
+                "description": "CSS styles (optional)"
+              },
+              "client_script": {
+                "type": "string",
+                "description": "Client controller script (optional)"
+              },
+              "server_script": {
+                "type": "string",
+                "description": "Server script (optional)"
+              },
+              "option_schema": {
+                "type": "string",
+                "description": "Widget options schema JSON"
+              },
+              "validation_mode": {
+                "type": "string",
+                "enum": [
+                  "full",
+                  "template_only",
+                  "data_only"
+                ],
+                "description": "Validation mode: full (all components), template_only (HTML bindings), data_only (server data)",
+                "default": "full"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_widget_test",
+          "description": "Executes comprehensive widget testing with multiple data scenarios. Validates client/server scripts, API calls, dependencies, and generates coverage reports.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "widget-testing",
+            "testing",
+            "validation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_id": {
+                "type": "string",
+                "description": "Widget sys_id to test"
+              },
+              "test_scenarios": {
+                "type": "array",
+                "description": "Array of test scenarios with input data and expected outputs",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Test scenario name"
+                    },
+                    "input": {
+                      "type": "object",
+                      "description": "Input data for the test"
+                    },
+                    "expected": {
+                      "type": "object",
+                      "description": "Expected output (optional)"
+                    },
+                    "options": {
+                      "type": "object",
+                      "description": "Widget instance options"
+                    }
+                  }
+                }
+              },
+              "coverage": {
+                "type": "boolean",
+                "description": "Check code coverage for HTML/CSS/JS integration",
+                "default": true
+              },
+              "validate_dependencies": {
+                "type": "boolean",
+                "description": "Check for missing dependencies like Chart.js",
+                "default": true
+              }
+            },
+            "required": [
+              "sys_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "vendor-risk",
+      "displayName": "Vendor Risk",
+      "tools": [
+        {
+          "name": "snow_grc_vendor_risk_manage",
+          "description": "Unified tool for ServiceNow GRC Vendor Risk Management: vendor inventory, assessment kick-off, and linkage back to the central risk register. Wraps the sn_vdr_vendor, sn_vdr_assessment, and sn_vdr_question_template tables that ship with the GRC: Vendor Risk Management plugin.\n\nActions:\n- list_vendors — list vendors in the third-party inventory, optionally filtered by tier or active flag\n- assess_vendor — kick off a vendor assessment using a question template (creates an sn_vdr_assessment row in draft state)\n- list_assessments — list assessments, optionally filtered by vendor, state, or framework\n- create_assessment — create an assessment record directly with explicit fields (low-level alternative to assess_vendor)\n- link_to_risk — link a vendor assessment back to an entry in the central risk register (sn_risk_advanced_risk)\n\nUse when: the agent needs to drive third-party / vendor risk — inventorying vendors, kicking off questionnaire-based assessments, and connecting the vendor risk outcome to the central risk register. For internal risk register operations use snow_grc_risk_manage; for compliance issues and exceptions use snow_grc_issue_manage.\n\nReturns: vendor rows with sys_id, name, tier, active flag; assessment rows with state, template, scheduled date; question template rows with sys_id and name. GRC plugin gating: the first call against the vendor tables will surface a clear error if the GRC: Vendor Risk Management plugin is not active on the target instance.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "grc",
+            "vendor-risk",
+            "third-party",
+            "assessment",
+            "vrm"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Management action to perform",
+                "enum": [
+                  "list_vendors",
+                  "assess_vendor",
+                  "list_assessments",
+                  "create_assessment",
+                  "link_to_risk"
+                ]
+              },
+              "vendor_sys_id": {
+                "type": "string",
+                "description": "[assess_vendor/list_assessments/create_assessment] Vendor sys_id (sn_vdr_vendor)"
+              },
+              "assessment_sys_id": {
+                "type": "string",
+                "description": "[link_to_risk] Assessment sys_id (sn_vdr_assessment)"
+              },
+              "template_sys_id": {
+                "type": "string",
+                "description": "[assess_vendor/create_assessment] Question template sys_id (sn_vdr_question_template)"
+              },
+              "risk_sys_id": {
+                "type": "string",
+                "description": "[link_to_risk] Risk sys_id (sn_risk_advanced_risk) to link the assessment to"
+              },
+              "tier": {
+                "type": "string",
+                "description": "[list_vendors] Filter by vendor tier (tier_1, tier_2, tier_3, tier_4, critical, strategic)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "[list_vendors] Only return active vendors",
+                "default": false
+              },
+              "state": {
+                "type": "string",
+                "description": "[list_assessments] Filter by assessment state",
+                "enum": [
+                  "draft",
+                  "scheduled",
+                  "in_progress",
+                  "submitted",
+                  "reviewed",
+                  "completed",
+                  "cancelled"
+                ]
+              },
+              "framework": {
+                "type": "string",
+                "description": "[list_assessments] Filter by compliance framework (SOC2, ISO27001, NIST, custom)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list_vendors/list_assessments] Maximum records to return",
+                "default": 50
+              },
+              "fields": {
+                "type": "string",
+                "description": "[list_vendors/list_assessments] Comma-separated list of fields to return"
+              },
+              "assessment_name": {
+                "type": "string",
+                "description": "[assess_vendor/create_assessment] Assessment name / short description"
+              },
+              "scheduled_start_date": {
+                "type": "string",
+                "description": "[assess_vendor/create_assessment] ISO date string (YYYY-MM-DD) for scheduled start"
+              },
+              "due_date": {
+                "type": "string",
+                "description": "[assess_vendor/create_assessment] ISO date string (YYYY-MM-DD) when the assessment is due"
+              },
+              "assigned_to": {
+                "type": "string",
+                "description": "[assess_vendor/create_assessment] sys_user sys_id of the vendor-side respondent"
+              },
+              "assessment_framework": {
+                "type": "string",
+                "description": "[create_assessment] Compliance framework label (SOC2, ISO27001, NIST, custom)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "virtual-agent",
+      "displayName": "Virtual Agent",
+      "tools": [
+        {
+          "name": "snow_create_va_topic",
+          "description": "Create Virtual Agent conversation topic",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "conversational-ai",
+            "nlu"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "utterances": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "response": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "utterances"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_va_topic_block",
+          "description": "Creates a conversation block within a Virtual Agent topic. Blocks define conversation steps and responses.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "conversation-flow",
+            "topic-blocks"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "topic": {
+                "type": "string",
+                "description": "Parent topic sys_id"
+              },
+              "name": {
+                "type": "string",
+                "description": "Block name"
+              },
+              "type": {
+                "type": "string",
+                "description": "Block type: text, question, script, handoff, decision"
+              },
+              "order": {
+                "type": "number",
+                "description": "Block execution order"
+              },
+              "text": {
+                "type": "string",
+                "description": "Response text for text blocks"
+              },
+              "script": {
+                "type": "string",
+                "description": "Script for script blocks"
+              },
+              "variable": {
+                "type": "string",
+                "description": "Variable to store user input"
+              },
+              "next_block": {
+                "type": "string",
+                "description": "Next block to execute"
+              }
+            },
+            "required": [
+              "topic",
+              "name",
+              "type",
+              "order"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_va_topics",
+          "description": "Discovers available Virtual Agent topics and their configurations.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "topic-discovery",
+            "conversational-ai"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "type": "string",
+                "description": "Filter by category"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Show only active topics",
+                "default": true
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_get_va_conversation",
+          "description": "Retrieves Virtual Agent conversation history and context for a specific session.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "conversation-history",
+            "analytics"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "conversation_id": {
+                "type": "string",
+                "description": "Conversation sys_id"
+              },
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id (alternative to conversation_id)"
+              },
+              "include_transcript": {
+                "type": "boolean",
+                "description": "Include full transcript",
+                "default": true
+              },
+              "limit": {
+                "type": "number",
+                "description": "Maximum messages to retrieve",
+                "default": 50
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_handoff_to_agent",
+          "description": "Initiates handoff from Virtual Agent to a live agent when automated assistance is insufficient.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "agent-handoff",
+            "escalation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "conversation_id": {
+                "type": "string",
+                "description": "Conversation to handoff"
+              },
+              "queue": {
+                "type": "string",
+                "description": "Agent queue for routing"
+              },
+              "priority": {
+                "type": "number",
+                "description": "Queue priority"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Handoff reason"
+              },
+              "context": {
+                "type": "object",
+                "description": "Context to pass to agent"
+              }
+            },
+            "required": [
+              "conversation_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_send_va_message",
+          "description": "Sends a message to Virtual Agent and gets the response. Simulates user interaction with the chatbot.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "testing",
+            "conversation"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "conversation_id": {
+                "type": "string",
+                "description": "Existing conversation ID (optional)"
+              },
+              "message": {
+                "type": "string",
+                "description": "User message text"
+              },
+              "user_id": {
+                "type": "string",
+                "description": "User sys_id"
+              },
+              "context": {
+                "type": "object",
+                "description": "Additional context variables"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        {
+          "name": "snow_train_va_nlu",
+          "description": "Trigger training of a Virtual Agent NLU model by model_id via /api/now/v1/va/models/{id}/train. Training runs asynchronously on the platform; this call only starts the job.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "virtual-agent",
+            "nlu-training",
+            "machine-learning"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "model_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "model_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "vulnerability-management",
+      "displayName": "Vulnerability Management",
+      "tools": [
+        {
+          "name": "snow_scan_vulnerabilities",
+          "description": "Scan for security vulnerabilities",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "security",
+            "vulnerabilities",
+            "scanning"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "scan_type": {
+                "type": "string",
+                "enum": [
+                  "full",
+                  "quick"
+                ]
+              }
+            },
+            "required": [
+              "target"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "vulnerability-scanning",
+      "displayName": "Vulnerability Scanning",
+      "tools": [
+        {
+          "name": "snow_create_vulnerability_scan",
+          "description": "Creates vulnerability scanning configurations. Schedules scans, sets severity thresholds, and enables auto-remediation.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "scanning",
+            "security",
+            "compliance"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Scan name"
+              },
+              "scope": {
+                "type": "string",
+                "description": "Scan scope (application, platform, integrations)"
+              },
+              "schedule": {
+                "type": "string",
+                "description": "Scan schedule"
+              },
+              "severity": {
+                "type": "string",
+                "description": "Minimum severity to report"
+              },
+              "notifications": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Notification recipients"
+              },
+              "remediation": {
+                "type": "boolean",
+                "description": "Auto-remediation enabled"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Scan active status"
+              }
+            },
+            "required": [
+              "name",
+              "scope"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "workflow",
+      "displayName": "Workflow",
+      "tools": [
+        {
+          "name": "snow_create_workflow",
+          "description": "⚠️ LEGACY: Create workflow definition (deprecated - ServiceNow recommends Flow Designer). Use for backwards compatibility only. For new automations, consider Flow Designer and ask Serac to generate a specification document.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workflow",
+            "process-automation",
+            "business-logic"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Workflow name"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table workflow applies to"
+              },
+              "description": {
+                "type": "string",
+                "description": "Workflow description"
+              },
+              "condition": {
+                "type": "string",
+                "description": "When to trigger workflow"
+              }
+            },
+            "required": [
+              "name",
+              "table"
+            ]
+          },
+          "deprecated": true
+        },
+        {
+          "name": "snow_create_workflow_activity",
+          "description": "⚠️ LEGACY: Create workflow activity (deprecated - ServiceNow recommends Flow Designer). Configures activity types, conditions, and execution order.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "automation",
+            "workflow",
+            "activities"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Activity name"
+              },
+              "workflowName": {
+                "type": "string",
+                "description": "Parent workflow name or sys_id"
+              },
+              "activityType": {
+                "type": "string",
+                "description": "Activity type (approval, script, notification, etc.)"
+              },
+              "script": {
+                "type": "string",
+                "description": "Activity script (ES5 only!)"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Activity condition"
+              },
+              "order": {
+                "type": "number",
+                "description": "Activity order",
+                "default": 100
+              },
+              "description": {
+                "type": "string",
+                "description": "Activity description"
+              }
+            },
+            "required": [
+              "name",
+              "workflowName",
+              "activityType"
+            ]
+          },
+          "deprecated": true
+        },
+        {
+          "name": "snow_start_workflow",
+          "description": "⚠️ LEGACY: Start a workflow on a record (deprecated - ServiceNow recommends Flow Designer). Workflows run asynchronously.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workflow",
+            "workflow-execution",
+            "automation"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "workflow_sys_id": {
+                "type": "string",
+                "description": "Workflow sys_id (from wf_workflow table)"
+              },
+              "workflow_name": {
+                "type": "string",
+                "description": "Workflow name (alternative to sys_id)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Table name the record belongs to"
+              },
+              "record_sys_id": {
+                "type": "string",
+                "description": "Record sys_id to run workflow on"
+              }
+            },
+            "required": [
+              "record_sys_id",
+              "table"
+            ]
+          },
+          "deprecated": true
+        },
+        {
+          "name": "snow_workflow_analyze",
+          "description": "Analyze workflow executions for performance and errors",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "integration",
+            "workflow",
+            "analysis"
+          ],
+          "complexity": "advanced",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "workflow_name": {
+                "type": "string",
+                "description": "Workflow name or sys_id"
+              },
+              "time_range_hours": {
+                "type": "number",
+                "description": "Analyze executions from last N hours",
+                "default": 24
+              },
+              "include_performance": {
+                "type": "boolean",
+                "description": "Include performance analysis",
+                "default": true
+              },
+              "include_errors": {
+                "type": "boolean",
+                "description": "Include error analysis",
+                "default": true
+              }
+            },
+            "required": [
+              "workflow_name"
+            ]
+          }
+        },
+        {
+          "name": "snow_workflow_manage",
+          "description": "⚠️ LEGACY: Manage legacy workflows (deprecated - ServiceNow recommends Flow Designer). Use for backwards compatibility only. For new automations, consider Flow Designer (not programmable via Serac, but specs can be generated). Actions: list, get, stop, retry, clone, enable/disable, delete, get_history",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workflow",
+            "process-automation",
+            "workflow-management"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "stop",
+                  "retry",
+                  "clone",
+                  "enable",
+                  "disable",
+                  "delete",
+                  "get_history"
+                ],
+                "description": "Action to perform"
+              },
+              "workflow_id": {
+                "type": "string",
+                "description": "Workflow sys_id or name (required for get, stop, retry, clone, enable, disable, delete)"
+              },
+              "context_id": {
+                "type": "string",
+                "description": "Workflow context sys_id (required for stop, retry, get_history on specific execution)"
+              },
+              "table": {
+                "type": "string",
+                "description": "Filter workflows by table (for list action)"
+              },
+              "active_only": {
+                "type": "boolean",
+                "description": "Only list active workflows",
+                "default": true
+              },
+              "new_name": {
+                "type": "string",
+                "description": "New name for cloned workflow (for clone action)"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max results for list/get_history",
+                "default": 50
+              }
+            },
+            "required": [
+              "action"
+            ]
+          },
+          "deprecated": true
+        },
+        {
+          "name": "snow_workflow_transition",
+          "description": "⚠️ LEGACY: Manage workflow transitions (deprecated - ServiceNow recommends Flow Designer). Actions: create, update, delete, list",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workflow",
+            "workflow-design",
+            "activity-connections"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update",
+                  "delete",
+                  "list"
+                ],
+                "description": "Action to perform"
+              },
+              "workflow_id": {
+                "type": "string",
+                "description": "Workflow sys_id or name (required for create, list)"
+              },
+              "transition_id": {
+                "type": "string",
+                "description": "Transition sys_id (required for update, delete)"
+              },
+              "from_activity": {
+                "type": "string",
+                "description": "Source activity sys_id (for create)"
+              },
+              "to_activity": {
+                "type": "string",
+                "description": "Target activity sys_id (for create)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Transition name/label"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Condition script for conditional transitions"
+              },
+              "condition_type": {
+                "type": "string",
+                "enum": [
+                  "always",
+                  "condition",
+                  "else"
+                ],
+                "description": "Type of condition",
+                "default": "always"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          },
+          "deprecated": true
+        }
+      ]
+    },
+    {
+      "name": "workspace",
+      "displayName": "Workspace",
+      "tools": [
+        {
+          "name": "snow_create_complete_workspace",
+          "description": "Create Complete UX Workspace - Executes all steps automatically: Experience (Builder Toolkit) → App Config → Page → List Configuration → Route. Creates a fully functional workspace.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "ux-experience",
+            "complete-setup"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "workspace_name": {
+                "type": "string",
+                "description": "Workspace name (used for all components)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Workspace description"
+              },
+              "home_page_name": {
+                "type": "string",
+                "default": "home",
+                "description": "Home page name (default: \"home\")"
+              },
+              "route_name": {
+                "type": "string",
+                "description": "URL route name (auto-generated from workspace name if not provided)"
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tables for list configuration (e.g., [\"incident\", \"task\"])"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Role sys_ids required to access this workspace"
+              }
+            },
+            "required": [
+              "workspace_name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_configurable_agent_workspace",
+          "description": "Create Configurable Agent Workspace using UX App architecture (sys_ux_app_route, sys_ux_screen_type). Creates workspace with screen collections for multiple tables.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "agent",
+            "screen-collections"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Agent workspace name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Workspace description"
+              },
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Tables for screen collections (e.g., [\"incident\", \"task\"])"
+              },
+              "application": {
+                "type": "string",
+                "default": "global",
+                "description": "Application scope"
+              }
+            },
+            "required": [
+              "name",
+              "tables"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ux_app_config",
+          "description": "STEP 2: Create UX App Configuration Record (sys_ux_app_config) - Contains workspace settings and links to the experience from Step 1.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "configuration",
+            "ux-experience"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "App config name (e.g., \"My Workspace Config\")"
+              },
+              "experience_sys_id": {
+                "type": "string",
+                "description": "Experience sys_id from Step 1"
+              },
+              "description": {
+                "type": "string",
+                "description": "App configuration description"
+              },
+              "list_config_id": {
+                "type": "string",
+                "description": "List menu configuration sys_id (optional)"
+              }
+            },
+            "required": [
+              "name",
+              "experience_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ux_app_route",
+          "description": "STEP 5: Create Route Record (sys_ux_app_route) - Defines the URL slug that leads to the page.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "routing",
+            "url"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Route name - becomes URL slug (e.g., \"home\")"
+              },
+              "app_config_sys_id": {
+                "type": "string",
+                "description": "App config sys_id from Step 2 (optional)"
+              },
+              "experience_sys_id": {
+                "type": "string",
+                "description": "Experience sys_id (alternative to app_config_sys_id)"
+              },
+              "page_sys_name": {
+                "type": "string",
+                "description": "Page sys_name from Step 4 registry (optional)"
+              },
+              "route": {
+                "type": "string",
+                "description": "URL route path (e.g., \"/home\")"
+              },
+              "description": {
+                "type": "string",
+                "description": "Route description"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ux_experience",
+          "description": "Create UX Experience via Builder Toolkit API - The top-level container for a workspace. Returns experienceID used by all subsequent workspace steps.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "ux-experience",
+            "foundation"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Experience name (e.g., \"My Workspace\")"
+              },
+              "path": {
+                "type": "string",
+                "description": "URL path slug (e.g., \"my-workspace\"). Auto-generated from name if not provided."
+              },
+              "homepage": {
+                "type": "string",
+                "description": "Homepage route name (default: \"home\")"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Role sys_ids required to access this experience"
+              },
+              "app_shell_ui": {
+                "type": "string",
+                "description": "App shell macroponent sys_id (auto-detected if not provided)"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ux_page_macroponent",
+          "description": "STEP 3: Create Page Macroponent Record (sys_ux_macroponent) - Defines the actual page content that will be displayed.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "page",
+            "macroponent"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Page macroponent name (e.g., \"My Home Page\")"
+              },
+              "root_component": {
+                "type": "string",
+                "default": "sn-canvas-panel",
+                "description": "Root component to render (default: sn-canvas-panel for simple pages)"
+              },
+              "composition": {
+                "type": "object",
+                "description": "JSON layout configuration (default: simple single column)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Page macroponent description"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "name": "snow_create_ux_page_registry",
+          "description": "STEP 4: Create Page Registry Record (sys_ux_page_registry) - Registers the page for use within the workspace configuration.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "registry",
+            "configuration"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "sys_name": {
+                "type": "string",
+                "description": "Unique technical name for the page (e.g., \"my_home_page\")"
+              },
+              "app_config_sys_id": {
+                "type": "string",
+                "description": "App config sys_id from Step 2"
+              },
+              "macroponent_sys_id": {
+                "type": "string",
+                "description": "Macroponent sys_id from Step 3"
+              },
+              "description": {
+                "type": "string",
+                "description": "Page registry description"
+              }
+            },
+            "required": [
+              "sys_name",
+              "app_config_sys_id",
+              "macroponent_sys_id"
+            ]
+          }
+        },
+        {
+          "name": "snow_discover_all_workspaces",
+          "description": "Discover all workspaces (UX Experiences via Builder Toolkit, Agent Workspaces, UI Builder pages) with comprehensive details.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "discovery",
+            "analytics"
+          ],
+          "complexity": "beginner",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "include_ux_experiences": {
+                "type": "boolean",
+                "default": true,
+                "description": "Include Now Experience Framework workspaces"
+              },
+              "include_agent_workspaces": {
+                "type": "boolean",
+                "default": true,
+                "description": "Include Configurable Agent Workspaces"
+              },
+              "include_ui_builder": {
+                "type": "boolean",
+                "default": true,
+                "description": "Include UI Builder pages"
+              },
+              "active_only": {
+                "type": "boolean",
+                "default": true,
+                "description": "Only show active workspaces"
+              }
+            }
+          }
+        },
+        {
+          "name": "snow_update_ux_app_config_landing_page",
+          "description": "Update App Configuration with Landing Page Route - Sets the default landing page for the workspace.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "configuration",
+            "landing-page"
+          ],
+          "complexity": "beginner",
+          "frequency": "low",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "app_config_sys_id": {
+                "type": "string",
+                "description": "App config sys_id from Step 2"
+              },
+              "route_name": {
+                "type": "string",
+                "description": "Route name to set as landing page"
+              }
+            },
+            "required": [
+              "app_config_sys_id",
+              "route_name"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_workspace_configuration",
+          "description": "Validate workspace configuration for completeness, best practices, and potential issues across all workspace types.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "workspace",
+            "validation",
+            "quality"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "workspace_sys_id": {
+                "type": "string",
+                "description": "Workspace sys_id to validate"
+              },
+              "workspace_type": {
+                "type": "string",
+                "enum": [
+                  "ux_experience",
+                  "agent_workspace",
+                  "ui_builder"
+                ],
+                "description": "Type of workspace to validate"
+              },
+              "check_performance": {
+                "type": "boolean",
+                "default": true,
+                "description": "Include performance analysis"
+              },
+              "check_security": {
+                "type": "boolean",
+                "default": true,
+                "description": "Include security validation"
+              }
+            },
+            "required": [
+              "workspace_sys_id",
+              "workspace_type"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #205.

docs.serac.build fetches the tool list from `raw.githubusercontent.com/serac-labs/serac/main/packages/opencode/tools.json` (and `sn-roles.manifest.json`) — both 404 because neither is committed on `main`. The 522 tool sources are already on main; the generator + workflow that produce these manifests only exist on the in-flight `feat/extract-servicenow-mcp` branch.

This commits the generated manifests (`tools.json` count **429**, matches main's sources) so the public docs render immediately. The generator + workflow arrive with the extraction merge and keep them current afterward — at which point these files just get regenerated identically.