### PR TITLE
chore: restore the Apache 2.0 relicense + license guard

### DIFF
--- a/.github/workflows/license-guard.yml
+++ b/.github/workflows/license-guard.yml
@@ -1,0 +1,46 @@
+name: license-guard
+
+# The Apache 2.0 relicense was silently lost once before: the 1.1.x upstream
+# re-sync rebuilt main's history and upstream's MIT LICENSE/README came back
+# with it (the merged relicense PR #189 was left behind on the abandoned
+# history line). This guard makes that class of regression impossible to miss:
+# any push or PR where the root LICENSE is not Apache 2.0, the NOTICE with the
+# opencode MIT attribution is missing, or a package.json license field slides
+# back to MIT, fails loudly.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Root LICENSE must be Apache 2.0
+        run: |
+          head -5 LICENSE | grep -q "Apache License" || {
+            echo "::error file=LICENSE::Root LICENSE is no longer Apache 2.0 — the relicense regressed (likely an upstream sync clobbered it). Restore LICENSE/NOTICE before merging."
+            exit 1
+          }
+
+      - name: NOTICE with opencode attribution must exist
+        run: |
+          test -f NOTICE && grep -q "opencode" NOTICE && grep -q "Apache License" NOTICE || {
+            echo "::error file=NOTICE::NOTICE file missing or missing the opencode MIT attribution."
+            exit 1
+          }
+
+      - name: No package.json may declare MIT
+        run: |
+          BAD=$(grep -rl '"license": "MIT"' --include=package.json . | grep -v node_modules || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::package.json license fields regressed to MIT:"
+            echo "$BAD"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OpenCode
+# Contributing to Serac
 
-We want to make it easy for you to contribute to OpenCode. Here are the most common type of changes that get merged:
+We want to make it easy for you to contribute to Serac. Here are the most common type of changes that get merged:
 
 - Bug fixes
 - Additional LSPs / Formatters
@@ -23,6 +23,20 @@ If you are unsure if a PR would be accepted, feel free to ask a maintainer or lo
 > PRs that ignore these guardrails will likely be closed.
 
 Want to take on an issue? Leave a comment and a maintainer may assign it to you unless it is something we are already working on.
+
+## License and the Developer Certificate of Origin (DCO)
+
+Serac is released under the [Apache License 2.0](./LICENSE) and is built on the MIT-licensed [opencode](https://github.com/anomalyco/opencode) project (see [`NOTICE`](./NOTICE)). By contributing, you agree that your contributions are licensed under the same Apache 2.0 terms.
+
+We use the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) — a lightweight way to certify that you wrote, or otherwise have the right to submit, the code you contribute. It is **not** a copyright-assignment CLA; you keep ownership of your work.
+
+Sign off every commit by adding a `Signed-off-by` line, which `git commit -s` does for you:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match your commit author. Signing off certifies the statements at https://developercertificate.org/.
 
 ## Adding New Providers
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 opencode
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Serac Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,38 @@
+Serac
+Copyright 2026 Serac Labs
+
+This product is licensed under the Apache License, Version 2.0 (see the
+LICENSE file).
+
+------------------------------------------------------------------------
+Third-party attributions
+------------------------------------------------------------------------
+
+This product is built on and includes software from the opencode project
+(https://github.com/anomalyco/opencode), which is licensed under the MIT
+License. Serac extends opencode with a ServiceNow-native tool layer, agents,
+skills, and related additions. Portions of this product derived from opencode
+remain subject to the MIT License terms reproduced below; Serac's own additions
+are licensed under the Apache License, Version 2.0.
+
+    MIT License
+
+    Copyright (c) 2025 opencode
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
 <p align="center">
-  <a href="https://serac.build">
-    <h1 align="center">Serac</h1>
-  </a>
+<pre align="center">
+███████╗███████╗██████╗  █████╗  ██████╗
+██╔════╝██╔════╝██╔══██╗██╔══██╗██╔════╝
+███████╗█████╗  ██████╔╝███████║██║     
+╚════██║██╔══╝  ██╔══██╗██╔══██║██║     
+███████║███████╗██║  ██║██║  ██║╚██████╗
+╚══════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝
+</pre>
 </p>
-<p align="center">The open source AI coding agent.</p>
+
+<h3 align="center">The terminal-native AI agent for ServiceNow developers and consultants.</h3>
+
 <p align="center">
-  <a href="https://www.npmjs.com/package/@serac-labs/core"><img alt="npm" src="https://img.shields.io/npm/v/@serac-labs/core?style=flat-square" /></a>
+  Your terminal &bull; your keys (BYOK, 20+ providers) &bull; every instance &bull; 429 ServiceNow MCP tools
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@serac-labs/core"><img alt="npm" src="https://img.shields.io/npm/v/@serac-labs/core?style=for-the-badge&logo=npm&logoColor=white&color=CB3837" /></a>&nbsp;
+  <a href="https://www.npmjs.com/package/@serac-labs/core"><img alt="Downloads" src="https://img.shields.io/npm/dw/@serac-labs/core?style=for-the-badge&logo=npm&logoColor=white&label=downloads&color=CB3837" /></a>&nbsp;
+  <a href="https://github.com/serac-labs/serac/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/serac-labs/serac?style=for-the-badge&logo=github&color=yellow" /></a>&nbsp;
+  <a href="https://github.com/serac-labs/serac"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white" /></a>&nbsp;
+  <a href="https://github.com/serac-labs/serac/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge" /></a>
 </p>
 
 <p align="center">
@@ -34,6 +49,8 @@
 </p>
 
 [![Serac Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://serac.build)
+
+Serac is a terminal-native AI development agent purpose-built for **ServiceNow**. It brings 429 ServiceNow MCP tools, 55 bundled domain skills (including Blast Radius impact analysis), and 20+ AI providers into your own terminal — your editor, your keys (BYOK), and any instance you connect to. It's built for ServiceNow developers and the consultants who work across many client instances. Serac extends the open-source [opencode](https://github.com/anomalyco/opencode) agent with a deep ServiceNow domain layer.
 
 ---
 
@@ -101,3 +118,7 @@ If you're interested in contributing to Serac, please read our [contributing doc
 ### Building on Serac
 
 If you are working on a project that's related to Serac and is using "serac" as part of its name, for example "serac-dashboard" or "serac-mobile", please add a note to your README to clarify that it is not built by the Serac team and is not affiliated with us in any way.
+
+### License
+
+Licensed under the [Apache License 2.0](LICENSE) — see also [`NOTICE`](NOTICE) for third-party attributions (built on the MIT-licensed [opencode](https://github.com/anomalyco/opencode)).

--- a/github/package.json
+++ b/github/package.json
@@ -3,7 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/bun": "catalog:"
   },

--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -95,7 +95,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "The open source coding agent";
     homepage = "https://opencode.ai";
-    license = lib.licenses.mit;
+    license = lib.licenses.asl20;
     mainProgram = "opencode";
     inherit (node_modules.meta) platforms;
   };

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "type": "git",
     "url": "https://github.com/anomalyco/opencode"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "prettier": {
     "semi": false,
     "printWidth": 120

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,7 +26,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e/playwright-report"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@happy-dom/global-registrator": "20.0.11",
     "@playwright/test": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/cli",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bin": {
     "lildax": "./bin/lildax.cjs"
   },

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/console-app",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",

--- a/packages/console/app/src/i18n/ar.ts
+++ b/packages/console/app/src/i18n/ar.ts
@@ -178,7 +178,7 @@ export const dict = {
   "home.faq.q8": "هل OpenCode مفتوح المصدر؟",
   "home.faq.a8.p1": "نعم، OpenCode مفتوح المصدر بالكامل. الكود المصدري متاح علنًا على",
   "home.faq.a8.p2": "بموجب",
-  "home.faq.a8.mitLicense": "رخصة MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     "، مما يعني أن أي شخص يستطيع استخدامه أو تعديله أو المساهمة في تطويره. يمكن لأي شخص من المجتمع فتح قضايا، وتقديم طلبات سحب، وتوسيع الوظائف.",
 

--- a/packages/console/app/src/i18n/br.ts
+++ b/packages/console/app/src/i18n/br.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "OpenCode é código aberto?",
   "home.faq.a8.p1": "Sim, OpenCode é totalmente open source. O código-fonte é público no",
   "home.faq.a8.p2": "sob a",
-  "home.faq.a8.mitLicense": "Licença MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", o que significa que qualquer pessoa pode usar, modificar ou contribuir para o seu desenvolvimento. Qualquer pessoa da comunidade pode abrir issues, enviar pull requests e estender a funcionalidade.",
 

--- a/packages/console/app/src/i18n/da.ts
+++ b/packages/console/app/src/i18n/da.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "Er OpenCode open source?",
   "home.faq.a8.p1": "Ja, OpenCode er fuldt open source. Kildekoden er offentlig på",
   "home.faq.a8.p2": "under",
-  "home.faq.a8.mitLicense": "MIT-licensen",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", hvilket betyder at alle kan bruge, ændre eller bidrage til udviklingen. Alle i communityet kan oprette issues, indsende pull requests og udvide funktionalitet.",
 

--- a/packages/console/app/src/i18n/de.ts
+++ b/packages/console/app/src/i18n/de.ts
@@ -181,7 +181,7 @@ export const dict = {
   "home.faq.q8": "Ist OpenCode Open Source?",
   "home.faq.a8.p1": "Ja, OpenCode ist vollständig Open Source. Der Quellcode ist öffentlich auf",
   "home.faq.a8.p2": "unter der",
-  "home.faq.a8.mitLicense": "MIT Lizenz",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", was bedeutet, dass jeder ihn nutzen, modifizieren oder zu seiner Entwicklung beitragen kann. Jeder aus der Community kann Issues melden, Pull Requests einreichen und die Funktionalität erweitern.",
 

--- a/packages/console/app/src/i18n/en.ts
+++ b/packages/console/app/src/i18n/en.ts
@@ -178,7 +178,7 @@ export const dict = {
   "home.faq.q8": "Is OpenCode open source?",
   "home.faq.a8.p1": "Yes, OpenCode is fully open source. The source code is public on",
   "home.faq.a8.p2": "under the",
-  "home.faq.a8.mitLicense": "MIT License",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", meaning anyone can use, modify, or contribute to its development. Anyone from the community can file issues, submit pull requests, and extend functionality.",
 

--- a/packages/console/app/src/i18n/es.ts
+++ b/packages/console/app/src/i18n/es.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "¿Es OpenCode de código abierto?",
   "home.faq.a8.p1": "Sí, OpenCode es totalmente de código abierto. El código fuente es público en",
   "home.faq.a8.p2": "bajo la",
-  "home.faq.a8.mitLicense": "Licencia MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", lo que significa que cualquiera puede usar, modificar o contribuir a su desarrollo. Cualquiera de la comunidad puede abrir problemas, enviar solicitudes de extracción y extender la funcionalidad.",
 

--- a/packages/console/app/src/i18n/fr.ts
+++ b/packages/console/app/src/i18n/fr.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "OpenCode est-il open source ?",
   "home.faq.a8.p1": "Oui, OpenCode est entièrement open source. Le code source est public sur",
   "home.faq.a8.p2": "sous la",
-  "home.faq.a8.mitLicense": "Licence MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", ce qui signifie que tout le monde peut l'utiliser, le modifier ou contribuer à son développement. Toute personne de la communauté peut ouvrir des tickets, soumettre des pull requests et étendre les fonctionnalités.",
 

--- a/packages/console/app/src/i18n/it.ts
+++ b/packages/console/app/src/i18n/it.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "OpenCode è open source?",
   "home.faq.a8.p1": "Sì, OpenCode è completamente open source. Il codice sorgente è pubblico su",
   "home.faq.a8.p2": "sotto la",
-  "home.faq.a8.mitLicense": "Licenza MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", il che significa che chiunque può usarlo, modificarlo o contribuire al suo sviluppo. Chiunque nella comunità può aprire issue, inviare pull request ed estendere le funzionalità.",
 

--- a/packages/console/app/src/i18n/ja.ts
+++ b/packages/console/app/src/i18n/ja.ts
@@ -179,7 +179,7 @@ export const dict = {
   "home.faq.q8": "OpenCodeはオープンソースですか？",
   "home.faq.a8.p1": "はい、OpenCodeは完全にオープンソースです。ソースコードは",
   "home.faq.a8.p2": "の",
-  "home.faq.a8.mitLicense": "MITライセンス",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     "のもとで公開されており、誰でも使用、変更、開発への参加ができます。コミュニティの誰でもissueを起こしたり、pull requestを送ったり、機能を拡張できます。",
 

--- a/packages/console/app/src/i18n/ko.ts
+++ b/packages/console/app/src/i18n/ko.ts
@@ -178,7 +178,7 @@ export const dict = {
   "home.faq.q8": "OpenCode는 오픈 소스인가요?",
   "home.faq.a8.p1": "네, OpenCode는 완전히 오픈 소스입니다. 소스 코드는",
   "home.faq.a8.p2": "에 공개되어 있으며,",
-  "home.faq.a8.mitLicense": "MIT 라이선스",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     "를 따릅니다. 즉, 누구나 사용, 수정 또는 개발에 기여할 수 있습니다. 커뮤니티의 누구든지 이슈를 등록하고, 풀 리퀘스트를 제출하고, 기능을 확장할 수 있습니다.",
 

--- a/packages/console/app/src/i18n/no.ts
+++ b/packages/console/app/src/i18n/no.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "Er OpenCode åpen kildekode?",
   "home.faq.a8.p1": "Ja, OpenCode er fullt open source. Kildekoden er offentlig på",
   "home.faq.a8.p2": "under",
-  "home.faq.a8.mitLicense": "MIT-lisensen",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", som betyr at hvem som helst kan bruke, endre eller bidra til utviklingen. Alle i communityet kan opprette issues, sende inn pull requests og utvide funksjonalitet.",
 

--- a/packages/console/app/src/i18n/pl.ts
+++ b/packages/console/app/src/i18n/pl.ts
@@ -180,7 +180,7 @@ export const dict = {
   "home.faq.q8": "Czy OpenCode jest open source?",
   "home.faq.a8.p1": "Tak, OpenCode jest w pełni open source. Kod źródłowy jest publicznie dostępny na",
   "home.faq.a8.p2": "na licencji",
-  "home.faq.a8.mitLicense": "MIT License",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", co oznacza, że każdy może go używać, modyfikować i wspierać jego rozwój. Każdy ze społeczności może zgłaszać błędy, przesyłać pull requesty i rozszerzać funkcjonalność.",
 

--- a/packages/console/app/src/i18n/ru.ts
+++ b/packages/console/app/src/i18n/ru.ts
@@ -182,7 +182,7 @@ export const dict = {
   "home.faq.q8": "OpenCode — это open source?",
   "home.faq.a8.p1": "Да, OpenCode полностью open source. Исходный код доступен публично на",
   "home.faq.a8.p2": "под",
-  "home.faq.a8.mitLicense": "лицензией MIT",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", что означает, что любой может использовать, изменять или вносить вклад в его развитие. Любой участник сообщества может создавать issues, отправлять pull requests и расширять функциональность.",
 

--- a/packages/console/app/src/i18n/th.ts
+++ b/packages/console/app/src/i18n/th.ts
@@ -178,7 +178,7 @@ export const dict = {
   "home.faq.q8": "OpenCode เป็นโอเพนซอร์สหรือไม่?",
   "home.faq.a8.p1": "ใช่ OpenCode เป็นโอเพนซอร์สเต็มรูปแบบ ซอร์สโค้ดเปิดเผยต่อสาธารณะบน",
   "home.faq.a8.p2": "ภายใต้",
-  "home.faq.a8.mitLicense": "MIT License",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     " ซึ่งหมายความว่าใครๆ ก็สามารถใช้ แก้ไข หรือร่วมพัฒนาได้ ทุกคนในชุมชนสามารถเปิด issue, ส่ง pull request และขยายฟังก์ชันการทำงานได้",
 

--- a/packages/console/app/src/i18n/tr.ts
+++ b/packages/console/app/src/i18n/tr.ts
@@ -179,7 +179,7 @@ export const dict = {
   "home.faq.q8": "OpenCode açık kaynak mı?",
   "home.faq.a8.p1": "Evet, OpenCode tamamen açık kaynaktır. Kaynak kodu",
   "home.faq.a8.p2": "'da",
-  "home.faq.a8.mitLicense": "MIT Lisansı",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     "altında herkese açıktır, yani herkes kullanabilir, değiştirebilir veya geliştirmeye katkıda bulunabilir. Topluluktan herkes issue açabilir, pull request gönderebilir ve işlevselliği genişletebilir.",
 

--- a/packages/console/app/src/i18n/uk.ts
+++ b/packages/console/app/src/i18n/uk.ts
@@ -181,7 +181,7 @@ export const dict = {
   "home.faq.q8": "Чи є OpenCode відкритим?",
   "home.faq.a8.p1": "Так, OpenCode повністю відкритий. Вихідний код доступний публічно на",
   "home.faq.a8.p2": "під ліцензією",
-  "home.faq.a8.mitLicense": "MIT License",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     ", тобто кожен може використовувати, змінювати або сприяти його розвитку. Будь-хто зі спільноти може створювати issues, надсилати pull request'и та розширювати функціональність.",
 

--- a/packages/console/app/src/i18n/zh.ts
+++ b/packages/console/app/src/i18n/zh.ts
@@ -175,7 +175,7 @@ export const dict = {
   "home.faq.q8": "OpenCode 是开源的吗？",
   "home.faq.a8.p1": "是的，OpenCode 是完全开源的。源代码公开在",
   "home.faq.a8.p2": "遵循",
-  "home.faq.a8.mitLicense": "MIT 许可证",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3":
     "，这意味着任何人都可以使用、修改或为它的发展做贡献。社区中的任何人都可以提交 issue、提交 PR 并扩展功能。",
 

--- a/packages/console/app/src/i18n/zht.ts
+++ b/packages/console/app/src/i18n/zht.ts
@@ -176,7 +176,7 @@ export const dict = {
   "home.faq.q8": "OpenCode 是開源的嗎？",
   "home.faq.a8.p1": "是的，OpenCode 完全開源。原始碼公開在",
   "home.faq.a8.p2": "並採用",
-  "home.faq.a8.mitLicense": "MIT 授權條款",
+  "home.faq.a8.mitLicense": "Apache License 2.0",
   "home.faq.a8.p3": "，意味著任何人都可以使用、修改或貢獻。社群中的任何人都可以提交 issue、pull requests 並擴充功能。",
 
   "home.zenCta.title": "存取可靠且最佳化的編碼代理模型",

--- a/packages/console/app/src/routes/download/index.tsx
+++ b/packages/console/app/src/routes/download/index.tsx
@@ -469,7 +469,7 @@ export default function Download() {
                   {i18n.t("nav.github")}
                 </a>{" "}
                 {i18n.t("home.faq.a8.p2")}{" "}
-                <a href={`${config.github.repoUrl}?tab=MIT-1-ov-file#readme`} target="_blank">
+                <a href={`${config.github.repoUrl}?tab=Apache-2.0-1-ov-file#readme`} target="_blank">
                   {i18n.t("home.faq.a8.mitLicense")}
                 </a>
                 {i18n.t("home.faq.a8.p3")}

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -718,7 +718,7 @@ export default function Home() {
                     {i18n.t("nav.github")}
                   </a>{" "}
                   {i18n.t("home.faq.a8.p2")}{" "}
-                  <a href={`${config.github.repoUrl}?tab=MIT-1-ov-file#readme`} target="_blank">
+                  <a href={`${config.github.repoUrl}?tab=Apache-2.0-1-ov-file#readme`} target="_blank">
                     {i18n.t("home.faq.a8.mitLicense")}
                   </a>
                   {i18n.t("home.faq.a8.p3")}

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -4,7 +4,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-sts": "3.782.0",
     "@jsx-email/render": "1.1.1",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -4,7 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -18,5 +18,5 @@
     "dev": "email preview emails/templates"
   },
   "type": "module",
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/console/resource/package.json
+++ b/packages/console/resource/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-resource",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@cloudflare/workers-types": "catalog:"
   },

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/console-support",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "sst shell --stage production -- vite dev"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "name": "@opencode-ai/core",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "db": "bun drizzle-kit",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "homepage": "https://opencode.ai",
   "author": {
     "name": "OpenCode",

--- a/packages/docs/LICENSE
+++ b/packages/docs/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2023 Mintlify
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Serac Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "test": "bun test --timeout 30000",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "typecheck": "tsgo --noEmit"

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -4,7 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "@tsconfig/node22": "22.0.2",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -4,7 +4,7 @@
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/anomalyco/opencode.git",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -3,7 +3,7 @@
   "version": "1.16.2",
   "name": "@opencode-ai/llm",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "setup:recording-env": "bun run script/setup-recording-env.ts",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/plugin",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "tsc"

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@opencode-ai/script",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "semver": "^7.6.3"
   },

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -3,7 +3,7 @@
   "name": "@opencode-ai/sdk",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "bun ./script/build.ts"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/slack",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "dev": "bun run src/index.ts",
     "typecheck": "tsgo --noEmit"

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -4,7 +4,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -4,7 +4,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",
     "./athena": "./src/athena.ts",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.16.2",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "main": "./src/server.ts",
   "exports": {
     ".": "./src/server.ts"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "test": "bun test --timeout 30000",
     "typecheck": "tsgo --noEmit"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/ui",
   "version": "1.16.2",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "exports": {
     "./package.json": "./package.json",
     "./*": "./src/components/*.tsx",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/web",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "version": "1.16.2",
   "scripts": {
     "dev": "astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/anomalyco/opencode"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "icon": "images/icon.png",
   "galleryBanner": {
     "color": "#000000",


### PR DESCRIPTION
Fixes #229

The 1.1.x history rebuild orphaned the merged relicense (#189): root LICENSE reverted to upstream MIT, NOTICE vanished, README/CONTRIBUTING repositioning went with them. This restores it on the current tree and adds a guard so it can't happen silently again.

- Root `LICENSE` → Apache 2.0; `NOTICE` restored (opencode MIT attribution preserved); `packages/docs/LICENSE` → Apache.
- README hero/positioning + License section back; CONTRIBUTING retitled to Serac + DCO section back.
- 30 `package.json` license fields MIT → Apache-2.0 (opencode + servicenow-mcp already carried it); nix metadata; console license links/labels.
- New `license-guard` workflow: fails any push/PR where LICENSE isn't Apache, NOTICE is missing, or a package.json regresses to MIT.

No runtime code changes.