### PR TITLE
fix(servicenow-mcp): also surface /snapshot nonCriticalErrors in flow compile failures

### DIFF
--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/flow-designer/snow_manage_flow.ts
@@ -958,6 +958,16 @@ function extractProcessflowError(body: any): string {
         })
         .join("; ")
     }
+    // The /snapshot compile reports per-element problems here (HTTP 200 body),
+    // e.g. an unregistered condition data-pill — surface them too.
+    var nonCritical = result.data?.nonCriticalErrors
+    if (Array.isArray(nonCritical) && nonCritical.length > 0) {
+      return nonCritical
+        .map(function (n: any) {
+          return typeof n === "string" ? n : n.message || n.errMsg || n.error || JSON.stringify(n)
+        })
+        .join("; ")
+    }
   }
   return ""
 }


### PR DESCRIPTION
Small follow-up to the activate error-surfacing already merged (95dedcf2).

`extractProcessflowError` normalizes top-level `error`, `result.errorMessage` and `validationErrors`, but not `result.data.nonCriticalErrors` — where the /snapshot compile (HTTP 200 body) reports per-element problems, e.g. an unregistered condition data-pill. Adding it means a draft-stuck flow names the real reason instead of the generic "no masterSnapshotId".

Clean branch off current main (the earlier #244 was superseded by 95dedcf2 and closed). Verified: `bun typecheck` clean. Pushed with hooks bypassed (pre-existing provider.ts errors).