### PR TITLE
fix(skills): update stale snow_* tool names in bundled skills to current catalog

### DIFF
--- a/packages/opencode/src/bundled-skills/acl-security/SKILL.md
+++ b/packages/opencode/src/bundled-skills/acl-security/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_review_access_control
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_test_acl
+  - snow_artifact_manage
+  - snow_execute_script
   - snow_impersonate_user
   - snow_session_context
 ---

--- a/packages/opencode/src/bundled-skills/agent-workspace/SKILL.md
+++ b/packages/opencode/src/bundled-skills/agent-workspace/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_workspace_create
+  - snow_create_workspace
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Agent Workspace for ServiceNow
@@ -440,12 +440,12 @@ action.insert()
 
 ### Available Tools
 
-| Tool                              | Purpose                  |
-| --------------------------------- | ------------------------ |
-| `snow_find_artifact`              | Find workspace configs   |
-| `snow_query_table`                | Query workspace tables   |
-| `snow_deploy`                     | Deploy workspace widgets |
-| `snow_execute_script_with_output` | Test workspace scripts   |
+| Tool                   | Purpose                                       |
+| ---------------------- | --------------------------------------------- |
+| `snow_artifact_manage` | Find workspace widgets (`action: "find"`)     |
+| `snow_query_table`     | Query workspace tables                        |
+| `snow_artifact_manage` | Deploy workspace widgets (`action: "create"`) |
+| `snow_execute_script`  | Test workspace scripts                        |
 
 ### Example Workflow
 
@@ -465,7 +465,7 @@ await snow_query_table({
 })
 
 // 3. Test similar incident finder
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var finder = new SimilarIncidentFinder();
         var similar = finder.findSimilar('incident_sys_id');

--- a/packages/opencode/src/bundled-skills/approval-workflows/SKILL.md
+++ b/packages/opencode/src/bundled-skills/approval-workflows/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_approval_rule_create
+  - snow_approval_chain_manage
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Approval Workflows for ServiceNow
@@ -351,12 +351,13 @@ function sendApprovalNotification(approvalSysId) {
 
 ### Available Tools
 
-| Tool                              | Purpose                  |
-| --------------------------------- | ------------------------ |
-| `snow_query_table`                | Query approvals          |
-| `snow_find_artifact`              | Find approval rules      |
-| `snow_execute_script_with_output` | Test approval scripts    |
-| `snow_create_business_rule`       | Create approval triggers |
+| Tool                          | Purpose                                            |
+| ----------------------------- | -------------------------------------------------- |
+| `snow_query_table`            | Query approvals and approval rules                 |
+| `snow_approval_chain_manage`  | Define multi-step approval chains (`define_chain`) |
+| `snow_artifact_manage`        | Find approval business rules (`action='find'`)     |
+| `snow_execute_script`         | Test approval scripts                              |
+| `snow_create_business_rule`   | Create approval triggers                           |
 
 ### Example Workflow
 
@@ -376,7 +377,7 @@ await snow_query_table({
 })
 
 // 3. Check delegations
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var delegates = getActiveDelegates(gs.getUserID());
         gs.info('Active delegates: ' + JSON.stringify(delegates));

--- a/packages/opencode/src/bundled-skills/asset-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/asset-management/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_asset_create
+  - snow_create_asset
   - snow_cmdb_search
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Asset Management for ServiceNow
@@ -380,12 +380,12 @@ function getAssetInventorySummary() {
 
 ### Available Tools
 
-| Tool                              | Purpose                   |
-| --------------------------------- | ------------------------- |
-| `snow_query_table`                | Query assets and licenses |
-| `snow_cmdb_search`                | Search CMDB for CIs       |
-| `snow_execute_script_with_output` | Test asset scripts        |
-| `snow_find_artifact`              | Find asset configurations |
+| Tool                   | Purpose                                     |
+| ---------------------- | ------------------------------------------- |
+| `snow_query_table`     | Query assets and licenses                   |
+| `snow_cmdb_search`     | Search CMDB for CIs                         |
+| `snow_execute_script`  | Test asset scripts                          |
+| `snow_artifact_manage` | Find asset configurations (`action: find`)  |
 
 ### Example Workflow
 
@@ -398,7 +398,7 @@ await snow_query_table({
 })
 
 // 2. Check license compliance
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var license = new GlideRecord('alm_license');
         license.addQuery('remainingRELATIVELT@integer@0');

--- a/packages/opencode/src/bundled-skills/atf-testing/SKILL.md
+++ b/packages/opencode/src/bundled-skills/atf-testing/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_atf_test_create
-  - snow_atf_test_run
+  - snow_create_atf_test
+  - snow_execute_atf_test
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Automated Test Framework (ATF) for ServiceNow

--- a/packages/opencode/src/bundled-skills/business-rule-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/business-rule-patterns/SKILL.md
@@ -4,9 +4,8 @@ description: Write ServiceNow business rules (before/after/async/display) — cu
 version: 1.0.0
 tools:
   - snow_create_business_rule
-  - snow_find_artifact
-  - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Business Rule Best Practices for ServiceNow

--- a/packages/opencode/src/bundled-skills/catalog-items/SKILL.md
+++ b/packages/opencode/src/bundled-skills/catalog-items/SKILL.md
@@ -8,10 +8,11 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_catalog_item_create
-  - snow_catalog_variable_create
+  - snow_create_catalog_item
+  - snow_create_catalog_variable
+  - snow_create_variable
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Service Catalog Development for ServiceNow
@@ -69,15 +70,23 @@ Catalog Item: Request New Laptop
 ### Basic Variable
 
 ```javascript
-// Via MCP
-snow_create_catalog_variable({
-  catalog_item: "laptop_request",
+// Via MCP (snow_create_variable supports reference, checkbox, etc.;
+// snow_create_catalog_variable covers text/choice types only)
+snow_create_variable({
+  cat_item: "<catalog item sys_id>",
   name: "laptop_model",
+  question_text: "Laptop Model",
   type: "reference",
-  reference: "cmdb_model",
-  reference_qual: "category=computer",
   mandatory: true,
   order: 100,
+})
+
+// Set the reference table and qualifier on the created variable
+snow_record_manage({
+  action: "update",
+  table: "item_option_new",
+  sys_id: "<variable sys_id>",
+  data: { reference: "cmdb_model", reference_qual: "category=computer" },
 })
 ```
 

--- a/packages/opencode/src/bundled-skills/change-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/change-management/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_change_create
-  - snow_change_schedule
+  - snow_change_manage
+  - snow_change_query
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Change Management for ServiceNow
@@ -378,42 +378,44 @@ function transitionChange(changeSysId, newState, notes) {
 
 ### Available Change Tools
 
-| Tool                          | Purpose          |
-| ----------------------------- | ---------------- |
-| `snow_create_change_request`  | Create change    |
-| `snow_create_change_task`     | Add tasks        |
-| `snow_get_change_request`     | Get details      |
-| `snow_update_change_state`    | Transition state |
-| `snow_search_change_requests` | Find changes     |
-| `snow_schedule_cab_meeting`   | Schedule CAB     |
+| Tool                                            | Purpose          |
+| ----------------------------------------------- | ---------------- |
+| `snow_change_manage` (`action='create'`)        | Create change    |
+| `snow_change_manage` (`action='create_task'`)   | Add tasks        |
+| `snow_change_query` (`action='get'`)            | Get details      |
+| `snow_change_manage` (`action='update_state'`)  | Transition state |
+| `snow_change_query` (`action='search'`)         | Find changes     |
+| `snow_change_manage` (`action='schedule_cab'`)  | Schedule CAB     |
 
 ### Example Workflow
 
 ```javascript
-// 1. Create change
-var changeId = await snow_create_change_request({
+// 1. Create change (scheduling happens later via action: "update_state" -> "scheduled")
+var changeId = await snow_change_manage({
+  action: "create",
   short_description: "Database upgrade",
   type: "normal",
-  risk: "moderate",
-  start_date: "2024-03-20 22:00:00",
-  end_date: "2024-03-21 02:00:00",
+  risk: "medium",
 })
 
 // 2. Add tasks
-await snow_create_change_task({
-  change: changeId,
-  description: "Backup database",
-  order: 100,
+await snow_change_manage({
+  action: "create_task",
+  sys_id: changeId,
+  short_description: "Backup database",
 })
 
-// 3. Check conflicts
-var conflicts = await snow_check_change_conflicts({
-  change: changeId,
+// 3. Check conflicts: search for overlapping open changes in the same window
+// (see checkChangeConflicts above for per-CI conflict detection)
+var conflicts = await snow_change_query({
+  action: "search",
+  query: "stateNOT INclosed,cancelled^start_date<=2024-03-21 02:00:00^end_date>=2024-03-20 22:00:00",
 })
 
 // 4. Submit for approval
-await snow_update_change_state({
-  change: changeId,
+await snow_change_manage({
+  action: "update_state",
+  sys_id: changeId,
   state: "assess",
 })
 ```

--- a/packages/opencode/src/bundled-skills/client-scripts/SKILL.md
+++ b/packages/opencode/src/bundled-skills/client-scripts/SKILL.md
@@ -9,8 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_create_client_script
-  - snow_find_artifact
-  - snow_edit_artifact
+  - snow_artifact_manage
   - snow_create_script_include
 ---
 

--- a/packages/opencode/src/bundled-skills/cmdb-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/cmdb-patterns/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_cmdb_search
-  - snow_cmdb_ci_create
-  - snow_cmdb_relationship_create
+  - snow_create_ci
+  - snow_create_ci_relationship
   - snow_query_table
 ---
 
@@ -386,19 +386,20 @@ await snow_cmdb_search({
   include_relationships: true,
 })
 
-// 2. Create new CI if not found
+// 2. Create new CI if not found (extra CI fields go in attributes)
 await snow_create_ci({
   ci_class: "cmdb_ci_linux_server",
   name: "PROD-WEB-002",
-  ip_address: "10.0.1.101",
-  operational_status: 1,
+  attributes: { ip_address: "10.0.1.101" },
+  operational_status: "1",
 })
 
-// 3. Create relationship
+// 3. Create relationship (relationship_type is a cmdb_rel_type sys_id,
+//    look it up via snow_query_table on cmdb_rel_type)
 await snow_create_ci_relationship({
-  parent: appSysId,
-  child: serverSysId,
-  type: "Runs on::Runs",
+  parent_ci: appSysId,
+  child_ci: serverSysId,
+  relationship_type: runsOnRelTypeSysId, // sys_id of "Runs on::Runs"
 })
 
 // 4. Impact analysis

--- a/packages/opencode/src/bundled-skills/code-review/SKILL.md
+++ b/packages/opencode/src/bundled-skills/code-review/SKILL.md
@@ -8,9 +8,8 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_find_artifact
-  - snow_execute_script_with_output
-  - snow_analyze_artifact
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # ServiceNow Code Review Checklist

--- a/packages/opencode/src/bundled-skills/csm-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/csm-patterns/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_csm_case_create
+  - snow_create_customer_case
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Customer Service Management for ServiceNow
@@ -370,12 +370,11 @@ function checkEntitlement(accountSysId, entitlementType) {
 
 ### Available Tools
 
-| Tool                              | Purpose                 |
-| --------------------------------- | ----------------------- |
-| `snow_query_table`                | Query CSM tables        |
-| `snow_find_artifact`              | Find CSM configurations |
-| `snow_execute_script_with_output` | Test CSM scripts        |
-| `snow_deploy`                     | Deploy CSM widgets      |
+| Tool                   | Purpose                                                                                   |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `snow_query_table`     | Query CSM tables                                                                           |
+| `snow_artifact_manage` | Find CSM configurations (`action: "find"`) and deploy CSM widgets (`action: "create"`)     |
+| `snow_execute_script`  | Test CSM scripts                                                                           |
 
 ### Example Workflow
 
@@ -388,7 +387,7 @@ await snow_query_table({
 })
 
 // 2. Check entitlements
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = checkEntitlement('account_sys_id', 'premium_support');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/data-policies/SKILL.md
+++ b/packages/opencode/src/bundled-skills/data-policies/SKILL.md
@@ -10,8 +10,7 @@ metadata:
 tools:
   - snow_discover_table_fields
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Data Policies & Dictionary for ServiceNow
@@ -373,12 +372,11 @@ function fieldExists(tableName, fieldName) {
 
 ### Available Tools
 
-| Tool                              | Purpose                 |
-| --------------------------------- | ----------------------- |
-| `snow_query_table`                | Query dictionary        |
-| `snow_discover_table_fields`      | Get field definitions   |
-| `snow_execute_script_with_output` | Test dictionary scripts |
-| `snow_find_artifact`              | Find data policies      |
+| Tool                         | Purpose                          |
+| ---------------------------- | -------------------------------- |
+| `snow_query_table`           | Query dictionary & data policies |
+| `snow_discover_table_fields` | Get field definitions            |
+| `snow_execute_script`        | Test dictionary scripts          |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/discovery-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/discovery-patterns/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_discovery_schedule_create
+  - snow_asset_discovery
   - snow_cmdb_search
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Discovery Patterns for ServiceNow
@@ -346,12 +346,12 @@ function getDiscoveredDevices(statusSysId) {
 
 ### Available Tools
 
-| Tool                              | Purpose                |
-| --------------------------------- | ---------------------- |
-| `snow_query_table`                | Query discovery tables |
-| `snow_find_artifact`              | Find discovery configs |
-| `snow_execute_script_with_output` | Test discovery scripts |
-| `snow_cmdb_search`                | Search discovered CIs  |
+| Tool                   | Purpose                          |
+| ---------------------- | -------------------------------- |
+| `snow_query_table`     | Query discovery tables           |
+| `snow_artifact_manage` | Find artifacts (`action='find'`) |
+| `snow_execute_script`  | Test discovery scripts           |
+| `snow_cmdb_search`     | Search discovered CIs            |
 
 ### Example Workflow
 
@@ -364,7 +364,7 @@ await snow_query_table({
 })
 
 // 2. Check recent discovery status
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var status = getDiscoveryStatus('schedule_sys_id');
         gs.info(JSON.stringify(status));

--- a/packages/opencode/src/bundled-skills/document-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/document-management/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
+  - snow_execute_script
+  - snow_artifact_manage
 ---
 
 # Document Management for ServiceNow
@@ -400,11 +400,11 @@ function canAccessAttachment(attachmentSysId) {
 
 ### Available Tools
 
-| Tool                              | Purpose               |
-| --------------------------------- | --------------------- |
-| `snow_query_table`                | Query attachments     |
-| `snow_execute_script_with_output` | Test document scripts |
-| `snow_find_artifact`              | Find templates        |
+| Tool                   | Purpose                                                |
+| ---------------------- | ------------------------------------------------------ |
+| `snow_query_table`     | Query attachments and templates                        |
+| `snow_execute_script`  | Test document scripts                                  |
+| `snow_artifact_manage` | Find artifacts (`action: "find"`, `type` required)     |
 
 ### Example Workflow
 
@@ -417,7 +417,7 @@ await snow_query_table({
 })
 
 // 2. Generate document
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var html = generateDocumentFromTemplate('Incident Summary', 'inc_sys_id');
         gs.info('Generated: ' + (html ? 'success' : 'failed'));

--- a/packages/opencode/src/bundled-skills/domain-separation/SKILL.md
+++ b/packages/opencode/src/bundled-skills/domain-separation/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
+  - snow_execute_script
+  - snow_artifact_manage
 ---
 
 # Domain Separation for ServiceNow
@@ -357,11 +357,11 @@ function onboardTenant(tenantData) {
 
 ### Available Tools
 
-| Tool                              | Purpose                    |
-| --------------------------------- | -------------------------- |
-| `snow_query_table`                | Query domain-aware data    |
-| `snow_execute_script_with_output` | Test domain scripts        |
-| `snow_find_artifact`              | Find domain configurations |
+| Tool                   | Purpose                                      |
+| ---------------------- | -------------------------------------------- |
+| `snow_query_table`     | Query domain-aware data                      |
+| `snow_execute_script`  | Test domain scripts                          |
+| `snow_artifact_manage` | Find domain configurations (`action='find'`) |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/email-notifications/SKILL.md
+++ b/packages/opencode/src/bundled-skills/email-notifications/SKILL.md
@@ -8,10 +8,11 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_configure_email
+  - snow_email_notification_manage
+  - snow_create_email_config
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Email Notifications for ServiceNow

--- a/packages/opencode/src/bundled-skills/es5-compliance/SKILL.md
+++ b/packages/opencode/src/bundled-skills/es5-compliance/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_convert_es6_to_es5
 ---
 

--- a/packages/opencode/src/bundled-skills/event-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/event-management/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
   - snow_create_event
 ---
 
@@ -402,12 +402,12 @@ function getThresholdName(severity) {
 
 ### Available Tools
 
-| Tool                              | Purpose                 |
-| --------------------------------- | ----------------------- |
-| `snow_query_table`                | Query events and alerts |
-| `snow_find_artifact`              | Find event rules        |
-| `snow_execute_script_with_output` | Test event scripts      |
-| `snow_create_event`               | Trigger system events   |
+| Tool                   | Purpose                                  |
+| ---------------------- | ---------------------------------------- |
+| `snow_query_table`     | Query events, alerts, and event rules    |
+| `snow_artifact_manage` | Find related artifacts (`action='find'`) |
+| `snow_execute_script`  | Test event scripts                       |
+| `snow_create_event`    | Trigger system events                    |
 
 ### Example Workflow
 
@@ -427,7 +427,7 @@ await snow_query_table({
 })
 
 // 3. Create test event
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var event = new GlideRecord('em_event');
         event.initialize();

--- a/packages/opencode/src/bundled-skills/field-service/SKILL.md
+++ b/packages/opencode/src/bundled-skills/field-service/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
+  - snow_execute_script
+  - snow_artifact_manage
 ---
 
 # Field Service Management for ServiceNow
@@ -371,11 +371,11 @@ function recordTimeEntry(workOrderSysId, timeData) {
 
 ### Available Tools
 
-| Tool                              | Purpose             |
-| --------------------------------- | ------------------- |
-| `snow_query_table`                | Query FSM tables    |
-| `snow_execute_script_with_output` | Test FSM scripts    |
-| `snow_find_artifact`              | Find configurations |
+| Tool                   | Purpose                              |
+| ---------------------- | ------------------------------------ |
+| `snow_query_table`     | Query FSM tables                     |
+| `snow_execute_script`  | Test FSM scripts                     |
+| `snow_artifact_manage` | Find configurations (action='find')  |
 
 ### Example Workflow
 
@@ -388,7 +388,7 @@ await snow_query_table({
 })
 
 // 2. Find available technicians
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var available = getAvailableTechnicians(
             new GlideDateTime(),

--- a/packages/opencode/src/bundled-skills/flow-designer/SKILL.md
+++ b/packages/opencode/src/bundled-skills/flow-designer/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Flow Designer Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/gliderecord-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/gliderecord-patterns/SKILL.md
@@ -4,7 +4,7 @@ description: Write efficient ServiceNow GlideRecord queries — addQuery vs addE
 version: 1.0.0
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_discover_table_fields
 ---
 

--- a/packages/opencode/src/bundled-skills/grc-compliance/SKILL.md
+++ b/packages/opencode/src/bundled-skills/grc-compliance/SKILL.md
@@ -9,9 +9,9 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_audit_compliance
-  - snow_assess_risk
+  - snow_execute_script
+  - snow_run_compliance_scan
+  - snow_grc_risk_manage (action='assess')
 ---
 
 # GRC & Compliance for ServiceNow
@@ -409,12 +409,12 @@ function getComplianceSummary() {
 
 ### Available Tools
 
-| Tool                              | Purpose               |
-| --------------------------------- | --------------------- |
-| `snow_query_table`                | Query GRC tables      |
-| `snow_execute_script_with_output` | Test GRC scripts      |
-| `snow_audit_compliance`           | Run compliance audits |
-| `snow_assess_risk`                | Risk assessment       |
+| Tool                                   | Purpose               |
+| -------------------------------------- | --------------------- |
+| `snow_query_table`                     | Query GRC tables      |
+| `snow_execute_script`                  | Test GRC scripts      |
+| `snow_run_compliance_scan`             | Run compliance audits |
+| `snow_grc_risk_manage` (action='assess') | Risk assessment       |
 
 ### Example Workflow
 
@@ -434,7 +434,7 @@ await snow_query_table({
 })
 
 // 3. Get compliance summary
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var summary = getComplianceSummary();
         gs.info(JSON.stringify(summary));

--- a/packages/opencode/src/bundled-skills/hr-service-delivery/SKILL.md
+++ b/packages/opencode/src/bundled-skills/hr-service-delivery/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_hr_case_create
+  - snow_create_hr_case
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # HR Service Delivery for ServiceNow
@@ -370,12 +370,12 @@ function processTemplate(template, data) {
 
 ### Available Tools
 
-| Tool                              | Purpose                       |
-| --------------------------------- | ----------------------------- |
-| `snow_query_table`                | Query HR cases and activities |
-| `snow_find_artifact`              | Find HR configurations        |
-| `snow_execute_script_with_output` | Test HR scripts               |
-| `snow_deploy`                     | Deploy HR widgets             |
+| Tool                                  | Purpose                       |
+| ------------------------------------- | ----------------------------- |
+| `snow_query_table`                    | Query HR cases and activities |
+| `snow_artifact_manage` (action=find)  | Find HR configurations        |
+| `snow_execute_script`                 | Test HR scripts               |
+| `snow_artifact_manage` (action=create)| Deploy HR widgets             |
 
 ### Example Workflow
 
@@ -395,7 +395,7 @@ await snow_query_table({
 })
 
 // 3. Create HR case
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var hrCase = new GlideRecord('sn_hr_core_case');
         hrCase.initialize();

--- a/packages/opencode/src/bundled-skills/import-export/SKILL.md
+++ b/packages/opencode/src/bundled-skills/import-export/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_create_import_set
   - snow_create_transform_map
-  - snow_execute_script_with_output
+  - snow_execute_script
   - snow_query_table
 ---
 
@@ -443,7 +443,7 @@ function bulkDelete(tableName, encodedQuery, maxRecords) {
 | --------------------------------- | ------------------ |
 | `snow_create_import_set`          | Create import sets |
 | `snow_create_transform_map`       | Create transforms  |
-| `snow_execute_script_with_output` | Test import/export |
+| `snow_execute_script`             | Test import/export |
 | `snow_query_table`                | Query data         |
 
 ### Example Workflow
@@ -457,7 +457,7 @@ await snow_query_table({
 })
 
 // 2. Export data
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var csv = exportToCSV('incident', 'active=true', 'number,short_description,state');
         gs.info('Exported ' + csv.split('\\n').length + ' rows');

--- a/packages/opencode/src/bundled-skills/incident-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/incident-management/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_query_incidents
+  - snow_record_manage
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Incident Management for ServiceNow
@@ -433,24 +433,26 @@ function calculateMTTR(startDate, endDate, filters) {
 
 ### Available Tools
 
-| Tool                              | Purpose                    |
-| --------------------------------- | -------------------------- |
-| `snow_query_incidents`            | Query incident records     |
-| `snow_query_table`                | Advanced incident queries  |
-| `snow_execute_script_with_output` | Test incident scripts      |
-| `snow_create_business_rule`       | Create incident automation |
+| Tool                                       | Purpose                    |
+| ------------------------------------------ | -------------------------- |
+| `snow_record_manage` (action='query')      | Query incident records     |
+| `snow_query_table`                         | Advanced incident queries  |
+| `snow_execute_script`                      | Test incident scripts      |
+| `snow_create_business_rule`                | Create incident automation |
 
 ### Example Workflow
 
 ```javascript
 // 1. Query open P1 incidents
-await snow_query_incidents({
+await snow_record_manage({
+  action: "query",
+  table: "incident",
   query: "priority=1^active=true",
   fields: "number,short_description,assigned_to,opened_at",
 })
 
 // 2. Check incident metrics
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var stats = calculateMTTR(gs.beginningOfThisMonth(), gs.endOfThisMonth(), {});
         gs.info('MTTR: ' + stats.mttr_hours + ' hours');

--- a/packages/opencode/src/bundled-skills/instance-security/SKILL.md
+++ b/packages/opencode/src/bundled-skills/instance-security/SKILL.md
@@ -8,10 +8,8 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_property_get
-  - snow_property_set
-  - snow_execute_script_with_output
-  - snow_review_access_control
+  - snow_property_manage
+  - snow_execute_script
   - snow_query_table
 ---
 
@@ -388,22 +386,23 @@ function securityHealthCheck() {
 
 ### Available Tools
 
-| Tool                              | Purpose                   |
-| --------------------------------- | ------------------------- |
-| `snow_property_get`               | Check security properties |
-| `snow_execute_script_with_output` | Test security scripts     |
-| `snow_review_access_control`      | Review ACLs               |
+| Tool                                | Purpose                   |
+| ----------------------------------- | ------------------------- |
+| `snow_property_manage` (action=get) | Check security properties |
+| `snow_execute_script`               | Test security scripts     |
+| `snow_query_table`                  | Review ACLs               |
 
 ### Example Workflow
 
 ```javascript
 // 1. Check security properties
-await snow_property_get({
+await snow_property_manage({
+  action: "get",
   name: "glide.security.session.timeout",
 })
 
 // 2. Run security health check
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var health = securityHealthCheck();
         gs.info(JSON.stringify(health));

--- a/packages/opencode/src/bundled-skills/integration-hub/SKILL.md
+++ b/packages/opencode/src/bundled-skills/integration-hub/SKILL.md
@@ -9,9 +9,9 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
   - snow_test_rest_connection
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # IntegrationHub for ServiceNow
@@ -362,9 +362,9 @@ function executeWithRetry(fn, maxRetries, delayMs) {
 | Tool                              | Purpose                  |
 | --------------------------------- | ------------------------ |
 | `snow_query_table`                | Query spokes and actions |
-| `snow_find_artifact`              | Find integration configs |
+| `snow_artifact_manage` (action='find') | Find integration configs |
 | `snow_test_rest_connection`       | Test connections         |
-| `snow_execute_script_with_output` | Test action scripts      |
+| `snow_execute_script`             | Test action scripts      |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/knowledge-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/knowledge-management/SKILL.md
@@ -8,10 +8,9 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_knowledge_article_create
-  - snow_knowledge_search
+  - snow_knowledge_article_manage
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Knowledge Management for ServiceNow
@@ -369,24 +368,25 @@ function updateArticleRating(articleSysId) {
 
 ### Available Tools
 
-| Tool                              | Purpose               |
-| --------------------------------- | --------------------- |
-| `snow_knowledge_search`           | Search knowledge base |
-| `snow_query_table`                | Query kb_knowledge    |
-| `snow_find_artifact`              | Find articles         |
-| `snow_execute_script_with_output` | Test KB scripts       |
+| Tool                                          | Purpose               |
+| --------------------------------------------- | --------------------- |
+| `snow_knowledge_article_manage` (action='search') | Search knowledge base |
+| `snow_query_table`                            | Query kb_knowledge    |
+| `snow_artifact_manage` (action='find')        | Find articles         |
+| `snow_execute_script`                         | Test KB scripts       |
 
 ### Example Workflow
 
 ```javascript
 // 1. Search for existing articles
-await snow_knowledge_search({
+await snow_knowledge_article_manage({
+  action: "search",
   query: "password reset",
   limit: 5,
 })
 
 // 2. Create new article
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var article = new GlideRecord('kb_knowledge');
         article.initialize();

--- a/packages/opencode/src/bundled-skills/mcp-tool-discovery/SKILL.md
+++ b/packages/opencode/src/bundled-skills/mcp-tool-discovery/SKILL.md
@@ -151,7 +151,7 @@ Tools follow consistent naming patterns:
 | Pattern         | Example                  | Purpose               |
 | --------------- | ------------------------ | --------------------- |
 | `snow_*`        | `snow_query_table`       | ServiceNow operations |
-| `snow_deploy_*` | `snow_deploy_widget`     | Artifact creation     |
+| `snow_deploy_*` | `snow_artifact_manage` (action='create', type='sp_widget') | Artifact creation     |
 | `snow_update_*` | `snow_update_set_manage` | Update operations     |
 | `jira_*`        | `jira_search_issues`     | Jira integration      |
 | `azdo_*`        | `azdo_search_work_items` | Azure DevOps          |
@@ -198,8 +198,8 @@ Serac includes specialized MCP servers:
 tool_search({ query: "incident" })
 
 // Use discovered tools
-snow_query_incidents({ filters: { active: true, priority: 1 } })
-snow_create_incident({ short_description: "...", caller_id: "..." })
+snow_record_manage({ action: "query", table: "incident", query: "active=true^priority=1" })
+snow_record_manage({ action: "create", table: "incident", short_description: "...", caller_id: "..." })
 ```
 
 ### Finding Widget Tools
@@ -209,8 +209,8 @@ snow_create_incident({ short_description: "...", caller_id: "..." })
 tool_search({ query: "widget" })
 
 // Use discovered tools
-snow_find_artifact({ type: "widget", query: "incident" })
-snow_widget_pull({ widget_name: "incident-dashboard", local_path: "./widgets" })
+snow_artifact_manage({ action: "find", type: "sp_widget", query: "incident" })
+snow_pull_artifact({ sys_id: "<widget sys_id>", table: "sp_widget", output_dir: "./widgets" })
 ```
 
 ### Finding Enterprise Tools

--- a/packages/opencode/src/bundled-skills/mid-server/SKILL.md
+++ b/packages/opencode/src/bundled-skills/mid-server/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # MID Server for ServiceNow
@@ -401,11 +401,11 @@ function getMIDServerStatus() {
 
 ### Available Tools
 
-| Tool                              | Purpose                  |
-| --------------------------------- | ------------------------ |
-| `snow_query_table`                | Query MID and ECC tables |
-| `snow_find_artifact`              | Find probes/sensors      |
-| `snow_execute_script_with_output` | Test MID scripts         |
+| Tool                                  | Purpose                  |
+| ------------------------------------- | ------------------------ |
+| `snow_query_table`                    | Query MID and ECC tables |
+| `snow_artifact_manage` (action='find') | Find probes/sensors      |
+| `snow_execute_script`                 | Test MID scripts         |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/mobile-development/SKILL.md
+++ b/packages/opencode/src/bundled-skills/mobile-development/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
+  - snow_execute_script
+  - snow_artifact_manage
 ---
 
 # Mobile Development for ServiceNow
@@ -424,11 +424,11 @@ function findNearbyAssets(latitude, longitude, radiusMeters) {
 
 ### Available Tools
 
-| Tool                              | Purpose              |
-| --------------------------------- | -------------------- |
-| `snow_query_table`                | Query mobile configs |
-| `snow_execute_script_with_output` | Test mobile scripts  |
-| `snow_find_artifact`              | Find configurations  |
+| Tool                                  | Purpose              |
+| ------------------------------------- | -------------------- |
+| `snow_query_table`                    | Query mobile configs |
+| `snow_execute_script`                 | Test mobile scripts  |
+| `snow_artifact_manage` (action='find')| Find configurations  |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/notification-events/SKILL.md
+++ b/packages/opencode/src/bundled-skills/notification-events/SKILL.md
@@ -10,8 +10,8 @@ metadata:
 tools:
   - snow_create_event
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Notification Events for ServiceNow
@@ -338,12 +338,12 @@ function getPendingEvents(eventName) {
 
 ### Available Tools
 
-| Tool                              | Purpose                   |
-| --------------------------------- | ------------------------- |
-| `snow_create_event`               | Queue events              |
-| `snow_query_table`                | Query event queue         |
-| `snow_find_artifact`              | Find event configurations |
-| `snow_execute_script_with_output` | Test event scripts        |
+| Tool                                       | Purpose                   |
+| ------------------------------------------ | ------------------------- |
+| `snow_create_event`                        | Queue events              |
+| `snow_query_table`                         | Query event queue         |
+| `snow_artifact_manage` (action='find')     | Find event configurations |
+| `snow_execute_script`                      | Test event scripts        |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/performance-analytics/SKILL.md
+++ b/packages/opencode/src/bundled-skills/performance-analytics/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_pa_indicator_create
-  - snow_pa_breakdown_create
+  - snow_pa_indicator_manage
+  - snow_pa_create
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage
 ---
 
 # Performance Analytics for ServiceNow
@@ -319,51 +319,60 @@ job.collectIndicatorScores(indicatorSysId)
 
 ### Available PA Tools
 
-| Tool                          | Purpose            |
-| ----------------------------- | ------------------ |
-| `snow_create_pa_indicator`    | Create indicator   |
-| `snow_create_pa_breakdown`    | Create breakdown   |
-| `snow_create_pa_threshold`    | Create threshold   |
-| `snow_create_pa_widget`       | Create widget      |
-| `snow_get_pa_scores`          | Retrieve scores    |
-| `snow_collect_pa_data`        | Trigger collection |
-| `snow_discover_pa_indicators` | Find indicators    |
+| Tool                                       | Purpose            |
+| ------------------------------------------ | ------------------ |
+| `snow_pa_create` (action='indicator')      | Create indicator   |
+| `snow_pa_create` (action='breakdown')      | Create breakdown   |
+| `snow_pa_create` (action='threshold')      | Create threshold   |
+| `snow_pa_create` (action='widget')         | Create widget      |
+| `snow_pa_operate` (action='get_scores')    | Retrieve scores    |
+| `snow_pa_operate` (action='collect_data')  | Trigger collection |
+| `snow_pa_discover` (action='indicators')   | Find indicators    |
 
 ### Example Workflow
 
 ```javascript
 // 1. Create indicator
-var indicatorId = await snow_create_pa_indicator({
+var indicatorResult = await snow_pa_create({
+  action: "indicator",
   name: "Open P1 Incidents",
   table: "incident",
   conditions: "active=true^priority=1",
   aggregate: "COUNT",
-  direction: "down_is_good",
 })
+var indicatorId = indicatorResult.sys_id
 
 // 2. Create breakdown
-var breakdownId = await snow_create_pa_breakdown({
+var breakdownResult = await snow_pa_create({
+  action: "breakdown",
   name: "By Assignment Group",
   table: "incident",
   field: "assignment_group",
 })
+var breakdownId = breakdownResult.sys_id
 
-// 3. Link breakdown
-await snow_create_pa_indicator_breakdown({
-  indicator: indicatorId,
-  breakdown: breakdownId,
+// 3. Attach the breakdown to the indicator
+//    (add_breakdown creates the breakdown + the indicator link in one step)
+await snow_pa_indicator_manage({
+  action: "add_breakdown",
+  sys_id: indicatorId,
+  breakdown_name: "By Assignment Group",
+  breakdown_table: "incident",
+  breakdown_field: "assignment_group",
 })
 
 // 4. Create threshold
-await snow_create_pa_threshold({
+await snow_pa_create({
+  action: "threshold",
   indicator: indicatorId,
+  type: "critical",
   operator: ">=",
   value: 10,
-  color: "red",
 })
 
 // 5. Create widget
-await snow_create_pa_widget({
+await snow_pa_create({
+  action: "widget",
   name: "P1 Incidents Scorecard",
   type: "scorecard",
   indicator: indicatorId,
@@ -371,8 +380,9 @@ await snow_create_pa_widget({
 })
 
 // 6. Get current scores
-var scores = await snow_get_pa_scores({
-  indicator: indicatorId,
+var scores = await snow_pa_operate({
+  action: "get_scores",
+  indicator_sys_id: indicatorId,
   time_range: "last_30_days",
 })
 ```

--- a/packages/opencode/src/bundled-skills/predictive-intelligence/SKILL.md
+++ b/packages/opencode/src/bundled-skills/predictive-intelligence/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
   - ml_predict_change_risk
   - ml_detect_anomalies
 ---
@@ -371,9 +371,9 @@ function getPredictionAccuracy(solutionName, days) {
 
 | Tool                              | Purpose             |
 | --------------------------------- | ------------------- |
-| `snow_query_table`                | Query ML tables     |
-| `snow_execute_script_with_output` | Test predictions    |
-| `ml_predict_change_risk`          | Predict change risk |
+| `snow_query_table`         | Query ML tables     |
+| `snow_execute_script`      | Test predictions    |
+| `ml_predict_change_risk`   | Predict change risk |
 | `ml_detect_anomalies`             | Anomaly detection   |
 
 ### Example Workflow
@@ -394,7 +394,7 @@ await snow_query_table({
 })
 
 // 3. Test prediction
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = getClassificationPrediction('incident', 'inc_sys_id', 'incident_classifier');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/problem-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/problem-management/SKILL.md
@@ -9,9 +9,9 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
-  - snow_knowledge_article_create
+  - snow_artifact_manage
+  - snow_execute_script
+  - snow_knowledge_article_manage
 ---
 
 # Problem Management for ServiceNow
@@ -494,12 +494,12 @@ function notifyLinkedIncidents(problemSysId, message) {
 
 ### Available Tools
 
-| Tool                              | Purpose                         |
-| --------------------------------- | ------------------------------- |
-| `snow_query_table`                | Query problems and known errors |
-| `snow_find_artifact`              | Find problem records            |
-| `snow_execute_script_with_output` | Test problem scripts            |
-| `snow_create_business_rule`       | Create problem automation       |
+| Tool                                  | Purpose                            |
+| ------------------------------------- | ---------------------------------- |
+| `snow_query_table`                    | Query problems and known errors    |
+| `snow_artifact_manage` (action=`find`) | Find related dev artifacts         |
+| `snow_execute_script`                 | Test problem scripts               |
+| `snow_create_business_rule`           | Create problem automation          |
 
 ### Example Workflow
 
@@ -519,7 +519,7 @@ await snow_query_table({
 })
 
 // 3. Find recurring incidents for proactive problems
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var patterns = identifyProactiveProblems();
         gs.info('Patterns found: ' + patterns.length);

--- a/packages/opencode/src/bundled-skills/reporting-dashboards/SKILL.md
+++ b/packages/opencode/src/bundled-skills/reporting-dashboards/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 tools:
   - snow_create_report
   - snow_create_dashboard
-  - snow_schedule_report
+  - snow_schedule_report_delivery
   - snow_query_table
 ---
 
@@ -330,26 +330,28 @@ function exportReportToCSV(reportSysId) {
 
 ### Available Reporting Tools
 
-| Tool                             | Purpose               |
-| -------------------------------- | --------------------- |
-| `snow_create_report`             | Create report         |
-| `snow_create_dashboard`          | Create dashboard      |
-| `snow_create_scheduled_report`   | Schedule delivery     |
-| `snow_discover_reporting_tables` | Find available tables |
-| `snow_discover_report_fields`    | Get field options     |
-| `snow_export_report_data`        | Export data           |
-| `snow_create_data_visualization` | Create chart          |
+| Tool                                          | Purpose               |
+| --------------------------------------------- | --------------------- |
+| `snow_create_report`                          | Create report         |
+| `snow_create_dashboard`                       | Create dashboard      |
+| `snow_pa_create` (action='scheduled_report')  | Schedule delivery     |
+| `snow_pa_discover` (action='reporting_tables')| Find available tables |
+| `snow_pa_discover` (action='report_fields')   | Get field options     |
+| `snow_pa_operate` (action='export_report')    | Export data           |
+| `snow_pa_create` (action='visualization')     | Create chart          |
 
 ### Example Workflow
 
 ```javascript
 // 1. Discover available tables
-var tables = await snow_discover_reporting_tables({
+var tables = await snow_pa_discover({
+  action: "reporting_tables",
   category: "itsm",
 })
 
 // 2. Get fields for table
-var fields = await snow_discover_report_fields({
+var fields = await snow_pa_discover({
+  action: "report_fields",
   table: "incident",
 })
 
@@ -377,12 +379,13 @@ await snow_add_dashboard_widget({
   column: 0,
 })
 
-// 6. Schedule report
-await snow_create_scheduled_report({
-  report: reportId,
-  frequency: "weekly",
-  recipients: "managers@company.com",
-  format: "pdf",
+// 6. Schedule report (looked up by name, recipients as array)
+await snow_pa_create({
+  action: "scheduled_report",
+  reportName: "Incident Overview",
+  schedule: "weekly",
+  recipients: ["managers@company.com"],
+  format: "PDF",
 })
 ```
 

--- a/packages/opencode/src/bundled-skills/request-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/request-management/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
   - snow_create_catalog_item
 ---
 
@@ -344,12 +344,12 @@ function getRequestApprovalStatus(requestSysId) {
 
 ### Available Tools
 
-| Tool                              | Purpose                  |
-| --------------------------------- | ------------------------ |
-| `snow_query_table`                | Query requests and RITMs |
-| `snow_find_artifact`              | Find catalog items       |
-| `snow_execute_script_with_output` | Test request scripts     |
-| `snow_create_catalog_item`        | Create catalog items     |
+| Tool                                       | Purpose                  |
+| ------------------------------------------ | ------------------------ |
+| `snow_query_table`                         | Query requests and RITMs |
+| `snow_artifact_manage` (action='find')     | Find catalog items       |
+| `snow_execute_script`                      | Test request scripts     |
+| `snow_create_catalog_item`                 | Create catalog items     |
 
 ### Example Workflow
 
@@ -362,7 +362,7 @@ await snow_query_table({
 })
 
 // 2. Get request details
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var vars = getRITMVariables('ritm_sys_id');
         gs.info(JSON.stringify(vars));

--- a/packages/opencode/src/bundled-skills/rest-integration/SKILL.md
+++ b/packages/opencode/src/bundled-skills/rest-integration/SKILL.md
@@ -5,8 +5,8 @@ version: 1.0.0
 tools:
   - snow_create_rest_message
   - snow_test_rest_connection
-  - snow_test_web_service
-  - snow_execute_script_with_output
+  - snow_test_integration
+  - snow_execute_script
 ---
 
 # REST Integration Patterns for ServiceNow

--- a/packages/opencode/src/bundled-skills/scheduled-jobs/SKILL.md
+++ b/packages/opencode/src/bundled-skills/scheduled-jobs/SKILL.md
@@ -9,9 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_schedule_job
-  - snow_find_artifact
-  - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Scheduled Jobs for ServiceNow
@@ -370,12 +369,12 @@ while (history.next()) {
 
 ### Available Tools
 
-| Tool                              | Purpose                  |
-| --------------------------------- | ------------------------ |
-| `snow_schedule_job`               | Create scheduled job     |
-| `snow_find_artifact`              | Find existing jobs       |
-| `snow_execute_script_with_output` | Test job script          |
-| `snow_get_logs`                   | Check job execution logs |
+| Tool                                  | Purpose                  |
+| ------------------------------------- | ------------------------ |
+| `snow_schedule_job`                   | Create scheduled job     |
+| `snow_artifact_manage` (action=find)  | Find existing jobs       |
+| `snow_execute_script`                 | Test job script          |
+| `snow_get_logs`                       | Check job execution logs |
 
 ### Example Workflow
 
@@ -390,7 +389,7 @@ await snow_schedule_job({
 })
 
 // 2. Test the script
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: "/* test job script */",
 })
 

--- a/packages/opencode/src/bundled-skills/scoped-apps/SKILL.md
+++ b/packages/opencode/src/bundled-skills/scoped-apps/SKILL.md
@@ -8,8 +8,8 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_create_scoped_application
-  - snow_update_set_create
+  - snow_create_application
+  - snow_update_set_manage (action='create')
   - snow_query_table
   - snow_property_manager
 ---

--- a/packages/opencode/src/bundled-skills/script-include-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/script-include-patterns/SKILL.md
@@ -9,9 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_create_script_include
-  - snow_find_artifact
-  - snow_edit_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # Script Include Patterns for ServiceNow
@@ -323,9 +322,9 @@ MyAppUtils.prototype = {
 | Tool                              | Purpose                       |
 | --------------------------------- | ----------------------------- |
 | `snow_create_script_include`      | Create new Script Include     |
-| `snow_find_artifact`              | Find existing Script Includes |
-| `snow_edit_artifact`              | Modify Script Include code    |
-| `snow_execute_script_with_output` | Test Script Include           |
+| `snow_artifact_manage` (action='find')   | Find existing Script Includes |
+| `snow_artifact_manage` (action='update') | Modify Script Include code    |
+| `snow_execute_script`             | Test Script Include           |
 
 ### Example Workflow
 
@@ -339,7 +338,7 @@ await snow_create_script_include({
 })
 
 // 2. Test the Script Include
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var utils = new IncidentUtils();
         var incident = utils.getByNumber('INC0010001');

--- a/packages/opencode/src/bundled-skills/security-operations/SKILL.md
+++ b/packages/opencode/src/bundled-skills/security-operations/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
   - snow_create_event
 ---
 
@@ -376,12 +376,12 @@ function disableUser(user) {
 
 ### Available Tools
 
-| Tool                              | Purpose                 |
-| --------------------------------- | ----------------------- |
-| `snow_query_table`                | Query SecOps tables     |
-| `snow_find_artifact`              | Find security configs   |
-| `snow_execute_script_with_output` | Test SecOps scripts     |
-| `snow_create_event`               | Trigger security events |
+| Tool                                | Purpose                 |
+| ----------------------------------- | ----------------------- |
+| `snow_query_table`                  | Query SecOps tables     |
+| `snow_artifact_manage` (action='find') | Find security configs   |
+| `snow_execute_script`               | Test SecOps scripts     |
+| `snow_create_event`                 | Trigger security events |
 
 ### Example Workflow
 
@@ -401,7 +401,7 @@ await snow_query_table({
 })
 
 // 3. Check threat indicator
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var result = checkThreatIndicator('suspicious-domain.com', 'domain');
         gs.info(JSON.stringify(result));

--- a/packages/opencode/src/bundled-skills/sla-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/sla-management/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_sla_definition_create
+  - snow_create_sla_definition
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # SLA Management for ServiceNow
@@ -361,20 +361,21 @@ gs.info("P1 Response SLA Compliance: " + stats.compliance + "%")
 
 ### Available Tools
 
-| Tool                              | Purpose                |
-| --------------------------------- | ---------------------- |
-| `snow_find_artifact`              | Find SLA definitions   |
-| `snow_query_table`                | Query task_sla records |
-| `snow_execute_script_with_output` | Test SLA scripts       |
-| `snow_create_business_rule`       | Create SLA triggers    |
+| Tool                                    | Purpose                |
+| --------------------------------------- | ---------------------- |
+| `snow_artifact_manage` (action='find')  | Find SLA definitions   |
+| `snow_query_table`                      | Query task_sla records |
+| `snow_execute_script`                   | Test SLA scripts       |
+| `snow_create_business_rule`             | Create SLA triggers    |
 
 ### Example Workflow
 
 ```javascript
 // 1. Find existing SLAs
-await snow_find_artifact({
+await snow_artifact_manage({
+  action: "find",
   type: "contract_sla",
-  name: "P1",
+  query: "P1",
 })
 
 // 2. Query SLA breaches
@@ -385,7 +386,7 @@ await snow_query_table({
 })
 
 // 3. Check SLA compliance
-await snow_execute_script_with_output({
+await snow_execute_script({
   script:
     'var stats = getSLAComplianceRate("P1 Response", gs.beginningOfThisMonth(), gs.endOfThisMonth()); gs.info(JSON.stringify(stats));',
 })

--- a/packages/opencode/src/bundled-skills/transform-maps/SKILL.md
+++ b/packages/opencode/src/bundled-skills/transform-maps/SKILL.md
@@ -11,7 +11,7 @@ tools:
   - snow_create_transform_map
   - snow_create_import_set
   - snow_query_table
-  - snow_execute_script_with_output
+  - snow_execute_script
 ---
 
 # Transform Maps for ServiceNow
@@ -416,15 +416,16 @@ if (importSetSysId) {
 ### Example Workflow
 
 ```javascript
-// 1. Create import set table
-await snow_create_import_set_table({
+// 1. Create import set table, then add one column per field
+await snow_create_table({
   name: "u_vendor_import",
-  fields: [
-    { name: "u_vendor_id", type: "string" },
-    { name: "u_vendor_name", type: "string" },
-    { name: "u_contact_email", type: "string" },
-  ],
+  label: "Vendor Import",
+  extends_table: "sys_import_set_row",
 })
+
+await snow_create_field({ table: "u_vendor_import", column_name: "u_vendor_id", internal_type: "string" })
+await snow_create_field({ table: "u_vendor_import", column_name: "u_vendor_name", internal_type: "string" })
+await snow_create_field({ table: "u_vendor_import", column_name: "u_contact_email", internal_type: "string" })
 
 // 2. Create transform map
 var transformId = await snow_create_transform_map({
@@ -447,10 +448,17 @@ await snow_create_field_map({
   target: "name",
 })
 
-// 4. Run import
-await snow_execute_import({
-  data_source: dataSourceId,
-  transform_map: transformId,
+// 4. Stage rows into the import set table, then run the transform
+var importResult = await snow_create_import_set({
+  table: "u_vendor_import",
+  data: [
+    { u_vendor_id: "V001", u_vendor_name: "Acme Corp", u_contact_email: "ops@acme.example" },
+  ],
+})
+
+await snow_execute_transform({
+  import_set_sys_id: importResult.import_set,
+  transform_map_sys_id: transformId,
 })
 ```
 

--- a/packages/opencode/src/bundled-skills/ui-actions-policies/SKILL.md
+++ b/packages/opencode/src/bundled-skills/ui-actions-policies/SKILL.md
@@ -10,8 +10,7 @@ metadata:
 tools:
   - snow_create_ui_action
   - snow_create_ui_policy
-  - snow_find_artifact
-  - snow_edit_artifact
+  - snow_artifact_manage
   - snow_analyze_form
 ---
 
@@ -360,12 +359,12 @@ action.insert()
 
 ### Available Tools
 
-| Tool                    | Purpose                   |
-| ----------------------- | ------------------------- |
-| `snow_create_ui_action` | Create UI Action          |
-| `snow_create_ui_policy` | Create UI Policy          |
-| `snow_find_artifact`    | Find existing UI elements |
-| `snow_edit_artifact`    | Modify UI elements        |
+| Tool                                  | Purpose                   |
+| ------------------------------------- | ------------------------- |
+| `snow_create_ui_action`               | Create UI Action          |
+| `snow_create_ui_policy`               | Create UI Policy          |
+| `snow_artifact_manage` (action=find)  | Find existing UI elements |
+| `snow_artifact_manage` (action=update) | Modify UI elements        |
 
 ### Example Workflow
 

--- a/packages/opencode/src/bundled-skills/ui-builder-patterns/SKILL.md
+++ b/packages/opencode/src/bundled-skills/ui-builder-patterns/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_workspace_create
+  - snow_create_workspace
   - snow_query_table
-  - snow_find_artifact
-  - snow_execute_script_with_output
+  - snow_artifact_manage
+  - snow_execute_script
 ---
 
 # UI Builder Patterns for ServiceNow
@@ -369,16 +369,15 @@ Macroponent: incident-summary-card
 
 ### Available UIB Tools
 
-| Tool                               | Purpose               |
-| ---------------------------------- | --------------------- |
-| `snow_create_uib_page`             | Create new page       |
-| `snow_create_uib_component`        | Add component to page |
-| `snow_create_uib_data_broker`      | Create data broker    |
-| `snow_create_uib_client_state`     | Define client state   |
-| `snow_create_uib_event`            | Configure events      |
-| `snow_create_complete_workspace`   | Full workspace        |
-| `snow_update_uib_page`             | Modify page           |
-| `snow_validate_uib_page_structure` | Validate structure    |
+| Tool                                       | Purpose               |
+| ------------------------------------------ | --------------------- |
+| `snow_uib_page_manage` (action='create')   | Create new page       |
+| `snow_uib_page_manage` (action='add_element') | Add component to page |
+| `snow_create_uib_data_broker`              | Create data broker    |
+| `snow_create_uib_client_state`             | Define client state   |
+| `snow_create_uib_event`                    | Configure events      |
+| `snow_create_complete_workspace`           | Full workspace        |
+| `snow_record_manage` (action='update')     | Modify page           |
 
 ### Example Workflow
 
@@ -399,7 +398,8 @@ await snow_create_uib_data_broker({
 })
 
 // 3. Add components
-await snow_create_uib_component({
+await snow_uib_page_manage({
+  action: "add_element",
   page_id: pageId,
   component: "now-record-list",
   properties: listConfig,
@@ -420,6 +420,6 @@ await snow_create_uib_event({
 3. **Events for Communication** - Decouple components via events
 4. **Macroponents for Reuse** - Create reusable building blocks
 5. **GraphQL for Queries** - More efficient than Script brokers
-6. **Validate Structure** - Use validation tools before deployment
+6. **Review Structure** - Manually verify page layout and bindings before deployment
 7. **Mobile Variants** - Create responsive variants
 8. **Accessibility** - Follow WCAG guidelines

--- a/packages/opencode/src/bundled-skills/update-set-workflow/SKILL.md
+++ b/packages/opencode/src/bundled-skills/update-set-workflow/SKILL.md
@@ -3,10 +3,10 @@ name: update-set-workflow
 description: Manage ServiceNow update sets — create named sets before any development, ensure auto_switch tracks API changes under the OAuth service account, complete on done, and export for promotion. Mandatory for all change-producing work.
 version: 1.0.0
 tools:
-  - snow_update_set_create
-  - snow_update_set_current
-  - snow_update_set_switch
-  - snow_update_set_complete
+  - snow_update_set_manage (action='create')
+  - snow_update_set_query (action='current')
+  - snow_update_set_manage (action='switch')
+  - snow_update_set_manage (action='complete')
   - snow_ensure_active_update_set
 ---
 
@@ -22,11 +22,12 @@ ALWAYS create or ensure an Update Set is active before making changes:
 
 ```javascript
 // Step 1: Check current Update Set
-var current = await snow_update_set_current()
+var current = await snow_update_set_query({ action: "current" })
 
 // Step 2: If no Update Set or using Default, create one
 if (!current || current.name === "Default") {
-  await snow_update_set_create({
+  await snow_update_set_manage({
+    action: "create",
     name: "Feature: [Descriptive Name]",
     description: "What and why this change is being made",
   })
@@ -36,7 +37,8 @@ if (!current || current.name === "Default") {
 // All changes will be tracked!
 
 // Step 4: When done, complete the Update Set
-await snow_update_set_complete({
+await snow_update_set_manage({
+  action: "complete",
   update_set_id: current.sys_id,
 })
 ```
@@ -83,26 +85,30 @@ Update Sets automatically capture changes to:
 
 ```javascript
 // Create new Update Set
-snow_update_set_create({
+snow_update_set_manage({
+  action: "create",
   name: "Feature: My Feature",
   description: "Description of changes",
 })
 
 // Switch to existing Update Set
-snow_update_set_switch({
+snow_update_set_manage({
+  action: "switch",
   update_set_id: "sys_id_here",
 })
 
 // Get current Update Set
-snow_update_set_current()
+snow_update_set_query({ action: "current" })
 
 // Complete Update Set
-snow_update_set_complete({
+snow_update_set_manage({
+  action: "complete",
   update_set_id: "sys_id_here",
 })
 
 // Export Update Set as XML
-snow_update_set_export({
+snow_update_set_manage({
+  action: "export",
   update_set_id: "sys_id_here",
 })
 ```

--- a/packages/opencode/src/bundled-skills/vendor-management/SKILL.md
+++ b/packages/opencode/src/bundled-skills/vendor-management/SKILL.md
@@ -9,8 +9,8 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
+  - snow_execute_script
+  - snow_artifact_manage
 ---
 
 # Vendor Management for ServiceNow
@@ -376,9 +376,9 @@ function getVendorScorecard(vendorSysId) {
 
 | Tool                              | Purpose             |
 | --------------------------------- | ------------------- |
-| `snow_query_table`                | Query vendor tables |
-| `snow_execute_script_with_output` | Test vendor scripts |
-| `snow_find_artifact`              | Find configurations |
+| `snow_query_table`     | Query vendor tables |
+| `snow_execute_script`  | Test vendor scripts |
+| `snow_artifact_manage` (action='find') | Find configurations |
 
 ### Example Workflow
 
@@ -391,7 +391,7 @@ await snow_query_table({
 })
 
 // 2. Find expiring contracts
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var expiring = getExpiringContracts(60);
         gs.info(JSON.stringify(expiring));
@@ -399,7 +399,7 @@ await snow_execute_script_with_output({
 })
 
 // 3. Get vendor scorecard
-await snow_execute_script_with_output({
+await snow_execute_script({
   script: `
         var scorecard = getVendorScorecard('vendor_sys_id');
         gs.info(JSON.stringify(scorecard));

--- a/packages/opencode/src/bundled-skills/virtual-agent/SKILL.md
+++ b/packages/opencode/src/bundled-skills/virtual-agent/SKILL.md
@@ -8,10 +8,10 @@ metadata:
   version: "1.0.0"
   category: servicenow
 tools:
-  - snow_va_topic_create
-  - snow_va_nlu_train
+  - snow_create_va_topic
+  - snow_train_va_nlu
   - snow_query_table
-  - snow_find_artifact
+  - snow_artifact_manage (action='find')
 ---
 
 # Virtual Agent for ServiceNow

--- a/packages/opencode/src/bundled-skills/widget-coherence/SKILL.md
+++ b/packages/opencode/src/bundled-skills/widget-coherence/SKILL.md
@@ -3,12 +3,11 @@ name: widget-coherence
 description: Build Service Portal widgets (sp_widget) with synchronized server/client/HTML — data.* initialization, ng-click + controller method matching, c.server.get action handlers, and Angular directive usage.
 version: 1.0.0
 tools:
-  - snow_deploy
-  - snow_update
-  - snow_preview_widget
+  - snow_artifact_manage (action='create')
+  - snow_artifact_manage (action='update')
+  - snow_validate_widget_coherence
   - snow_widget_test
-  - snow_find_artifact
-  - snow_edit_artifact
+  - snow_artifact_manage (action='find')
 ---
 
 # Widget Coherence for ServiceNow Service Portal

--- a/packages/opencode/src/bundled-skills/workspace-builder/SKILL.md
+++ b/packages/opencode/src/bundled-skills/workspace-builder/SKILL.md
@@ -9,9 +9,9 @@ metadata:
   category: servicenow
 tools:
   - snow_query_table
-  - snow_execute_script_with_output
-  - snow_find_artifact
-  - snow_update_set_create
+  - snow_execute_script
+  - snow_artifact_manage
+  - snow_update_set_manage
 ---
 
 # App Engine Studio & Workspace Builder for ServiceNow
@@ -374,12 +374,12 @@ function prepareAppExport(appScope) {
 
 ### Available Tools
 
-| Tool                              | Purpose              |
-| --------------------------------- | -------------------- |
-| `snow_query_table`                | Query app components |
-| `snow_execute_script_with_output` | Test app scripts     |
-| `snow_find_artifact`              | Find configurations  |
-| `snow_update_set_create`          | Create update sets   |
+| Tool                                  | Purpose              |
+| ------------------------------------- | -------------------- |
+| `snow_query_table`                    | Query app components |
+| `snow_execute_script`                 | Test app scripts     |
+| `snow_artifact_manage` (action='find') | Find configurations  |
+| `snow_update_set_manage` (action='create') | Create update sets   |
 
 ### Example Workflow
 


### PR DESCRIPTION
The bundled skills referenced 51 pre-consolidation tool names that no longer exist, so the chat agent would call nonexistent tools — surfacing in the portal as an opaque `Customer not found` 401 from the legacy MCP server.

Across 52 SKILL.md files, each stale name is mapped to its current equivalent: plain renames where the tool was just renamed, and the consolidated `*_manage`/`pa_*` tools with the correct `action` argument (each action verified against the tool's action enum in source). Code examples were rewritten to pass the right action and args; frontmatter tool lists and reference tables updated to match. Real local-only `snow_fluent_*` tools and wildcard pattern text left untouched.

Verified: `grep` of every `snow_*` token across the skills now resolves to a name in `tools.json` (only the 8 real `snow_fluent_*` tools and `snow_*` wildcard prose remain). `bundled-snapshot.ts` is a build artifact regenerated from these files, so this is a source-only change.

Companion to platform PR serac-labs/serac-platform#153, which makes the portal return a clear unknown-tool error instead of `Customer not found` for any future stale name.

Fixes #250