### PR TITLE
feat(servicenow-mcp): block config writes while no update set is active

### DIFF
--- a/packages/opencode/src/bundled-skills/update-set-workflow/SKILL.md
+++ b/packages/opencode/src/bundled-skills/update-set-workflow/SKILL.md
@@ -14,6 +14,8 @@ tools:
 
 Update Sets are MANDATORY for tracking changes in ServiceNow development. Without an Update Set, changes are not tracked and cannot be deployed to other instances.
 
+This is also enforced: configuration writes are blocked at the tool layer while no update set is active for the session. When you hit that block, ask the user whether to capture the work in a named update set, then call `snow_ensure_active_update_set({ name })` once and retry. Only if the user explicitly declines tracking, re-issue the call once with `__skipUpdateSet: true` — the choice is remembered for the rest of the session.
+
 ## Before ANY Development
 
 ALWAYS create or ensure an Update Set is active before making changes:

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
@@ -16,6 +16,13 @@ import { ToolSearch } from "../shared/tool-search.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 import { formatArgsForLogging, isRetryableOperation } from "../shared/handler-helpers.js"
 import { reportArtifactToInstanceMap, isWriteTool } from "../shared/instance-map-hook.js"
+import {
+  guardKey,
+  observeUpdateSetTool,
+  recordUpdateSetSkip,
+  requiresUpdateSet,
+  updateSetActive,
+} from "../shared/update-set-guard.js"
 import { type HandlerDeps } from "./types.js"
 
 export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any) => {
@@ -145,9 +152,30 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
           `"__confirmProd": true added to the arguments. Reads, and writes to dev/test/uat, need no confirmation.`,
       )
     }
+
+    // Update-set safety: a configuration write with no active update set for
+    // this session is blocked, so changes can't silently land in the Default
+    // update set. The agent lifts the guard once per session by ensuring/
+    // creating/switching an update set; `__skipUpdateSet: true` records an
+    // explicit user decline and is remembered for the rest of the session.
+    const usKey = guardKey(context.tenantId, sessionId, context.instanceUrl)
+    if (args?.__skipUpdateSet === true) {
+      recordUpdateSetSkip(usKey)
+    }
+    if (requiresUpdateSet(tool.definition, args) && !updateSetActive(usKey)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `"${name}" is a configuration write but no update set is active for this session — the change ` +
+          `would land in the Default update set untracked. Ask the user whether to capture this work in a ` +
+          `named update set (suggest a name); after they approve, call snow_ensure_active_update_set({ name }) ` +
+          `once and re-issue this call. If the user explicitly declines tracking, re-issue once with ` +
+          `"__skipUpdateSet": true — the choice is remembered for the rest of the session.`,
+      )
+    }
+
     const execArgs =
-      args && typeof args === "object" && "__confirmProd" in args
-        ? Object.fromEntries(Object.entries(args).filter(([k]) => k !== "__confirmProd"))
+      args && typeof args === "object" && ("__confirmProd" in args || "__skipUpdateSet" in args)
+        ? Object.fromEntries(Object.entries(args).filter(([k]) => k !== "__confirmProd" && k !== "__skipUpdateSet"))
         : args
 
     // Execute tool with error handling (permission check passed!).
@@ -168,6 +196,10 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
         },
       },
     )
+
+    // Post-hook: keep the update-set guard in sync with what the update-set
+    // tools actually did (ensure/create/switch lift it, complete re-arms it).
+    observeUpdateSetTool(name, args, result, usKey)
 
     // Post-hook: report created/updated artifacts to the enterprise portal's
     // instance-map so the per-tenant graph stays in sync without relying on

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/no-module-state.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/no-module-state.test.ts
@@ -53,6 +53,16 @@ const ALLOWLIST: AllowedPattern[] = [
     pattern: /^export const SKIP_ACTIONS = new Set\(/,
     reason: "Static metadata — list of read-only/skip actions for the instance-map post-hook",
   },
+  {
+    file: "instance-map-hook.ts",
+    pattern: /^export const SKIP_TOOLS = new Set\(/,
+    reason: "Static metadata — write tools whose side effects are local-only (sync directory)",
+  },
+  {
+    file: "update-set-guard.ts",
+    pattern: /^const guardState = new Map</,
+    reason: "Keys are composed as tenantId\\x00sessionId\\x00instanceUrl — see guardKey()",
+  },
 ]
 
 describe("Multi-tenant invariants in shared/", () => {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/update-set-guard.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/update-set-guard.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Update-set guard tests.
+ *
+ * Covers the two halves of shared/update-set-guard.ts: the conservative
+ * config-write classification (requiresUpdateSet) and the session-scoped
+ * state machine the call-tool handler drives (guardKey / updateSetActive /
+ * recordUpdateSetSkip / observeUpdateSetTool).
+ */
+
+import { describe, test, expect, beforeEach } from "@jest/globals"
+import {
+  guardKey,
+  observeUpdateSetTool,
+  recordUpdateSetSkip,
+  requiresUpdateSet,
+  resetUpdateSetState,
+  updateSetActive,
+} from "../update-set-guard"
+import { MCPToolDefinition } from "../types"
+
+function definition(overrides: Partial<MCPToolDefinition>): MCPToolDefinition {
+  return {
+    name: "snow_test_tool",
+    description: "test tool",
+    inputSchema: { type: "object", properties: {} },
+    ...overrides,
+  }
+}
+
+describe("requiresUpdateSet — classification", () => {
+  test("a config-category write tool is gated", () => {
+    const def = definition({ name: "snow_flow_manage", category: "development", permission: "write" })
+    expect(requiresUpdateSet(def, { action: "update" })).toBe(true)
+  })
+
+  test("permission defaults to write when omitted", () => {
+    const def = definition({ name: "snow_create_widget", category: "ui-frameworks" })
+    expect(requiresUpdateSet(def, {})).toBe(true)
+  })
+
+  test("read tools are never gated", () => {
+    const def = definition({ name: "snow_query_table", category: "development", permission: "read" })
+    expect(requiresUpdateSet(def, {})).toBe(false)
+  })
+
+  test("data-category writes are exempt (itsm, cmdb, ...)", () => {
+    expect(requiresUpdateSet(definition({ name: "snow_incident_manage", category: "itsm", permission: "write" }), {})).toBe(false)
+    expect(requiresUpdateSet(definition({ name: "snow_ci_manage", category: "cmdb", permission: "write" }), {})).toBe(false)
+  })
+
+  test("data-shaped subcategories inside config categories are exempt", () => {
+    const def = definition({
+      name: "snow_import_rows",
+      category: "integration",
+      subcategory: "import-export",
+      permission: "write",
+    })
+    expect(requiresUpdateSet(def, {})).toBe(false)
+  })
+
+  test("the update-set tools themselves are never gated", () => {
+    const def = definition({ name: "snow_ensure_active_update_set", category: "development", permission: "write" })
+    expect(requiresUpdateSet(def, {})).toBe(false)
+  })
+
+  test("local-only sync tools are exempt", () => {
+    const def = definition({ name: "snow_pull_artifact", category: "development", permission: "write" })
+    expect(requiresUpdateSet(def, {})).toBe(false)
+  })
+
+  test("read-shaped actions on a write tool are exempt", () => {
+    const def = definition({ name: "snow_flow_manage", category: "development", permission: "write" })
+    expect(requiresUpdateSet(def, { action: "list" })).toBe(false)
+    expect(requiresUpdateSet(def, { action: "get" })).toBe(false)
+  })
+
+  test("updateSet overrides beat the category defaults in both directions", () => {
+    const forced = definition({ name: "snow_data_thing", category: "itsm", permission: "write", updateSet: "required" })
+    expect(requiresUpdateSet(forced, {})).toBe(true)
+
+    const released = definition({ name: "snow_config_thing", category: "development", permission: "write", updateSet: "exempt" })
+    expect(requiresUpdateSet(released, {})).toBe(false)
+  })
+
+  test("missing definition is not gated", () => {
+    expect(requiresUpdateSet(undefined, {})).toBe(false)
+  })
+})
+
+describe("guard state — session lifecycle", () => {
+  const key = guardKey("42", "session-a", "https://dev1.service-now.com")
+
+  beforeEach(() => {
+    resetUpdateSetState()
+  })
+
+  test("a fresh session has no active update set", () => {
+    expect(updateSetActive(key)).toBe(false)
+  })
+
+  test("a successful ensure lifts the guard; complete re-arms it", () => {
+    observeUpdateSetTool(
+      "snow_ensure_active_update_set",
+      { name: "Feature: approval step" },
+      { success: true, data: { sys_id: "abc123", name: "Feature: approval step" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(true)
+
+    observeUpdateSetTool(
+      "snow_update_set_manage",
+      { action: "complete", update_set_id: "abc123" },
+      { success: true, data: { sys_id: "abc123", state: "complete" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+  })
+
+  test("create and switch lift the guard", () => {
+    observeUpdateSetTool(
+      "snow_update_set_manage",
+      { action: "create", name: "Feature: x" },
+      { success: true, data: { sys_id: "u1", name: "Feature: x" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(true)
+
+    resetUpdateSetState()
+    observeUpdateSetTool(
+      "snow_update_set_manage",
+      { action: "switch", update_set_id: "u2" },
+      { success: true, data: { sys_id: "u2", name: "Feature: y" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(true)
+  })
+
+  test("a create that does not switch tracking does not lift the guard", () => {
+    observeUpdateSetTool(
+      "snow_update_set_manage",
+      { action: "create", name: "Feature: x", auto_switch: false },
+      { success: true, data: { sys_id: "u1", name: "Feature: x" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+  })
+
+  test("an ensure without user sync does not lift the guard", () => {
+    observeUpdateSetTool(
+      "snow_ensure_active_update_set",
+      { name: "Feature: x", sync_with_user: false },
+      { success: true, data: { sys_id: "u1", name: "Feature: x" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+  })
+
+  test("failed tool results never lift the guard", () => {
+    observeUpdateSetTool(
+      "snow_ensure_active_update_set",
+      { name: "Feature: x" },
+      { success: false, error: "boom" },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+  })
+
+  test("verifying a current non-Default set lifts the guard; Default does not", () => {
+    observeUpdateSetTool(
+      "snow_update_set_query",
+      { action: "current" },
+      { success: true, data: { sys_id: "d1", name: "Default" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+
+    observeUpdateSetTool(
+      "snow_update_set_query",
+      { action: "current" },
+      { success: true, data: { sys_id: "u9", name: "Sprint 12 fixes" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(true)
+  })
+
+  test("an explicit user decline is remembered for the session", () => {
+    recordUpdateSetSkip(key)
+    expect(updateSetActive(key)).toBe(true)
+  })
+
+  test("state never crosses sessions, tenants, or instances", () => {
+    recordUpdateSetSkip(key)
+    expect(updateSetActive(guardKey("42", "session-b", "https://dev1.service-now.com"))).toBe(false)
+    expect(updateSetActive(guardKey("43", "session-a", "https://dev1.service-now.com"))).toBe(false)
+    expect(updateSetActive(guardKey("42", "session-a", "https://dev2.service-now.com"))).toBe(false)
+  })
+
+  test("non-update-set tools never touch the state", () => {
+    observeUpdateSetTool(
+      "snow_flow_manage",
+      { action: "update" },
+      { success: true, data: { sys_id: "f1", name: "Some flow" } },
+      key,
+    )
+    expect(updateSetActive(key)).toBe(false)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/types.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/types.ts
@@ -122,6 +122,15 @@ export interface MCPToolDefinition {
    */
   httpForbiddenArgs?: string[]
 
+  /**
+   * Update-set guard override. The call-tool handler blocks configuration
+   * writes while no update set is active for the session (see
+   * shared/update-set-guard.ts). The default classification is
+   * category-based; set "required" or "exempt" here to correct an
+   * individual tool instead of growing the central lists.
+   */
+  updateSet?: "required" | "exempt"
+
   inputSchema: {
     type: "object"
     properties: Record<string, any>

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
@@ -1,0 +1,173 @@
+/**
+ * Update-set guard.
+ *
+ * Companion to the prod-write guard in call-tool.ts: a configuration write
+ * with no active update set for the session is blocked, so agent changes
+ * can't silently land in the Default update set. The agent lifts the guard
+ * once per session by ensuring/creating/switching an update set (or by
+ * verifying a non-Default set is already current); an explicit user decline
+ * is recorded via `__skipUpdateSet: true` and remembered for the session.
+ *
+ * Classification is conservative: only write tools outside the data domains
+ * below are gated. Per-tool corrections go through the `updateSet` field on
+ * MCPToolDefinition ("required" | "exempt") instead of growing these lists.
+ */
+
+import { type MCPToolDefinition } from "./types.js"
+import { isWriteTool, SKIP_ACTIONS, SKIP_TOOLS } from "./instance-map-hook.js"
+
+// Write tools in these categories mutate process data (incidents, CIs,
+// assets, cases, ...), not configuration — ServiceNow does not capture them
+// in update sets, so demanding one would be wrong.
+const EXEMPT_CATEGORIES = [
+  "itsm",
+  "core-operations",
+  "cmdb",
+  "asset-management",
+  "csm",
+  "ml-analytics",
+  "performance-analytics",
+]
+
+// Same idea one level deeper: tools living in config-flavoured categories
+// whose writes are still data- or action-shaped (sending mail, executing a
+// background script, importing rows, managing users/queues/sessions).
+const EXEMPT_SUBCATEGORIES = [
+  "agile",
+  "approvals",
+  "attachments",
+  "comments",
+  "customer-service",
+  "email",
+  "field-service",
+  "hr",
+  "import-export",
+  "incidents",
+  "queues",
+  "script-execution",
+  "session",
+  "user-admin",
+  "user-management",
+]
+
+// The unlock/inspection tools themselves are never gated.
+const UPDATE_SET_TOOLS = ["snow_update_set_manage", "snow_update_set_query", "snow_ensure_active_update_set"]
+
+/**
+ * Should this call only run with an active update set?
+ */
+export function requiresUpdateSet(
+  definition: MCPToolDefinition | undefined,
+  args: Record<string, any> | undefined,
+): boolean {
+  if (!definition) return false
+  if (definition.updateSet === "exempt") return false
+  if (definition.updateSet === "required") return true
+  if (!isWriteTool(definition)) return false
+  if (UPDATE_SET_TOOLS.includes(definition.name)) return false
+  if (SKIP_TOOLS.has(definition.name)) return false
+  const action = typeof args?.action === "string" ? args.action : undefined
+  if (action && SKIP_ACTIONS.has(action)) return false
+  if (definition.category && EXEMPT_CATEGORIES.includes(definition.category)) return false
+  if (definition.subcategory && EXEMPT_SUBCATEGORIES.includes(definition.subcategory)) return false
+  return true
+}
+
+type GuardEntry = {
+  active?: { sysId?: string; name?: string }
+  skipped: boolean
+  touched: number
+}
+
+const TTL_MS = 24 * 60 * 60 * 1000
+const MAX_ENTRIES = 5000
+
+// Session-scoped guard state. Keys are composed as
+// tenantId\x00sessionId\x00instanceUrl — see guardKey() — so entries can
+// never cross tenants; pruned by age once the map grows.
+const guardState = new Map<string, GuardEntry>()
+
+export function guardKey(
+  tenantId: string | undefined,
+  sessionId: string | undefined,
+  instanceUrl: string | undefined,
+): string {
+  return `${tenantId ?? "stdio"}\x00${sessionId ?? "stdio"}\x00${instanceUrl ?? ""}`
+}
+
+function entry(key: string): GuardEntry {
+  prune()
+  const found = guardState.get(key)
+  if (found) {
+    found.touched = Date.now()
+    return found
+  }
+  const fresh: GuardEntry = { skipped: false, touched: Date.now() }
+  guardState.set(key, fresh)
+  return fresh
+}
+
+function prune(): void {
+  if (guardState.size < MAX_ENTRIES) return
+  const cutoff = Date.now() - TTL_MS
+  for (const [key, value] of guardState) {
+    if (value.touched < cutoff) guardState.delete(key)
+  }
+}
+
+/**
+ * True when the session has an active update set — or the user explicitly
+ * declined tracking for this session.
+ */
+export function updateSetActive(key: string): boolean {
+  const found = guardState.get(key)
+  if (!found) return false
+  found.touched = Date.now()
+  if (found.skipped) return true
+  return found.active !== undefined
+}
+
+/** Record an explicit user decline (`__skipUpdateSet: true`) for the session. */
+export function recordUpdateSetSkip(key: string): void {
+  entry(key).skipped = true
+}
+
+/** Test helper — wipe all guard state. */
+export function resetUpdateSetState(): void {
+  guardState.clear()
+}
+
+/**
+ * Keep the session state in sync with what the update-set tools actually
+ * did: the guard lifts the moment a set is ensured/created/switched (or
+ * verified current and non-Default) and re-arms on complete. A create with
+ * auto_switch=false (or ensure with sync_with_user=false) does not track
+ * changes, so it does not lift the guard either.
+ */
+export function observeUpdateSetTool(
+  name: string,
+  args: Record<string, any> | undefined,
+  result: unknown,
+  key: string,
+): void {
+  if (!UPDATE_SET_TOOLS.includes(name)) return
+  const res = result as { success?: boolean; data?: Record<string, any> } | undefined
+  if (!res?.success) return
+  const data = res.data ?? {}
+  const explicit = typeof args?.action === "string" ? args.action : undefined
+  const action = explicit ?? (name === "snow_ensure_active_update_set" ? "ensure" : undefined)
+
+  if (action === "complete") {
+    entry(key).active = undefined
+    return
+  }
+  if (action === "create" && args?.auto_switch === false) return
+  if (action === "ensure" && args?.sync_with_user === false) return
+  if (action === "ensure" || action === "create" || action === "switch") {
+    entry(key).active = { sysId: data.sys_id, name: data.name }
+    return
+  }
+  if (action === "current" && typeof data.name === "string" && data.name !== "Default" && data.sys_id) {
+    entry(key).active = { sysId: data.sys_id, name: data.name }
+  }
+}


### PR DESCRIPTION
Fixes #233

A configuration write with no active update set now blocks at the call-tool chokepoint — same pattern as the prod-write guard (#202). The agent asks the user, runs `snow_ensure_active_update_set({ name })` once, and retries; `__skipUpdateSet: true` records an explicit decline for the rest of the session.

- Classification: write tools outside the data domains (itsm/cmdb/assets/...) are gated; read-shaped actions and the update-set tools themselves are not. Per-tool corrections via a new `updateSet: "required" | "exempt"` field on the definition.
- Session state is tenant-keyed (`tenantId\x00sessionId\x00instanceUrl`, allowlisted in no-module-state) and driven by observing the update-set tools' results: ensure/create/switch lift the guard, complete re-arms it, a verified non-Default "current" also lifts it. A create with `auto_switch: false` does not lift it (those changes aren't tracked).
- Also allowlists the pre-existing `SKIP_TOOLS` violation that was failing no-module-state on main.
- The update-set-workflow skill now mentions the guard so agents pre-empt it instead of hitting the wall.

Note: the two failing tests in `shared/__tests__` (JWT expiry, stakeholder scenario) fail on clean main too — unrelated to this change.