### PR TITLE
docs(opencode): state the local-CLI surface boundary in the fluent skills

### DIFF
--- a/packages/opencode/src/bundled-skills/fluent-brownfield-migration/SKILL.md
+++ b/packages/opencode/src/bundled-skills/fluent-brownfield-migration/SKILL.md
@@ -23,6 +23,9 @@ tools:
 
 Take a scoped app that lives only on an instance and move it into a git-managed ServiceNow SDK (Fluent) project — incrementally, with zero functional change at the start. Based on `@servicenow/sdk` 4.x (`now-sdk` CLI). Run `snow_fluent_status` first to see where a project already stands (scope, SDK pin, keys.ts, XML vs Fluent counts); use `snow_fluent_explain` for offline SDK docs on any topic.
 
+> **Where these tools run:** the `snow_fluent_*` tools are local-only — they execute the ServiceNow SDK (`now-sdk`) on the developer's machine via the Serac CLI/TUI. In hosted surfaces without local tool access (e.g. a web chat), do not call them; drive the same flow through git + CI instead: commit the project files, trigger the build/deploy pipeline, and follow the workflow runs.
+
+
 ## 1. Step zero: pull the app down as-is
 
 Use `snow_fluent_init` with `from=<sys_app sys_id>` (CLI: `now-sdk init --from <sys_id>`). Since SDK 2.2.6 this does **not** generate Fluent code by default — it leaves every record as XML in the `metadata/` folder. Those XML files are the exact files the instance exports, so there is **no change to the application** at this point. `now.config.json` captures `scope` + `scopeId` (= the sys_app sys_id), and the XML builds and installs as-is.

--- a/packages/opencode/src/bundled-skills/fluent-ci-cd/SKILL.md
+++ b/packages/opencode/src/bundled-skills/fluent-ci-cd/SKILL.md
@@ -19,6 +19,9 @@ tools:
 
 How to run a ServiceNow Fluent (SDK 4.x, `now-sdk` CLI) project through version control and CI: what to commit, the PR check that catches stale `keys.ts`, headless auth, a minimal GitHub Actions workflow, and the hard line between CI deploys and production promotion. For the official reference, run `snow_fluent_explain` with topic `ci-integration` (offline `now-sdk explain ci-integration`).
 
+> **Where these tools run:** the `snow_fluent_*` tools are local-only — they execute the ServiceNow SDK (`now-sdk`) on the developer's machine via the Serac CLI/TUI. In hosted surfaces without local tool access (e.g. a web chat), do not call them; drive the same flow through git + CI instead: commit the project files, trigger the build/deploy pipeline, and follow the workflow runs.
+
+
 ## 1. Repo discipline
 
 The `.gitignore` that `snow_fluent_init` scaffolds is already correct — keep it as-is:

--- a/packages/opencode/src/bundled-skills/fluent-development/SKILL.md
+++ b/packages/opencode/src/bundled-skills/fluent-development/SKILL.md
@@ -22,6 +22,9 @@ tools:
 
 Fluent is ServiceNow's pro-code model: application **metadata as declarative TypeScript**, with **git as the source of truth** instead of the instance. You edit `.now.ts` files locally, compile them (`build`), and push the compiled package to an instance (`install`). The CLI behind the tools is `now-sdk` from `@servicenow/sdk` (4.x, Node 20+).
 
+> **Where these tools run:** the `snow_fluent_*` tools are local-only — they execute the ServiceNow SDK (`now-sdk`) on the developer's machine via the Serac CLI/TUI. In hosted surfaces without local tool access (e.g. a web chat), do not call them; drive the same flow through git + CI instead: commit the project files, trigger the build/deploy pipeline, and follow the workflow runs.
+
+
 ## 1. Fluent vs the classic snow_* API tools
 
 | Task | Use |


### PR DESCRIPTION
Fixes #223

One note per fluent skill, right under the intro: `snow_fluent_*` runs the ServiceNow SDK on the developer's machine via the Serac CLI/TUI; hosted surfaces without local tool access should drive the same flow through git + CI instead. Prompted by a portal test run where the agent followed the skill into tools that can't exist there and misread the failure as a tenant issue.