### PR TITLE
feat(chat): let the agent pick richer chart types

### DIFF
--- a/packages/opencode/src/project/agent-fragments/prompt-blocks/chart-rendering.txt
+++ b/packages/opencode/src/project/agent-fragments/prompt-blocks/chart-rendering.txt
@@ -1,0 +1,31 @@
+When presenting numeric data, render a chart code block instead of ASCII art or a markdown table. Pick the chart TYPE that fits the shape of the data — do not default to a plain bar chart for everything.
+
+```chart
+{
+  "type": "line",
+  "title": "Incidents per week",
+  "xKey": "week",
+  "series": [{"key": "count", "label": "Count", "color": "#22b8cf"}],
+  "data": [{"week": "Week 1", "count": 5}, {"week": "Week 2", "count": 3}]
+}
+```
+
+Choosing the type:
+- bar — compare a value across a few named categories. data: [{"name": "...", "value": N, "color": "#hex"}].
+- horizontal-bar — same as bar but with long category labels (they read better on the y-axis).
+- pie / donut — parts of a whole (a few slices that sum to 100%). data: [{"name": "...", "value": N}]. Prefer donut for 2–6 slices.
+- line — a trend over an ordered axis (time, sequence). Use xKey + series.
+- area — a trend where the magnitude/volume matters; add "stacked": true to show composition over time.
+- radar — compare ONE OR MORE entities across several dimensions (e.g. a flow's risk across complexity, blast-radius, test-coverage, dependencies). xKey is the dimension; each series is an entity. data: [{"dimension": "Complexity", "flowA": 8, "flowB": 4}, ...].
+- scatter — relationship between two numeric variables. Set xKey + yKey. data: [{"x": N, "y": N, "name": "..."}].
+- radial-bar — a small set of independent gauges/scores (0–100). data: [{"name": "...", "value": N}].
+- stacked bar — composition within each category: multiple series + "stacked": true.
+
+Shapes:
+- Single-series charts (bar, horizontal-bar, pie, donut, radial-bar): use data items with "name" and "value" (optionally "color"). No xKey/series needed.
+- Multi-series charts (line, area, radar, stacked bar): use "xKey" for the category axis and "series": [{"key","label","color"}], with each data row holding the xKey plus one numeric field per series key.
+
+Rules:
+- Always give a descriptive title and prefer the type that conveys the MOST information for the data — a single number is a stat, not a chart; two opaque bars convey little, so add the dimension that actually differentiates them (use radar or a grouped/stacked bar across sub-metrics instead of one total per item).
+- Use semantic colors when the data implies them (red #ff6b6b for critical/high, amber #fcc419 for medium, green #51cf66 for low/ok); otherwise omit color and let the brand palette apply.
+- Values are labelled and axes are rendered automatically — you do not need to restate the numbers in prose.


### PR DESCRIPTION
Expands the shared `chart-rendering.txt` prompt fragment so the agent picks the chart type that fits the data instead of always emitting a bar.

Adds `donut`, `scatter`, `radar`, `radial-bar` and stacked bar/area — all already supported by chart-rendering clients (the portal web UI) — with one line per type on when to use it and the expected data shape.

Prompt fragment only; no code changes.

Fixes #210