### PR TITLE
fix: declare @opencode-ai/http-recorder devDependency + bump source to 1.1.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -599,6 +599,7 @@
       "devDependencies": {
         "@babel/core": "7.28.4",
         "@octokit/webhooks-types": "7.6.1",
+        "@opencode-ai/http-recorder": "workspace:*",
         "@standard-schema/spec": "1.0.0",
         "@tsconfig/bun": "1.0.9",
         "@types/babel__core": "7.20.5",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "@serac-labs/core",
   "license": "Apache-2.0",
   "private": false,
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@babel/core": "7.28.4",
     "@octokit/webhooks-types": "7.6.1",
+    "@opencode-ai/http-recorder": "workspace:*",
     "@standard-schema/spec": "1.0.0",
     "@tsconfig/bun": "1.0.9",
     "@types/babel__core": "7.20.5",


### PR DESCRIPTION
Fixes #217 (the last piece)

v1.1.1 shipped, but the post-publish version bump failed: the runner's pre-push typecheck couldn't resolve @opencode-ai/http-recorder in llm-native-recorded.test.ts — the test-side instance of the same undeclared-workspace-dep problem. With it declared, `bun run typecheck` is fully green (0 errors; the Layer type error was knock-on from the unresolved module) and this branch was pushed with the pre-push hook active as proof. Also bumps source to 1.1.2 by hand since the workflow couldn't.