### PR TITLE
fix(servicenow-mcp): lenient guard flags + write-guards on the tool_execute path

### DIFF
--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
@@ -22,6 +22,9 @@ import {
   recordUpdateSetSkip,
   requiresUpdateSet,
   updateSetActive,
+  confirmationFlag,
+  prodWriteBlockMessage,
+  updateSetBlockMessage,
 } from "../shared/update-set-guard.js"
 import { type HandlerDeps } from "./types.js"
 
@@ -144,13 +147,8 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     // with `__confirmProd: true` only after the user approves the specific change;
     // the flag is stripped below so the executor never sees it.
     const prodWrite = context.environmentType === "production" && isWriteTool(tool.definition)
-    if (prodWrite && args?.__confirmProd !== true) {
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `"${name}" is a write against a PRODUCTION ServiceNow instance and is blocked by default. ` +
-          `Surface this change to the user; only after they approve, re-issue the exact same call with ` +
-          `"__confirmProd": true added to the arguments. Reads, and writes to dev/test/uat, need no confirmation.`,
-      )
+    if (prodWrite && !confirmationFlag(args?.__confirmProd)) {
+      throw new McpError(ErrorCode.InvalidRequest, prodWriteBlockMessage(name))
     }
 
     // Update-set safety: a configuration write with no active update set for
@@ -159,18 +157,11 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     // creating/switching an update set; `__skipUpdateSet: true` records an
     // explicit user decline and is remembered for the rest of the session.
     const usKey = guardKey(context.tenantId, sessionId, context.instanceUrl)
-    if (args?.__skipUpdateSet === true) {
+    if (confirmationFlag(args?.__skipUpdateSet)) {
       recordUpdateSetSkip(usKey)
     }
     if (requiresUpdateSet(tool.definition, args) && !updateSetActive(usKey)) {
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `"${name}" is a configuration write but no update set is active for this session — the change ` +
-          `would land in the Default update set untracked. Ask the user whether to capture this work in a ` +
-          `named update set (suggest a name); after they approve, call snow_ensure_active_update_set({ name }) ` +
-          `once and re-issue this call. If the user explicitly declines tracking, re-issue once with ` +
-          `"__skipUpdateSet": true — the choice is remembered for the rest of the session.`,
-      )
+      throw new McpError(ErrorCode.InvalidRequest, updateSetBlockMessage(name))
     }
 
     const execArgs =

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
@@ -171,3 +171,35 @@ export function observeUpdateSetTool(
     entry(key).active = { sysId: data.sys_id, name: data.name }
   }
 }
+
+/**
+ * Shared write-guard helpers — used by BOTH dispatch paths (the direct
+ * handler in call-tool.ts and the tool_execute meta path), so the guard
+ * behavior and messages cannot drift apart.
+ *
+ * confirmationFlag: agents — especially smaller models — routinely
+ * stringify booleans ("__confirmProd": "true", "active": "true"). Both
+ * write-guards accept boolean true and the string "true", so a
+ * user-approved retry is not re-blocked over a serialization detail.
+ */
+export function confirmationFlag(value: unknown): boolean {
+  return value === true || (typeof value === "string" && value.toLowerCase() === "true")
+}
+
+export function prodWriteBlockMessage(name: string): string {
+  return (
+    `"${name}" is a write against a PRODUCTION ServiceNow instance and is blocked by default. ` +
+    `Surface this change to the user; only after they approve, re-issue the exact same call with ` +
+    `"__confirmProd": true added to the arguments. Reads, and writes to dev/test/uat, need no confirmation.`
+  )
+}
+
+export function updateSetBlockMessage(name: string): string {
+  return (
+    `"${name}" is a configuration write but no update set is active for this session — the change ` +
+    `would land in the Default update set untracked. Ask the user whether to capture this work in a ` +
+    `named update set (suggest a name); after they approve, call snow_ensure_active_update_set({ name }) ` +
+    `once and re-issue this call. If the user explicitly declines tracking, re-issue once with ` +
+    `"__skipUpdateSet": true — the choice is remembered for the rest of the session.`
+  )
+}

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
@@ -21,6 +21,17 @@
 import { type MCPToolDefinition, type ServiceNowContext } from "../../shared/types.js"
 import { toolRegistry } from "../../shared/tool-registry.js"
 import { ToolSearch } from "../../shared/tool-search.js"
+import { isWriteTool } from "../../shared/instance-map-hook.js"
+import {
+  guardKey,
+  requiresUpdateSet,
+  updateSetActive,
+  recordUpdateSetSkip,
+  observeUpdateSetTool,
+  confirmationFlag,
+  prodWriteBlockMessage,
+  updateSetBlockMessage,
+} from "../../shared/update-set-guard.js"
 
 // ============================================================================
 // tool_search - Search for available tools
@@ -341,6 +352,21 @@ export async function tool_execute_exec(
     }
   }
 
+  // Mirror the write-guards from the direct dispatch path (call-tool.ts):
+  // without them tool_execute is a bypass around the prod-write and
+  // update-set confirmations. Same messages, same lenient flag parsing.
+  const prodWrite = context.environmentType === "production" && isWriteTool(tool.definition)
+  if (prodWrite && !confirmationFlag(toolArgs.__confirmProd)) {
+    return { success: false, error: prodWriteBlockMessage(toolName) }
+  }
+  const usKey = guardKey(context.tenantId, sessionId, context.instanceUrl)
+  if (confirmationFlag(toolArgs.__skipUpdateSet)) {
+    recordUpdateSetSkip(usKey)
+  }
+  if (requiresUpdateSet(tool.definition, toolArgs) && !updateSetActive(usKey)) {
+    return { success: false, error: updateSetBlockMessage(toolName) }
+  }
+
   // Check if tool is deferred and needs to be enabled first
   const canExecute = await ToolSearch.canExecuteTool(sessionId, toolName, tenantId)
   if (!canExecute) {
@@ -354,10 +380,17 @@ export async function tool_execute_exec(
     }
   }
 
-  // Execute the tool
+  // Execute the tool. Strip the guard flags so executors never see them,
+  // and feed update-set lifecycle tools into the guard state — in lazy
+  // mode (TUI) snow_ensure_active_update_set runs through THIS path, so
+  // without the observe call the guard could never be lifted.
+  const execArgs = Object.fromEntries(
+    Object.entries(toolArgs).filter(([k]) => k !== "__confirmProd" && k !== "__skipUpdateSet"),
+  )
   try {
     console.error(`[MetaTool] Executing via tool_execute: ${toolName}`)
-    const result = await tool.executor(toolArgs, context)
+    const result = await tool.executor(execArgs, context)
+    observeUpdateSetTool(toolName, execArgs, result, usKey)
     return {
       success: true,
       tool: toolName,


### PR DESCRIPTION
Fixes #235

From a live portal test: the user approved a prod write, the agent re-issued with `\"__confirmProd\": \"true\"` (string — it stringified `active` the same way), and the strict `!== true` check blocked it again with the identical message. To the user this reads as 'the approval flow is broken'.

- `confirmationFlag()` accepts boolean `true` and string `\"true\"` for both `__confirmProd` and `__skipUpdateSet`; block messages extracted to shared builders in update-set-guard.ts so the dispatch paths can't drift.
- `tool_execute` now enforces both write-guards (it bypassed prod-write AND the new update-set guard from #234), strips the flags before the executor, and calls `observeUpdateSetTool` after execution — in TUI lazy mode `snow_ensure_active_update_set` runs through this path, so without that the update-set guard could never be lifted.

Verified: `bun typecheck` clean; all 21 update-set-guard tests + transport-parity pass. The 2 remaining shared-test failures (JWT-expiry, stakeholder scenario) are pre-existing on main, as documented in #234.