### PR TITLE
fix(servicenow-mcp): skip read-only tools in instance-map hook

### DIFF
--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/instance-map-hook.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/instance-map-hook.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, test, expect } from "@jest/globals"
-import { buildPayload, isWriteTool, pickHookTransport, SKIP_ACTIONS } from "../instance-map-hook"
+import { buildPayload, isWriteTool, pickHookTransport, SKIP_ACTIONS, SKIP_TOOLS } from "../instance-map-hook"
 import { MCPToolDefinition, ServiceNowContext, ToolResult } from "../types"
 
 const baseContext: ServiceNowContext = {
@@ -214,7 +214,7 @@ describe("instance-map-hook", () => {
 
   describe("SKIP_ACTIONS", () => {
     test("skips the expected read-only actions", () => {
-      for (const a of ["get", "find", "list", "analyze", "export", "verify"]) {
+      for (const a of ["get", "find", "list", "analyze", "export", "verify", "current", "preview"]) {
         expect(SKIP_ACTIONS.has(a)).toBe(true)
       }
     })
@@ -223,6 +223,24 @@ describe("instance-map-hook", () => {
       for (const a of ["create", "update", "import", "delete"]) {
         expect(SKIP_ACTIONS.has(a)).toBe(false)
       }
+    })
+
+    test("does not skip update-set actions that mutate the instance", () => {
+      for (const a of ["switch", "complete", "ignore", "add_artifact"]) {
+        expect(SKIP_ACTIONS.has(a)).toBe(false)
+      }
+    })
+  })
+
+  describe("SKIP_TOOLS", () => {
+    test("skips local-sync tools that never mutate the instance", () => {
+      for (const t of ["snow_pull_artifact", "snow_sync_status", "snow_sync_cleanup"]) {
+        expect(SKIP_TOOLS.has(t)).toBe(true)
+      }
+    })
+
+    test("does not skip snow_push_artifact, which writes to the instance", () => {
+      expect(SKIP_TOOLS.has("snow_push_artifact")).toBe(false)
     })
   })
 })

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/instance-map-hook.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/instance-map-hook.ts
@@ -33,7 +33,15 @@ export type ReportPayload = {
   metadata?: Record<string, unknown>
 }
 
-export const SKIP_ACTIONS = new Set(["get", "find", "list", "analyze", "export", "verify"])
+// Read-shaped action values: a write tool invoked with one of these only
+// observed the instance ("current"/"preview" are snow_update_set_manage's
+// inspection actions), so the artifact in the result was not touched.
+export const SKIP_ACTIONS = new Set(["get", "find", "list", "analyze", "export", "verify", "current", "preview"])
+
+// Tools whose `permission: "write"` covers LOCAL side effects only (files
+// under the sync directory) — they never mutate the instance, so their
+// artifact references are observations, not changes.
+export const SKIP_TOOLS = new Set(["snow_pull_artifact", "snow_sync_status", "snow_sync_cleanup"])
 
 export function isWriteTool(definition: MCPToolDefinition | undefined): boolean {
   if (!definition) return false
@@ -144,6 +152,7 @@ export function reportArtifactToInstanceMap(
   tenant?: TenantHint,
 ): void {
   if (!isWriteTool(toolDefinition)) return
+  if (SKIP_TOOLS.has(toolName)) return
   if (args && typeof args.action === "string" && SKIP_ACTIONS.has(args.action)) return
 
   const payload = buildPayload(toolName, args ?? {}, result, context)


### PR DESCRIPTION
### What does this PR do?

Fixes #207

Stops the instance-map post-hook from reporting read-only tools as touched artifacts. `permission: "write"` was used as a proxy for "mutated the instance", which misfires for the local-sync trio (`snow_pull_artifact`, `snow_sync_status`, `snow_sync_cleanup` — write-classified for their local file output only) and for `snow_update_set_manage`'s `current`/`preview` inspection actions.

- new `SKIP_TOOLS` set, checked by tool name in the hook
- `SKIP_ACTIONS` extended with `current` and `preview` (`switch`/`complete`/`ignore`/`add_artifact` still report — those mutate)

### How did you verify your code works?

- `bun test` on `packages/servicenow-mcp` passes (27/27), including new tests pinning the skip sets
- `bun run typecheck` on the package is clean

### Checklist
- [x] This PR links an existing issue (`Fixes #N`) — see the Issue-First policy in `CONTRIBUTING.md`
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)