### PR TITLE
feat(mcp): its own npm release, and honest state under a stateless transport

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -93,14 +93,18 @@ jobs:
           # reads. Action inputs are not affected by defaults.run.
           bun-version-file: package.json
 
-      # `npm@latest` is npm 12, which requires node >= 22 and hard-fails
-      # EBADENGINE on this runner's node 20. Pin to the 11.x line: it is the
-      # newest npm that runs here and it already satisfies the >= 11.5.1 that
-      # OIDC trusted publishing needs. Bumping node instead would change the
-      # engine the package is built and tested against, which is a bigger
-      # decision than a publish prerequisite should be making.
+      # node 24 matches test.yml, so the package publishes on the same engine it
+      # is tested on. The three publish workflows were the only place still on
+      # 20. This does NOT change the artifact: tsc emits according to `target`
+      # in tsconfig.build.json (ESNext), not according to whichever node runs
+      # the compiler.
+      #
+      # npm pinned to a major rather than `@latest`: npm 12 requires node >= 22,
+      # so `@latest` silently broke this job the moment npm 12 shipped. A major
+      # pin still satisfies the >= 11.5.1 that OIDC trusted publishing needs and
+      # will not jump an engine requirement underneath us.
       - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@^12
 
       - name: Configure npm for OIDC publishing
         # The empty _authToken line is required for npm to recognise OIDC mode;

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,465 @@
+name: Publish servicenow-mcp
+
+# Standalone release for @serac-labs/servicenow-mcp.
+#
+# Until now this package was published by a STEP inside publish-npm.yml's
+# opencode job: it took its version from packages/opencode/package.json, its
+# increment from "npm view @serac-labs/core", and its toolchain from a
+# monorepo-root install. It also carried "continue-on-error: true", so every
+# release went green while publishing nothing — npm still has only 0.1.0 from
+# 2026-06-08. As opencode is removed, that step loses its version source and
+# its publish path in the same commit, so the release moves here and depends
+# on nothing outside packages/servicenow-mcp.
+#
+# IMPORTANT: npm binds a Trusted Publisher to owner + repo + WORKFLOW FILENAME.
+# This file must stay named "publish-mcp.yml", and a trusted publisher for
+# @serac-labs/servicenow-mcp pointing at serac-labs/serac + publish-mcp.yml
+# (environment blank) must exist on npmjs.com before the first real publish.
+# The one for @serac-labs/core is bound to publish-npm.yml and is unaffected.
+#
+# TRIGGER: workflow_dispatch, deliberately, not a tag or a branch push.
+#   - The version is read from packages/servicenow-mcp/package.json and
+#     nowhere else. A tag would be a second version source that can disagree
+#     with the manifest — the same class of coupling that made this package
+#     inherit opencode's version number.
+#   - Publishing is not idempotent: npm 403s on a republish. An automatic
+#     trigger therefore makes most runs guaranteed failures, and the pressure
+#     to silence those failures is exactly how continue-on-error got added.
+#   - GitHub records who dispatched a run, so releases stay attributable.
+#   - The npm trusted publisher binds to the workflow file, not to the event,
+#     so dispatch is fully compatible with OIDC provenance.
+# pull_request runs the SAME build/test/gate steps and stops short of
+# publishing, so the release path is exercised on every PR that touches the
+# package instead of being discovered broken at release time.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "npm dist-tag. Stage on next, promote to latest once verified."
+        type: choice
+        options:
+          - next
+          - latest
+        default: next
+      dry_run:
+        description: "Build, test and gate, but stop before npm publish"
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - "packages/servicenow-mcp/**"
+      - ".github/workflows/publish-mcp.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A publish is not idempotent, so an in-flight release must never be
+  # cancelled out from under itself by a newer run. PR verification is
+  # disposable and does cancel. (publish-npm.yml shares one
+  # cancel-in-progress: true across everything, which can kill a live publish.)
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    # Every shell step runs inside the package. Nothing here reads
+    # packages/opencode, the repo-root node_modules, or the root install.
+    working-directory: packages/servicenow-mcp
+
+jobs:
+  publish:
+    name: build, gate and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing + signed provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          # Repo-root package.json — its packageManager field is the single bun
+          # pin for the monorepo, the same source .github/actions/setup-bun
+          # reads. Action inputs are not affected by defaults.run.
+          bun-version-file: package.json
+
+      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Configure npm for OIDC publishing
+        # The empty _authToken line is required for npm to recognise OIDC mode;
+        # without it the CLI falls back to anonymous and 401s.
+        run: |
+          rm -f ~/.npmrc .npmrc
+          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=" >> ~/.npmrc
+          echo "npm $(npm --version) configured for OIDC"
+
+      - name: Read version from packages/servicenow-mcp/package.json
+        id: version
+        # The ONLY version source. No tag name, no packages/opencode, no
+        # registry-derived increment: what the manifest says is what publishes,
+        # so "git show <sha>:packages/servicenow-mcp/package.json" always
+        # explains a published version.
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          test -n "$VERSION" || { echo "::error::package.json has no version"; exit 1; }
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "$NAME@$VERSION (from packages/servicenow-mcp/package.json)"
+
+      - name: Pre-flight — version is publishable
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag || 'next' }}
+        # Fail here, before a full build, rather than on npm's 403 at the very
+        # end. "npm view pkg@missing-version" exits non-zero with E404, so
+        # empty stdout is the "not published yet" signal.
+        run: |
+          set -euo pipefail
+          PUBLISHED=$(npm view "$NAME@$VERSION" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "::error::$NAME@$VERSION is already on npm. Bump the version in packages/servicenow-mcp/package.json."
+            exit 1
+          fi
+          case "$VERSION" in
+            *-*)
+              if [ "$DIST_TAG" = "latest" ]; then
+                echo "::error::$VERSION is a prerelease; publishing it as latest would hand it to every plain npm install. Use dist_tag=latest only for a stable version."
+                exit 1
+              fi
+              ;;
+          esac
+
+          CURRENT=$(npm view "$NAME" version 2>/dev/null || true)
+          echo "current registry latest: ${CURRENT:-none}"
+
+          # Monotonicity. "Not yet published" is not the same as "newer": a
+          # hotfix branch can hold an unpublished 0.1.1 long after 0.2.0 went
+          # out, and dispatching that with dist_tag=latest walks the tag
+          # BACKWARDS — every plain `npm install` silently downgrades. The
+          # check applies to `latest` only; staging an older line on `next` is
+          # legitimate.
+          if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ]; then
+            NEWEST=$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -1)
+            if [ "$NEWEST" != "$VERSION" ]; then
+              echo "::error::$VERSION is older than the registry's current latest ($CURRENT). Publishing it as latest would downgrade every consumer. Use dist_tag=next."
+              exit 1
+            fi
+          fi
+          echo "$NAME@$VERSION is unpublished; will go out under dist-tag '$DIST_TAG'"
+
+      - name: Install dependencies
+        # This resolves through the WORKSPACE, not just this directory: `bun
+        # install` inside a workspace member walks up to the repo-root
+        # package.json, installs all ~2400 packages and writes the root
+        # bun.lock. An earlier version of this step claimed the opposite ("it
+        # installs standalone"), which was wrong in a way that mattered — it
+        # also meant `-f bun.lock` (cwd = this package) was always false, so
+        # --frozen-lockfile never engaged and every release resolved fresh.
+        #
+        # --ignore-scripts is what actually decouples the release from
+        # opencode: without it the root `postinstall` (bun run --cwd
+        # packages/core fix-node-pty) and `prepare` (husky) run here, and a
+        # broken or deleted packages/core takes the MCP release down with it.
+        # Nothing in this package's dependency tree declares an install script.
+        #
+        # Standalone-ness is not asserted by comment — the gate below proves it
+        # by building and testing the package with no repo root in sight.
+        run: bun install --frozen-lockfile --ignore-scripts
+        working-directory: .
+
+      - name: Run tests
+        run: bun run test:ci
+
+      - name: Gate — the package builds and tests with no monorepo around it
+        # The whole point of moving the release out of publish-npm.yml is that
+        # this package must survive `rm -rf packages/opencode`. Copy it out of
+        # the workspace and do a real install/build/test there: no repo-root
+        # package.json, no root node_modules, no hoisting, no workspace: links.
+        # A missing devDependency or an accidental cross-package import fails
+        # here, on every PR, instead of the first release after the deletion.
+        run: |
+          set -euo pipefail
+          STANDALONE="$RUNNER_TEMP/standalone"
+          rm -rf "$STANDALONE"
+          mkdir -p "$STANDALONE"
+          tar -cf - --exclude=node_modules --exclude=dist . | tar -xf - -C "$STANDALONE"
+          cd "$STANDALONE"
+          test ! -e ../package.json || { echo "::error::standalone dir has a parent manifest; the test is meaningless"; exit 1; }
+          bun install --frozen-lockfile
+          bun run typecheck
+          bun run build
+          bun test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: servicenow-mcp-unit-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/servicenow-mcp/.artifacts/unit/junit.xml
+
+      - name: Build and rewrite exports to dist/
+        # Compiles to dist/ and repoints package.json exports/bin from
+        # ./src/*.ts to ./dist/*.js. Bun's $ throws on a non-zero tsc, which
+        # aborts before anything is rewritten or published.
+        run: bun run script/build-for-publish.ts
+
+      - name: Gate — tarball contains every published entrypoint
+        env:
+          # Passed as an env value rather than a heredoc: a quoted heredoc
+          # terminator has to sit at column 0, which is not expressible inside
+          # a YAML block scalar, and this way nothing in the script is exposed
+          # to shell expansion.
+          GATE_JS: |
+            // Every entrypoint package.json advertises must really be inside
+            // the tarball npm is about to publish. Reads what npm pack wrote.
+            //
+            // Checking the TARBALL rather than the working directory is
+            // deliberate: it is the only check that also catches a "files"
+            // field that forgot to ship dist/. And tsc writes dist/ even when
+            // it exits non-zero, so "dist/index.js exists" is not evidence of
+            // a good build.
+            //
+            // For the record, since the old guard's weakness is the reason
+            // this exists: 0.1.0 on npm is NOT a src-pointing tarball. It has
+            // a proper dist/ with fully rewritten exports. What went wrong for
+            // two months was upstream of that — the publish step carried
+            // continue-on-error, so runs went green having published nothing
+            // at all, and 0.1.0 simply stayed the newest thing on the
+            // registry. This gate covers the failure the old one could not
+            // see; it is not evidence that the old one ever shipped one.
+            import { readFileSync } from "node:fs"
+
+            const pkg = JSON.parse(readFileSync("package.json", "utf8"))
+            const packed = JSON.parse(readFileSync(process.argv[2], "utf8"))[0]
+            const files = new Set(packed.files.map((f) => f.path))
+
+            const targets = [
+              ...Object.entries(pkg.exports ?? {}).flatMap(([key, value]) =>
+                typeof value === "string"
+                  ? [[`exports["${key}"]`, value]]
+                  : Object.entries(value).map(([condition, file]) => [`exports["${key}"].${condition}`, file]),
+              ),
+              ...Object.entries(pkg.bin ?? {}).map(([key, value]) => [`bin["${key}"]`, value]),
+              ["files", "dist/index.js"],
+            ]
+
+            const inTarball = (file) => {
+              const path = file.replace(/^\.\//, "")
+              const star = path.indexOf("*")
+              if (star === -1) return files.has(path)
+              return [...files].some((f) => f.startsWith(path.slice(0, star)))
+            }
+
+            // The agent-fragment .txt assets ship verbatim from src/ and are
+            // the one deliberate exception. Anything else still pointing into
+            // src/*.ts means the export rewrite never ran.
+            const unbuilt = targets.filter(([, file]) => file.startsWith("./src/") && file.endsWith(".ts"))
+            const missing = targets.filter(([, file]) => !inTarball(file))
+
+            for (const [name, file] of targets) console.log(`${inTarball(file) ? "ok  " : "MISS"}  ${name} -> ${file}`)
+            console.log(`\n${packed.name}@${packed.version}: ${packed.entryCount} files, ${(packed.size / 1024).toFixed(1)} kB packed`)
+
+            if (unbuilt.length > 0) {
+              console.error(`\n::error::package.json still points at TypeScript source — the export rewrite did not run`)
+              for (const [name, file] of unbuilt) console.error(`  ${name} -> ${file}`)
+            }
+            if (missing.length > 0) {
+              console.error(`\n::error::${missing.length} published entrypoint(s) are not in the tarball`)
+              for (const [name, file] of missing) console.error(`  ${name} -> ${file}`)
+            }
+            if (unbuilt.length + missing.length > 0) process.exit(1)
+            console.log(`gate: all ${targets.length} published entrypoints are present in the tarball`)
+        run: |
+          set -euo pipefail
+          printf '%s' "$GATE_JS" > "$RUNNER_TEMP/gate.mjs"
+          npm pack --pack-destination "$RUNNER_TEMP" --json > "$RUNNER_TEMP/pack.json"
+          node "$RUNNER_TEMP/gate.mjs" "$RUNNER_TEMP/pack.json"
+
+      - name: Gate — every published subpath and bin loads under node
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          SMOKE_JS: |
+            // Every published subpath AND every bin must load under node.
+            // Bun's CJS interop is more forgiving than Node's, so a package
+            // that runs fine under bun — and in the GHCR mcp-http image, whose
+            // CMD is bun — can still be dead on arrival for `npm install`
+            // users. That was literally true here: a named import of
+            // node-machine-id (a webpack-bundled CJS file whose named exports
+            // cjs-module-lexer cannot see) took out 5 of 13 subpaths and both
+            // bins under node while every bun-based check stayed green.
+            //
+            // The bins are checked separately because NOTHING in exports
+            // reaches them: `servicenow-mcp-stdio` is not imported by any
+            // published subpath, so a subpath-only sweep declares the package
+            // healthy while its headline binary cannot start.
+            //
+            // A bin cannot be checked by importing it — both bins start an MCP
+            // server at module scope, so the import never resolves. They are
+            // spawned instead and driven with a real JSON-RPC `initialize`,
+            // which is a stronger check anyway: it proves the binary boots,
+            // speaks MCP, and — because stdout IS the protocol channel on
+            // stdio — that nothing prints noise onto it. (dotenv v17's startup
+            // banner went to stdout and corrupted the stream for strict
+            // clients; that is why the JSON-purity assert is here.)
+            import { spawn, spawnSync } from "node:child_process"
+            import { readFileSync } from "node:fs"
+            import { resolve } from "node:path"
+
+            const name = process.argv[2]
+            // Read the INSTALLED manifest — package.json is not itself an
+            // export, so it cannot be resolved through the exports map.
+            const root = `node_modules/${name}`
+            const pkg = JSON.parse(readFileSync(`${root}/package.json`, "utf8"))
+
+            const subpaths = Object.keys(pkg.exports)
+              .filter((key) => !key.includes("*"))
+              .map((key) => (key === "." ? name : `${name}/${key.slice(2)}`))
+
+            const importResults = subpaths.map((subpath) => {
+              const child = spawnSync(process.execPath, ["--input-type=module", "-e", `await import(${JSON.stringify(subpath)})`], {
+                encoding: "utf8",
+                timeout: 60000,
+              })
+              return { label: subpath, ok: child.status === 0, err: (child.stderr ?? "").trim() }
+            })
+
+            const handshake = JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "initialize",
+              params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "0" } },
+            })
+
+            const driveBin = (binName, file) =>
+              new Promise((done) => {
+                const child = spawn(process.execPath, [resolve(root, file)], { stdio: ["pipe", "pipe", "pipe"] })
+                let out = ""
+                let err = ""
+                const finish = (ok, detail) => {
+                  clearTimeout(timer)
+                  clearInterval(poll)
+                  child.kill("SIGKILL")
+                  done({ label: `bin:${binName}`, ok, err: detail })
+                }
+                child.stdout.on("data", (d) => (out += d))
+                child.stderr.on("data", (d) => (err += d))
+                child.on("error", (e) => finish(false, e.message))
+                child.on("exit", (code) => finish(false, `exited with ${code} before responding\n${err.trim()}`))
+                const timer = setTimeout(() => finish(false, `no initialize response in 30s\n${err.trim()}`), 30000)
+                const poll = setInterval(() => {
+                  const lines = out.split("\n").filter((l) => l.trim().length > 0)
+                  // Every line on stdout must be JSON: on stdio, stdout is the
+                  // protocol. A banner or a stray console.log breaks clients.
+                  const noise = lines.find((l) => { try { JSON.parse(l); return false } catch { return true } })
+                  if (noise) return finish(false, `non-JSON written to stdout (stdio's protocol channel): ${noise.slice(0, 120)}`)
+                  if (lines.some((l) => JSON.parse(l).id === 1)) finish(true, "")
+                }, 100)
+                child.stdin.write(handshake + "\n")
+              })
+
+            const binResults = []
+            for (const [binName, file] of Object.entries(pkg.bin ?? {})) binResults.push(await driveBin(binName, file))
+
+            const results = [...importResults, ...binResults]
+            for (const { label, ok } of results) console.log(`${ok ? "ok  " : "FAIL"}  ${label}`)
+
+            const failed = results.filter((r) => !r.ok)
+            if (failed.length > 0) {
+              console.error(`\n::error::${failed.length} of ${results.length} published entrypoints are broken under node ${process.version}`)
+              for (const { label, err } of failed) console.error(`  ${label}\n      ${err.split("\n").slice(0, 2).join("\n      ")}`)
+              process.exit(1)
+            }
+            console.log(`\nsmoke: ${subpaths.length} subpaths import and ${binResults.length} bins complete an MCP handshake under node ${process.version}`)
+        run: |
+          set -euo pipefail
+          printf '%s' "$SMOKE_JS" > "$RUNNER_TEMP/smoke.mjs"
+          TARBALL=$(ls "$RUNNER_TEMP"/*.tgz)
+          CONSUMER="$RUNNER_TEMP/consumer"
+          mkdir -p "$CONSUMER"
+          cd "$CONSUMER"
+          node -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "mcp-smoke", private: true, type: "module" }))'
+          npm install --no-audit --no-fund "$TARBALL"
+          node "$RUNNER_TEMP/smoke.mjs" "$NAME"
+
+      - name: Publish to npm (OIDC, signed provenance)
+        # No continue-on-error. A publish that cannot happen must turn the run
+        # red; continue-on-error on the old step is what let two months of
+        # releases report success while npm stayed on 0.1.0.
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' && github.repository == 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          echo "Publishing $NAME@$VERSION with tag: $DIST_TAG"
+
+          # Sigstore's transparency log occasionally 409s with
+          # TLOG_CREATE_ENTRY_ERROR when npm's internal retry races its own
+          # first, successfully landed tlog write (seen on the core publish of
+          # 1.1.6). A fresh publish signs with a new ephemeral cert and goes
+          # through, so retry the whole publish on that transient only.
+          for attempt in 1 2 3; do
+            if out=$(npm publish --access public --provenance --tag "$DIST_TAG" 2>&1); then
+              echo "$out"
+              exit 0
+            fi
+            echo "$out"
+            if echo "$out" | grep -qiE "TLOG_CREATE_ENTRY_ERROR|transparency log"; then
+              echo "transient sigstore tlog conflict (attempt $attempt) — retrying in 20s"
+              sleep 20
+              continue
+            fi
+            exit 1
+          done
+          echo "::error::npm publish failed after 3 tlog retries"
+          exit 1
+
+      - name: Verify the published version carries provenance
+        # A publish can succeed with a classic token and no attestation — that
+        # is how 0.1.0 got there. Assert the trusted publisher actually signed
+        # this one, so a mis-wired binding is loud instead of invisible.
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' && github.repository == 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            ATTESTATIONS=$(npm view "$NAME@$VERSION" dist.attestations --json 2>/dev/null || true)
+            if [ -n "$ATTESTATIONS" ]; then
+              echo "$ATTESTATIONS"
+              echo "$NAME@$VERSION published under dist-tag '$DIST_TAG' with signed provenance"
+              exit 0
+            fi
+            echo "no attestation visible yet (attempt $attempt) — waiting 10s"
+            sleep 10
+          done
+          echo "::error::$NAME@$VERSION published WITHOUT provenance. The npm Trusted Publisher for $NAME is probably not bound to serac-labs/serac + .github/workflows/publish-mcp.yml."
+          exit 1
+
+      - name: Summary (nothing published)
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run == 'true' || github.repository != 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: echo "$NAME@$VERSION built, tested and gated. Not published (pull request, dry run, or fork)."

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -93,8 +93,14 @@ jobs:
           # reads. Action inputs are not affected by defaults.run.
           bun-version-file: package.json
 
+      # `npm@latest` is npm 12, which requires node >= 22 and hard-fails
+      # EBADENGINE on this runner's node 20. Pin to the 11.x line: it is the
+      # newest npm that runs here and it already satisfies the >= 11.5.1 that
+      # OIDC trusted publishing needs. Bumping node instead would change the
+      # engine the package is built and tested against, which is a bigger
+      # decision than a publish prerequisite should be making.
       - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Configure npm for OIDC publishing
         # The empty _authToken line is required for npm to recognise OIDC mode;

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -258,7 +258,19 @@ jobs:
             import { readFileSync } from "node:fs"
 
             const pkg = JSON.parse(readFileSync("package.json", "utf8"))
-            const packed = JSON.parse(readFileSync(process.argv[2], "utf8"))[0]
+
+            // `npm pack --json` changed shape between majors: npm 11 emits an
+            // array of results, npm 12 emits the object directly. Reading
+            // [0].files crashed on npm 12 with "Cannot read properties of
+            // undefined". Accept both rather than pinning the gate to one npm,
+            // since this gate exists precisely to survive the tooling moving.
+            const raw = JSON.parse(readFileSync(process.argv[2], "utf8"))
+            const packed = Array.isArray(raw) ? raw[0] : raw
+            if (!packed?.files) {
+              console.error("::error::could not read the file list from `npm pack --json`")
+              console.error(`top-level keys: ${Object.keys(packed ?? {}).join(", ") || "(none)"}`)
+              process.exit(1)
+            }
             const files = new Set(packed.files.map((f) => f.path))
 
             const targets = [

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -259,13 +259,16 @@ jobs:
 
             const pkg = JSON.parse(readFileSync("package.json", "utf8"))
 
-            // `npm pack --json` changed shape between majors: npm 11 emits an
-            // array of results, npm 12 emits the object directly. Reading
-            // [0].files crashed on npm 12 with "Cannot read properties of
-            // undefined". Accept both rather than pinning the gate to one npm,
-            // since this gate exists precisely to survive the tooling moving.
+            // `npm pack --json` has had three shapes across majors: npm 11 emits
+            // an array of results, and npm 12 emits an object KEYED BY PACKAGE
+            // NAME ({"@serac-labs/servicenow-mcp": {files: [...]}}). A bare
+            // result object is the third possibility. Rather than track npm's
+            // releases, take the first candidate that actually carries a files
+            // array — this gate has to outlive the tooling under it, and it is
+            // the only thing standing between a broken build and the registry.
             const raw = JSON.parse(readFileSync(process.argv[2], "utf8"))
-            const packed = Array.isArray(raw) ? raw[0] : raw
+            const candidates = Array.isArray(raw) ? raw : [raw, ...Object.values(raw)]
+            const packed = candidates.find((c) => c && Array.isArray(c.files))
             if (!packed?.files) {
               console.error("::error::could not read the file list from `npm pack --json`")
               console.error(`top-level keys: ${Object.keys(packed ?? {}).join(", ") || "(none)"}`)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -445,33 +445,15 @@ jobs:
           echo "npm publish failed after 3 tlog retries" >&2
           exit 1
 
-      - name: Publish @serac-labs/servicenow-mcp to npm (OIDC)
-        # Separate npm package (ServiceNow MCP server). Unlike core (which
-        # ships .ts source), this ships a built dist/, so build + rewrite
-        # exports/bin from ./src/*.ts to ./dist/*.js first. Publishes via the
-        # same OIDC trusted-publisher path as core (the .npmrc above already
-        # put npm in OIDC mode). REQUIRES its OWN Trusted Publisher to be
-        # configured on npm for @serac-labs/servicenow-mcp pointing at this
-        # repo + workflow. Already independently published at 0.1.0.
-        #
-        # continue-on-error keeps a not-yet-configured trusted publisher (401)
-        # from failing the whole release (and the core publish above). REMOVE
-        # it in a follow-up once the trusted publisher is live and the first
-        # OIDC publish is confirmed green.
-        continue-on-error: true
-        run: |
-          cd packages/servicenow-mcp
-          VERSION="${{ steps.version.outputs.version }}"
-          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
-          bun run script/build-for-publish.ts
-          test -f dist/index.js || { echo "build produced no dist/index.js — aborting publish"; exit 1; }
-          NPM_TAG="${{ steps.channel.outputs.npm_tag }}"
-          echo "Publishing @serac-labs/servicenow-mcp@$VERSION with tag: $NPM_TAG (OIDC, signed provenance)"
-          if [ "$NPM_TAG" = "latest" ]; then
-            npm publish --access public --provenance
-          else
-            npm publish --access public --tag "$NPM_TAG" --provenance
-          fi
+      # NOTE: @serac-labs/servicenow-mcp is NOT published here. It used to be
+      # the last step of this job, which gave it opencode's version number, a
+      # root install for its toolchain, and this job's whole cross-compile
+      # chain as a prerequisite — under a continue-on-error that reported
+      # success for two months while npm stayed on 0.1.0. It now has its own
+      # workflow, .github/workflows/publish-mcp.yml, which reads its version
+      # from packages/servicenow-mcp/package.json and shares nothing with this
+      # file. Do not add it back: two publish paths for one package is how the
+      # version confusion started.
 
       # NOTE: there is deliberately NO "push a version bump back to main"
       # step here anymore. The main ruleset's required status checks reject

--- a/bun.lock
+++ b/bun.lock
@@ -688,7 +688,7 @@
     },
     "packages/servicenow-mcp": {
       "name": "@serac-labs/servicenow-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "servicenow-mcp-stdio": "./src/servicenow-mcp-unified/index.ts",
         "servicenow-mcp-enterprise-proxy": "./src/enterprise-proxy/index.ts",
@@ -703,7 +703,7 @@
         "zod": "4.1.8",
       },
       "devDependencies": {
-        "@jest/globals": "^29",
+        "@jest/globals": "29.7.0",
         "@types/bun": "1.3.13",
         "@typescript/native-preview": "7.0.0-dev.20251207.1",
         "typescript": "5.8.2",

--- a/packages/servicenow-mcp/LICENSE
+++ b/packages/servicenow-mcp/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Serac Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -1,0 +1,94 @@
+# @serac-labs/servicenow-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for ServiceNow: ~426 `snow_*` tools over
+stdio or streamable HTTP, plus blast-radius impact analysis. Part of [Serac](https://serac.build).
+
+```bash
+npm install -g @serac-labs/servicenow-mcp
+```
+
+## Use it as an MCP server
+
+Point any MCP client at the `servicenow-mcp-stdio` binary:
+
+```json
+{
+  "mcpServers": {
+    "servicenow": {
+      "command": "servicenow-mcp-stdio",
+      "env": {
+        "SNOW_INSTANCE_URL": "https://dev12345.service-now.com",
+        "SNOW_CLIENT_ID": "…",
+        "SNOW_CLIENT_SECRET": "…"
+      }
+    }
+  }
+}
+```
+
+The catalog is large enough to blow a context window, so tools are **deferred** by default: `tools/list`
+returns two meta-tools, and the model widens its own surface as it goes.
+
+```
+tool_search({query: "incident"})     → the matching tools, marked [ENABLED]
+tool_execute({tool: "snow_query_incidents", args: {query: "priority=1"}})
+```
+
+Set `SNOW_LAZY_TOOLS=false` to register the whole catalog up front instead.
+
+## Use it as a library
+
+ESM only. The package exports named subpaths rather than one barrel, so importing blast-radius does not
+pull in the transports:
+
+```ts
+import { snow_blast_radius_dependents_exec } from "@serac-labs/servicenow-mcp/blast-radius"
+
+const result = await snow_blast_radius_dependents_exec(
+  { artifact_type: "script_include", artifact_identifier: "AcmeUtils" },
+  { instanceUrl, clientId, clientSecret, accessToken, tenantId: "customer-1042", origin: "http" },
+)
+```
+
+Each tool is exported as a `*_def` / `*_exec` pair: the MCP tool definition and the executor.
+
+| Subpath            | What it is                                                     |
+| ------------------ | -------------------------------------------------------------- |
+| `.`                | Everything — the barrel                                        |
+| `/server`          | `createServer()`, to embed the MCP server in your own process   |
+| `/stdio`           | The stdio transport                                            |
+| `/http`            | The streamable-HTTP transport, as a Hono app                    |
+| `/blast-radius`    | Impact-analysis tools, usable without the MCP layer             |
+| `/types`           | `ServiceNowContext`, `MCPToolDefinition`, …                     |
+| `/auth`            | OAuth + basic auth, token cache, authenticated Axios client     |
+| `/error-handler`   | Result envelopes and error classification                       |
+| `/enterprise-proxy`| Client for the licensed enterprise tool catalog                 |
+
+## A note on tenancy
+
+`ServiceNowContext` carries a `tenantId` and an `origin`, and they are not decoration.
+
+- **stdio** is single-tenant: one process, one user, one credential set. In-process caches are shared
+  across requests and that is correct.
+- **HTTP** is multi-tenant: one process serves every customer, so every cache and every piece of session
+  state is keyed by tenant. A request that cannot be placed in a tenant is refused rather than pooled into
+  a shared bucket — see `src/servicenow-mcp-unified/shared/tenant-scope.ts`.
+
+If you embed a tool executor directly (rather than going through a transport), pass a `tenantId` whenever
+your process serves more than one customer. Without one, tenant-keyed caches fall back to fingerprinting
+the credentials, which is safe but colder.
+
+None of this state is shared between processes, so an HTTP deployment should run **single-replica** or
+supply its own shared store.
+
+## Requirements
+
+Node 20+ or Bun 1.2+. ESM only — there is no CommonJS `require` entrypoint.
+
+## Links
+
+- [Serac](https://serac.build) — the CLI and agent this catalog was built for
+- [Issues](https://github.com/serac-labs/serac/issues)
+- [Source](https://github.com/serac-labs/serac/tree/main/packages/servicenow-mcp)
+
+Apache-2.0

--- a/packages/servicenow-mcp/bun.lock
+++ b/packages/servicenow-mcp/bun.lock
@@ -1,0 +1,583 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@serac-labs/servicenow-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "axios": "1.13.5",
+        "dotenv": "17.2.3",
+        "form-data": "4.0.5",
+        "hono": "4.12.12",
+        "node-machine-id": "1.1.12",
+        "zod": "4.1.8",
+      },
+      "devDependencies": {
+        "@jest/globals": "29.7.0",
+        "@types/bun": "1.3.13",
+        "@typescript/native-preview": "7.0.0-dev.20251207.1",
+        "typescript": "5.8.2",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
+
+    "@babel/plugin-syntax-bigint": ["@babel/plugin-syntax-bigint@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg=="],
+
+    "@babel/plugin-syntax-class-properties": ["@babel/plugin-syntax-class-properties@7.12.13", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.12.13" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA=="],
+
+    "@babel/plugin-syntax-class-static-block": ["@babel/plugin-syntax-class-static-block@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw=="],
+
+    "@babel/plugin-syntax-import-attributes": ["@babel/plugin-syntax-import-attributes@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg=="],
+
+    "@babel/plugin-syntax-import-meta": ["@babel/plugin-syntax-import-meta@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g=="],
+
+    "@babel/plugin-syntax-json-strings": ["@babel/plugin-syntax-json-strings@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
+    "@babel/plugin-syntax-logical-assignment-operators": ["@babel/plugin-syntax-logical-assignment-operators@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig=="],
+
+    "@babel/plugin-syntax-nullish-coalescing-operator": ["@babel/plugin-syntax-nullish-coalescing-operator@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ=="],
+
+    "@babel/plugin-syntax-numeric-separator": ["@babel/plugin-syntax-numeric-separator@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug=="],
+
+    "@babel/plugin-syntax-object-rest-spread": ["@babel/plugin-syntax-object-rest-spread@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA=="],
+
+    "@babel/plugin-syntax-optional-catch-binding": ["@babel/plugin-syntax-optional-catch-binding@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q=="],
+
+    "@babel/plugin-syntax-optional-chaining": ["@babel/plugin-syntax-optional-chaining@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg=="],
+
+    "@babel/plugin-syntax-private-property-in-object": ["@babel/plugin-syntax-private-property-in-object@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg=="],
+
+    "@babel/plugin-syntax-top-level-await": ["@babel/plugin-syntax-top-level-await@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
+
+    "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
+    "@jest/environment": ["@jest/environment@29.7.0", "", { "dependencies": { "@jest/fake-timers": "^29.7.0", "@jest/types": "^29.6.3", "@types/node": "*", "jest-mock": "^29.7.0" } }, "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw=="],
+
+    "@jest/expect": ["@jest/expect@29.7.0", "", { "dependencies": { "expect": "^29.7.0", "jest-snapshot": "^29.7.0" } }, "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ=="],
+
+    "@jest/expect-utils": ["@jest/expect-utils@29.7.0", "", { "dependencies": { "jest-get-type": "^29.6.3" } }, "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA=="],
+
+    "@jest/fake-timers": ["@jest/fake-timers@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@sinonjs/fake-timers": "^10.0.2", "@types/node": "*", "jest-message-util": "^29.7.0", "jest-mock": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ=="],
+
+    "@jest/globals": ["@jest/globals@29.7.0", "", { "dependencies": { "@jest/environment": "^29.7.0", "@jest/expect": "^29.7.0", "@jest/types": "^29.6.3", "jest-mock": "^29.7.0" } }, "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ=="],
+
+    "@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
+
+    "@jest/transform": ["@jest/transform@29.7.0", "", { "dependencies": { "@babel/core": "^7.11.6", "@jest/types": "^29.6.3", "@jridgewell/trace-mapping": "^0.3.18", "babel-plugin-istanbul": "^6.1.1", "chalk": "^4.0.0", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.9", "jest-haste-map": "^29.7.0", "jest-regex-util": "^29.6.3", "jest-util": "^29.7.0", "micromatch": "^4.0.4", "pirates": "^4.0.4", "slash": "^3.0.0", "write-file-atomic": "^4.0.2" } }, "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw=="],
+
+    "@jest/types": ["@jest/types@29.6.3", "", { "dependencies": { "@jest/schemas": "^29.6.3", "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^17.0.8", "chalk": "^4.0.0" } }, "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
+
+    "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
+
+    "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
+
+    "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
+
+    "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
+
+    "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
+
+    "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
+
+    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20251207.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251207.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251207.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20251207.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251207.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20251207.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251207.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20251207.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-4QcRnzB0pi9rS0AOvg8kWbmuwHv5X7B2EXHbgcms9+56hsZ8SZrZjNgBJb2rUIodJ4kU5mrkj/xlTTT4r9VcpQ=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20251207.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-waWJnuuvkXh4WdpbTjYf7pyahJzx0ycesV2BylyHrE9OxU9FSKcD/cRLQYvbq3YcBSdF7sZwRLDBer7qTeLsYA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20251207.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-3bkD9QuIjxETtp6J1l5X2oKgudJ8z+8fwUq0izCjK1JrIs2vW1aQnbzxhynErSyHWH7URGhHHzcsXHbikckAsg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20251207.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OjrZBq8XJkB7uCQvT1AZ1FPsp+lT0cHxY5SisE+ZTAU6V0IHAZMwJ7J/mnwlGsBcCKRLBT+lX3hgEuOTSwHr9w=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20251207.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qhp06OObkwy5B+PlAhAmq+Ls3GVt4LHAovrTRcpLB3Mk3yJ0h9DnIQwPQiayp16TdvTsGHI3jdIX4MGm5L/ghA=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20251207.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fPRw0zfTBeVmrkgi5Le+sSwoeAz6pIdvcsa1OYZcrspueS9hn3qSC5bLEc5yX4NJP1vItadBqyGLUQ7u8FJjow=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20251207.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-KxY1i+HxeSFfzZ+HVsKwMGBM79laTRZv1ibFqHu22CEsfSPDt4yiV1QFis8Nw7OBXswNqJG/UGqY47VP8FeTvw=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20251207.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5l51HlXjX7lXwo65DEl1IaCFLjmkMtL6K3NrSEamPNeNTtTQwZRa3pQ9V65dCglnnCQ0M3+VF1RqzC7FU0iDKg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
+
+    "babel-plugin-istanbul": ["babel-plugin-istanbul@6.1.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-instrument": "^5.0.4", "test-exclude": "^6.0.0" } }, "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA=="],
+
+    "babel-preset-current-node-syntax": ["babel-preset-current-node-syntax@1.2.0", "", { "dependencies": { "@babel/plugin-syntax-async-generators": "^7.8.4", "@babel/plugin-syntax-bigint": "^7.8.3", "@babel/plugin-syntax-class-properties": "^7.12.13", "@babel/plugin-syntax-class-static-block": "^7.14.5", "@babel/plugin-syntax-import-attributes": "^7.24.7", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-syntax-json-strings": "^7.8.3", "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-numeric-separator": "^7.10.4", "@babel/plugin-syntax-object-rest-spread": "^7.8.3", "@babel/plugin-syntax-optional-catch-binding": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-syntax-private-property-in-object": "^7.14.5", "@babel/plugin-syntax-top-level-await": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0 || ^8.0.0-0" } }, "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+
+    "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
+
+    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.402", "", {}, "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
+    "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-package-type": ["get-package-type@0.1.0", "", {}, "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
+
+    "jest-diff": ["jest-diff@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "diff-sequences": "^29.6.3", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw=="],
+
+    "jest-get-type": ["jest-get-type@29.6.3", "", {}, "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw=="],
+
+    "jest-haste-map": ["jest-haste-map@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/graceful-fs": "^4.1.3", "@types/node": "*", "anymatch": "^3.0.3", "fb-watchman": "^2.0.0", "graceful-fs": "^4.2.9", "jest-regex-util": "^29.6.3", "jest-util": "^29.7.0", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "walker": "^1.0.8" }, "optionalDependencies": { "fsevents": "^2.3.2" } }, "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA=="],
+
+    "jest-matcher-utils": ["jest-matcher-utils@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "jest-diff": "^29.7.0", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g=="],
+
+    "jest-message-util": ["jest-message-util@29.7.0", "", { "dependencies": { "@babel/code-frame": "^7.12.13", "@jest/types": "^29.6.3", "@types/stack-utils": "^2.0.0", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "micromatch": "^4.0.4", "pretty-format": "^29.7.0", "slash": "^3.0.0", "stack-utils": "^2.0.3" } }, "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w=="],
+
+    "jest-mock": ["jest-mock@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "jest-util": "^29.7.0" } }, "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw=="],
+
+    "jest-regex-util": ["jest-regex-util@29.6.3", "", {}, "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg=="],
+
+    "jest-snapshot": ["jest-snapshot@29.7.0", "", { "dependencies": { "@babel/core": "^7.11.6", "@babel/generator": "^7.7.2", "@babel/plugin-syntax-jsx": "^7.7.2", "@babel/plugin-syntax-typescript": "^7.7.2", "@babel/types": "^7.3.3", "@jest/expect-utils": "^29.7.0", "@jest/transform": "^29.7.0", "@jest/types": "^29.6.3", "babel-preset-current-node-syntax": "^1.0.0", "chalk": "^4.0.0", "expect": "^29.7.0", "graceful-fs": "^4.2.9", "jest-diff": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0", "natural-compare": "^1.4.0", "pretty-format": "^29.7.0", "semver": "^7.5.3" } }, "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw=="],
+
+    "jest-util": ["jest-util@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA=="],
+
+    "jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
+
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
+
+    "node-machine-id": ["node-machine-id@1.1.12", "", {}, "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="],
+
+    "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
+
+    "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+  }
+}

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@serac-labs/servicenow-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Unified ServiceNow MCP server (~426 snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/servicenow-mcp/script/build-for-publish.ts
+++ b/packages/servicenow-mcp/script/build-for-publish.ts
@@ -4,27 +4,95 @@
 // the built output. Run right before `npm publish` in CI. The runner is
 // ephemeral (tag-triggered publish), so package.json is intentionally NOT
 // restored afterwards.
+//
+// Everything this needs (tsc, @types/bun) is declared in this package's own
+// devDependencies, so `bun install && bun run build:publish` works from this
+// directory alone — no monorepo root, no hoisted toolchain.
 import { $ } from "bun"
+import { existsSync, rmSync } from "node:fs"
 
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 
-await $`bun tsc --project tsconfig.build.json`
+// Start from an empty dist/. `files: ["dist"]` ships whatever is in there, so
+// without this a stale artifact from an earlier build — a file whose source has
+// since been deleted or renamed — rides along into the tarball, and the
+// entrypoint checks below cannot tell it apart from a freshly emitted one.
+rmSync("dist", { recursive: true, force: true })
 
-const pkg = await import("../package.json").then((m) => m.default)
+// Delegates to the package's own "build" script so the compiler flags have a
+// single source of truth. `$` throws on a non-zero exit, which aborts before
+// anything is rewritten or published.
+await $`bun run build`
+
+type Entry = string | { types: string; import: string }
+type Manifest = Record<string, unknown> & { exports?: Record<string, Entry>; bin?: Record<string, string> }
+
+const pkg: Manifest = await Bun.file("package.json").json()
 if (!pkg.exports || !pkg.bin) throw new Error("package.json must declare exports and bin to rewrite for publish")
-for (const [key, value] of Object.entries(pkg.exports)) {
-  // Non-TypeScript exports (the agent-fragment .txt assets, exposed as a
-  // subpath pattern) ship verbatim from src/ — `files` includes that dir and
-  // tsc never emits them into dist/, so rewriting them to ./dist/ would point
-  // the published package at files that do not exist.
-  if (!value.endsWith(".ts")) continue
-  const file = value.replace("./src/", "./dist/").replace(".ts", "")
-  // @ts-ignore
-  pkg.exports[key] = { import: file + ".js", types: file + ".d.ts" }
+
+const built = (value: string) => value.replace("./src/", "./dist/").replace(/\.ts$/, "")
+
+const exports: Record<string, Entry> = Object.fromEntries(
+  Object.entries(pkg.exports).map(([key, value]) => {
+    // Non-TypeScript exports (the agent-fragment .txt assets, exposed as a
+    // subpath pattern) ship verbatim from src/ — `files` includes that dir and
+    // tsc never emits them into dist/, so rewriting them to ./dist/ would point
+    // the published package at files that do not exist. Anything already
+    // rewritten (a re-run on the same checkout) is left alone.
+    if (typeof value !== "string" || !value.endsWith(".ts")) return [key, value]
+    // `types` is listed FIRST: export conditions are matched in declaration
+    // order, and publint / are-the-types-wrong flag a `types` condition that
+    // trails `import`, because a resolver can match the .js before it ever
+    // reaches the declarations.
+    return [key, { types: built(value) + ".d.ts", import: built(value) + ".js" }]
+  }),
+)
+
+// Extension-swapping rather than `built() + ".js"`, so a re-run on an already
+// rewritten package.json is a no-op instead of producing ./dist/index.js.js.
+const bin: Record<string, string> = Object.fromEntries(
+  Object.entries(pkg.bin).map(([key, value]) => [key, value.replace("./src/", "./dist/").replace(/\.ts$/, ".js")]),
+)
+
+const targets: { name: string; file: string }[] = [
+  ...Object.entries(exports).flatMap(([key, value]) =>
+    typeof value === "string"
+      ? [{ name: `exports["${key}"]`, file: value }]
+      : [
+          { name: `exports["${key}"].types`, file: value.types },
+          { name: `exports["${key}"].import`, file: value.import },
+        ],
+  ),
+  ...Object.entries(bin).map(([key, file]) => ({ name: `bin["${key}"]`, file })),
+]
+
+const onDisk = (file: string) => {
+  const path = file.replace(/^\.\//, "")
+  // Subpath patterns (./src/agent-fragments/*) resolve at import time; the most
+  // that can be checked here is that the directory they ship from exists.
+  const star = path.indexOf("*")
+  return existsSync(star === -1 ? path : path.slice(0, star))
 }
-for (const [key, value] of Object.entries(pkg.bin)) {
-  // @ts-ignore
-  pkg.bin[key] = value.replace("./src/", "./dist/").replace(/\.ts$/, ".js")
+
+// tsc writes dist/ even when it exits non-zero, so "some dist file exists" is
+// not evidence of a successful build. Assert instead that EVERY published
+// entrypoint resolves to a file that is really on disk. A partial build that
+// drops ./blast-radius would break serac-platform, which imports exactly that
+// subpath — this is the check that catches it before npm publish, not after.
+const missing = targets.filter((target) => !onDisk(target.file))
+if (missing.length > 0) {
+  const detail = missing.map((target) => `  ${target.name} -> ${target.file}`).join("\n")
+  throw new Error(`build produced no file for ${missing.length} published entrypoint(s):\n${detail}`)
 }
-await Bun.write("package.json", JSON.stringify(pkg, null, 2))
+
+// Nothing published may still point into src/ except the deliberate
+// agent-fragment passthrough above.
+const unbuilt = targets.filter((target) => target.file.startsWith("./src/") && target.file.endsWith(".ts"))
+if (unbuilt.length > 0) {
+  const detail = unbuilt.map((target) => `  ${target.name} -> ${target.file}`).join("\n")
+  throw new Error(`package.json still points at TypeScript source after the rewrite:\n${detail}`)
+}
+
+await Bun.write("package.json", JSON.stringify({ ...pkg, exports, bin }, null, 2) + "\n")
+console.log(`rewrote ${targets.length} published entrypoints to dist/ — all present`)

--- a/packages/servicenow-mcp/src/enterprise-proxy/proxy.ts
+++ b/packages/servicenow-mcp/src/enterprise-proxy/proxy.ts
@@ -14,7 +14,17 @@
 
 import axios, { AxiosError } from "axios"
 import crypto from "crypto"
-import { machineIdSync } from "node-machine-id"
+// Default import, NOT `import { machineIdSync }`. node-machine-id ships a
+// webpack-bundled CommonJS file; cjs-module-lexer sees only `default` and
+// `electron-machine-id` on it, so Node throws
+// `SyntaxError: Named export 'machineIdSync' not found` at import time — before
+// any of this module's code runs. That killed five of the published subpaths
+// (".", "/server", "/http", "/stdio", "/enterprise-proxy") and both bins for
+// every `npm install` consumer, while staying invisible under Bun (whose CJS
+// interop is more forgiving) and therefore in the GHCR mcp-http image, whose
+// CMD is bun. `.github/workflows/publish-mcp.yml`'s smoke gate now imports
+// every subpath and both bins under node so this cannot silently return.
+import nodeMachineId from "node-machine-id"
 import fs from "fs"
 import path from "path"
 import os from "os"
@@ -88,7 +98,7 @@ function getConfiguredLicenseKey(): string | undefined {
 // Generate unique machine ID for tracking
 let INSTANCE_ID: string
 try {
-  INSTANCE_ID = machineIdSync()
+  INSTANCE_ID = nodeMachineId.machineIdSync()
 } catch {
   // Fallback if machine ID generation fails
   INSTANCE_ID = `fallback-${Date.now()}-${crypto.randomBytes(6).toString("hex")}`

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
@@ -13,6 +13,7 @@ import { executeWithErrorHandling, SnowFlowError, classifyError } from "../share
 import { validatePermission, validateJWTExpiry } from "../shared/permission-validator.js"
 import { tool_search_exec, tool_execute_exec } from "../tools/meta/index.js"
 import { ToolSearch } from "../shared/tool-search.js"
+import { resolveTenantScope, STDIO_TENANT } from "../shared/tenant-scope.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 import { formatArgsForLogging, isRetryableOperation } from "../shared/handler-helpers.js"
 import { reportArtifactToInstanceMap, isWriteTool } from "../shared/instance-map-hook.js"
@@ -129,11 +130,16 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
     // duplicate enablement state over HTTP, which they currently don't.
     // So we skip the check on HTTP and let permission/feature gates
     // below do the real access control.
-    const tenantId = context.tenantId ?? "stdio"
+    //
+    // Scope resolution goes through the same helper tools/meta/index.ts writes
+    // with — see list-tools.ts. This branch only runs on stdio, where the
+    // scope is always the "stdio" sentinel, but computing it a second way here
+    // is how writer and reader drift apart.
+    const tenantScope = resolveTenantScope({ tenantId: context.tenantId, origin: ctx.origin })
     if (ctx.origin !== "http") {
-      const canExecute = await ToolSearch.canExecuteTool(sessionId, name, tenantId)
+      const canExecute = await ToolSearch.canExecuteTool(sessionId, name, tenantScope ?? STDIO_TENANT)
       if (!canExecute) {
-        const toolStatus = await ToolSearch.getToolStatus(sessionId, name, tenantId)
+        const toolStatus = await ToolSearch.getToolStatus(sessionId, name, tenantScope ?? STDIO_TENANT)
         throw new McpError(
           ErrorCode.InvalidRequest,
           `Tool "${name}" is ${toolStatus} and must be enabled first. ` +

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/list-tools.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/list-tools.ts
@@ -11,6 +11,7 @@ import { toolRegistry } from "../shared/tool-registry.js"
 import { filterToolsByRole } from "../shared/permission-validator.js"
 import { META_TOOLS } from "../tools/meta/index.js"
 import { ToolSearch } from "../shared/tool-search.js"
+import { resolveTenantScope } from "../shared/tenant-scope.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 import { type MCPToolDefinition } from "../shared/types.js"
 import { type HandlerDeps } from "./types.js"
@@ -26,10 +27,16 @@ export const listTools = (deps: HandlerDeps) => async (request: any, extra?: any
     )
   }
   const sessionId = ctx.sessionId
-  const tenantId = ctx.serviceNow.tenantId ?? "stdio"
+  // Same helper `tools/meta/index.ts` uses to WRITE the enabled set. Both ends
+  // of the store must compute the scope the same way or tool_search reports
+  // [ENABLED] for tools this handler then omits — writer and reader silently in
+  // different namespaces. The check above already guarantees a tenantId on
+  // HTTP, so `undefined` here means stdio-without-origin only.
+  const tenantScope = resolveTenantScope({ tenantId: ctx.serviceNow.tenantId, origin: ctx.origin })
 
   // Get enabled tools for this session (scoped by tenant to prevent cross-tenant leaks)
-  const enabledToolIds = sessionId ? await ToolSearch.getEnabledTools(sessionId, tenantId) : new Set<string>()
+  const enabledToolIds =
+    sessionId && tenantScope ? await ToolSearch.getEnabledTools(sessionId, tenantScope) : new Set<string>()
 
   // Debug: Log session info and sources
   mcpDebug(`[Server] ListTools request - sessionId: ${sessionId || "none"}`)

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
@@ -40,12 +40,19 @@ async function main() {
 
     // Load environment variables from .env file
     // Note: dotenv should NOT override existing vars, but we preserve them anyway for safety
-    const result = dotenv.config()
+    //
+    // `quiet: true` is load-bearing, not cosmetic. This is the stdio transport:
+    // stdout IS the JSON-RPC channel, and dotenv v17 prints an "[dotenv@17.2.3]
+    // injecting env (0) from .env -- tip: ..." banner there on every call. That
+    // banner is not JSON, so a strict MCP client fails to parse the stream
+    // before the server has answered anything. Diagnostics belong on stderr,
+    // which is what mcpDebug() below uses.
+    const result = dotenv.config({ quiet: true })
 
     if (result.error) {
       // Try loading from parent directory (common when MCP server is in subdirectory)
       const parentEnvPath = path.resolve(process.cwd(), "..", ".env")
-      const parentResult = dotenv.config({ path: parentEnvPath })
+      const parentResult = dotenv.config({ path: parentEnvPath, quiet: true })
 
       if (parentResult.error) {
         mcpDebug("[Main] No .env file found - using environment variables from MCP configuration")

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/no-module-state.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/no-module-state.test.ts
@@ -41,7 +41,7 @@ const ALLOWLIST: AllowedPattern[] = [
   {
     file: "scripted-exec.ts",
     pattern: /^const endpointCache = new Map</,
-    reason: "Keys are composed as tenantId\\x00instanceUrl — see getEndpointCacheKey()",
+    reason: "Keys are tenantScopedKey(tenantId, instanceUrl) — see getEndpointCacheKey()",
   },
   {
     file: "error-handler.ts",
@@ -61,7 +61,12 @@ const ALLOWLIST: AllowedPattern[] = [
   {
     file: "update-set-guard.ts",
     pattern: /^const guardState = new Map</,
-    reason: "Keys are composed as tenantId\\x00sessionId\\x00instanceUrl — see guardKey()",
+    reason: "Keys are tenantScopedKey(tenantId, sessionId, instanceUrl) — see guardKey()",
+  },
+  {
+    file: "update-set-guard.ts",
+    pattern: /^const assertedCurrent = new Map</,
+    reason: "Keys are tenantScopedKey(tenantId, instanceUrl) — see driftScope()",
   },
 ]
 
@@ -102,7 +107,14 @@ describe("Multi-tenant invariants in shared/", () => {
         if (/^(export\s+)?(async\s+)?(function|class|interface|type|namespace|enum)\s/.test(stripped)) continue
 
         const isMutableLet = /^(export\s+)?(let|var)\s+/.test(stripped)
-        const isNewMapSet = /new\s+(Map|Set|WeakMap|WeakSet)\(/.test(stripped)
+        // `[<(]`, not `\(`: every cache in this codebase is written
+        // `new Map<string, X>()`, which a bare `\(` never matches. With the
+        // narrow matcher this test caught none of them — the ALLOWLIST entries
+        // for `endpointCache` and `guardState` were dead code proving it, and
+        // `assertedCurrent` in update-set-guard.ts was neither detected nor
+        // allowlisted. A guard that cannot see the pattern it exists for is
+        // worse than no guard: it reads as coverage.
+        const isNewMapSet = /new\s+(Map|Set|WeakMap|WeakSet)\s*[<(]/.test(stripped)
 
         if (!isMutableLet && !isNewMapSet) continue
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tenant-scope.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tenant-scope.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The tenancy primitives every cache in this package now keys on.
+ *
+ * `shared/auth.ts` (OAuth tokens + authenticated Axios clients),
+ * `shared/scripted-exec.ts`, `shared/update-set-guard.ts` and the blast-radius
+ * discovery cache all compose their keys here, so a defect in these ~10 lines
+ * is a cross-tenant defect in all four at once. Those call sites are covered
+ * through their own behaviour elsewhere; this file pins the two properties they
+ * all rely on, directly.
+ */
+
+import { describe, test, expect } from "@jest/globals"
+import { STDIO_TENANT, resolveTenantScope, tenantScopedKey } from "../tenant-scope"
+
+describe("resolveTenantScope — who is this request", () => {
+  test("an explicit tenant id is returned verbatim", () => {
+    // Verbatim matters: both readers of the enabled-tools store call this same
+    // function, and any transform applied here but not there (an earlier
+    // revision percent-encoded) puts writer and readers in different
+    // namespaces. The portal emits colon-bearing ids, so a transform that only
+    // shows up on exotic input would still fire in production.
+    expect(resolveTenantScope({ tenantId: "c:1042", origin: "http" })).toBe("c:1042")
+    expect(resolveTenantScope({ tenantId: "1042", origin: "http" })).toBe("1042")
+  })
+
+  test("stdio without a tenant id resolves to the single-tenant sentinel", () => {
+    expect(resolveTenantScope({ origin: "stdio" })).toBe(STDIO_TENANT)
+  })
+
+  test("HTTP without a tenant id fails closed — never the sentinel", () => {
+    expect(resolveTenantScope({ origin: "http" })).toBeUndefined()
+  })
+
+  test("no origin at all is unprovable, so also fails closed", () => {
+    // An embedder calling a tool executor directly. We cannot show it is
+    // single-tenant, so it gets no shared state.
+    expect(resolveTenantScope({})).toBeUndefined()
+  })
+
+  test("an explicit tenant id wins over the transport", () => {
+    expect(resolveTenantScope({ tenantId: "1042", origin: "stdio" })).toBe("1042")
+  })
+})
+
+describe("tenantScopedKey — where does this go", () => {
+  test("is injective: distinct component tuples never collide", () => {
+    // The property that matters. `.replace(/[\x00:]/g, "_")`, which these call
+    // sites used to do, fails it — "c:1042" and "c_1042" both became "c_1042",
+    // and behind that key in auth.ts sits an OAuth token.
+    const tuples: Array<[string, string]> = [
+      ["c:1042", "inst"],
+      ["c_1042", "inst"],
+      ["c%3A1042", "inst"],
+      ["1042", "X\x00Y"],
+      ["1042\x00X", "Y"],
+      ["1042", ""],
+      ["", "1042"],
+    ]
+    const keys = tuples.map(([scope, part]) => tenantScopedKey(scope, part))
+    expect(new Set(keys).size).toBe(tuples.length)
+  })
+
+  test("the separator survives no component: a segment can never shift", () => {
+    expect(tenantScopedKey("1042\x00X", "Y")).not.toBe(tenantScopedKey("1042", "X\x00Y"))
+    expect(tenantScopedKey("1042", "X").split("\x00").length).toBe(2)
+    expect(tenantScopedKey("a\x00b\x00c", "d").split("\x00").length).toBe(2)
+  })
+
+  test("is stable — the same components always give the same key, or nothing caches", () => {
+    expect(tenantScopedKey("1042", "https://x.service-now.com")).toBe(
+      tenantScopedKey("1042", "https://x.service-now.com"),
+    )
+  })
+
+  test("an absent component is not the string 'undefined'", () => {
+    expect(tenantScopedKey("1042", undefined)).not.toBe(tenantScopedKey("1042", "undefined"))
+    expect(tenantScopedKey("1042", undefined)).toBe(tenantScopedKey("1042", ""))
+  })
+
+  test("takes any number of components", () => {
+    expect(tenantScopedKey("1042").split("\x00").length).toBe(1)
+    expect(tenantScopedKey("1042", "session", "instance").split("\x00").length).toBe(3)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-session-store.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-session-store.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Session-store tenancy.
+ *
+ * `FileToolSessionStore` is the process-wide DEFAULT (`tool-search.ts`
+ * initialises `sessionStore` with it), and the HTTP transport only replaces it
+ * as a side effect of `createHttpApp()`. An embedder that builds its own server
+ * from the `./server` export never triggers that, so the default store has to
+ * be the one that refuses multi-tenant use rather than the one that quietly
+ * accepts it. Real files in a temp dir — no mocks.
+ */
+
+import { describe, test, expect, afterEach } from "@jest/globals"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { FileToolSessionStore, MemoryToolSessionStore } from "../tool-session-store"
+
+const tempDirs: string[] = []
+
+const storeInTempDir = (): FileToolSessionStore => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-session-store-"))
+  tempDirs.push(dir)
+  return new FileToolSessionStore(dir)
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) fs.rmSync(tempDirs.pop()!, { recursive: true, force: true })
+})
+
+describe("FileToolSessionStore — stdio only", () => {
+  test("round-trips enablement for the stdio sentinel", async () => {
+    const store = storeInTempDir()
+    await store.setEnabled("stdio", "ses_abc", new Set(["snow_query_table"]))
+    expect(Array.from(await store.getEnabled("stdio", "ses_abc"))).toEqual(["snow_query_table"])
+  })
+
+  test("refuses a real tenant instead of writing tenant state to local disk", async () => {
+    const store = storeInTempDir()
+    await expect(store.setEnabled("1042", "user-42", new Set(["snow_query_table"]))).rejects.toThrow(/stdio-only/)
+    await expect(store.getEnabled("1042", "user-42")).rejects.toThrow(/stdio-only/)
+  })
+
+  test("the refusal names the fix", async () => {
+    const store = storeInTempDir()
+    await expect(store.setEnabled("1042", "user-42", new Set())).rejects.toThrow(/MemoryToolSessionStore/)
+  })
+
+  test("two tenant ids the path sanitiser would merge can never both reach the disk", async () => {
+    // sanitize() maps every non-[a-zA-Z0-9-_] character to "_", so "c:1042"
+    // and "c_1042" share a directory — the directory that is supposed to BE
+    // the tenant boundary. Refusing non-stdio tenants outright is what makes
+    // that unreachable; without the guard this is a cross-tenant read.
+    const store = storeInTempDir()
+    await expect(store.setEnabled("c:1042", "s", new Set(["a"]))).rejects.toThrow()
+    await expect(store.setEnabled("c_1042", "s", new Set(["b"]))).rejects.toThrow()
+  })
+})
+
+describe("MemoryToolSessionStore — the multi-tenant one", () => {
+  test("keeps two tenants sharing a session id apart, including sanitiser-colliding ids", async () => {
+    const store = new MemoryToolSessionStore()
+    await store.setEnabled("c:1042", "user-42", new Set(["snow_query_table"]))
+    await store.setEnabled("c_1042", "user-42", new Set(["snow_create_incident"]))
+
+    expect(Array.from(await store.getEnabled("c:1042", "user-42"))).toEqual(["snow_query_table"])
+    expect(Array.from(await store.getEnabled("c_1042", "user-42"))).toEqual(["snow_create_incident"])
+    expect((await store.getEnabled("c:2087", "user-42")).size).toBe(0)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/update-set-guard.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/update-set-guard.test.ts
@@ -266,4 +266,43 @@ describe("guard state — session lifecycle", () => {
     expect(needsCurrentReassert(driftScope("43", "https://dev1.service-now.com"), "x")).toBe(true)
     expect(needsCurrentReassert(driftScope("42", "https://dev2.service-now.com"), "x")).toBe(true)
   })
+
+  test("observeUpdateSetTool records drift under the scope driftScope() computes", () => {
+    // The guard key and the drift scope are built by two different functions;
+    // observeUpdateSetTool has only the guard key and has to derive the scope
+    // from it. If those two derivations disagree, drift is recorded in a slot
+    // nothing reads and every write re-asserts the current set forever.
+    // A colon-bearing tenant id is the shape the portal actually emits.
+    const key = guardKey("c:42", "chat-a", "https://dev1.service-now.com")
+    observeUpdateSetTool(
+      "snow_ensure_active_update_set",
+      { name: "US-A" },
+      { success: true, data: { sys_id: "us-a", name: "US-A" } },
+      key,
+    )
+    expect(needsCurrentReassert(driftScope("c:42", "https://dev1.service-now.com"), "us-a")).toBe(false)
+  })
+})
+
+describe("guard keys — separator spoofing", () => {
+  beforeEach(() => resetUpdateSetState())
+
+  test("a tenant id carrying the separator cannot inherit another tenant's lifted guard", () => {
+    // Naive `${tenant}\x00${session}\x00${url}` concatenation flattens both of
+    // these to "42\x00chat-a\x00https://dev1..." — so the spoofer would read
+    // the honest tenant's guard state and skip the update-set prompt.
+    const honest = guardKey("42", "chat-a", "https://dev1.service-now.com")
+    const spoofer = guardKey("42\x00chat-a", "https://dev1.service-now.com", undefined)
+    expect(spoofer).not.toBe(honest)
+
+    recordUpdateSetSkip(honest)
+    expect(updateSetActive(honest)).toBe(true)
+    expect(updateSetActive(spoofer)).toBe(false)
+  })
+
+  test("tenant ids differing only in a separator character stay distinct", () => {
+    // The old `.replace(/[\x00:]/g, "_")` sanitiser mapped both to "1_2".
+    expect(guardKey("1:2", "s", "u")).not.toBe(guardKey("1\x002", "s", "u"))
+    expect(driftScope("1:2", "u")).not.toBe(driftScope("1\x002", "u"))
+  })
 })

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
@@ -20,6 +20,7 @@ import * as os from "node:os"
 import { seracHomePath } from "./serac-home.js"
 import { type ServiceNowContext, type OAuthTokenResponse, type EnterpriseLicense } from "./types.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
+import { STDIO_TENANT, tenantScopedKey } from "./tenant-scope.js"
 
 /**
  * Extract a human-readable error message from a ServiceNow error response.
@@ -620,14 +621,20 @@ export class ServiceNowAuthManager {
    * Stdio callers without a tenantId fall back to the sentinel `"stdio"`.
    */
   private getCacheKey(context: ServiceNowContext): string {
-    // Disallow NUL and colon in tenantId so the separator can't be spoofed.
-    const rawTenant = context.tenantId ?? "stdio"
-    const tenant = rawTenant.replace(/[\x00:]/g, "_")
     const urlKey = context.instanceUrl
       .replace(/^https?:\/\//, "")
       .replace(/\/$/, "")
       .toLowerCase()
-    return `${tenant}\x00${urlKey}`
+    // Escape, don't sanitise. This used to be
+    // `rawTenant.replace(/[\x00:]/g, "_")` before the join, which mapped
+    // `c:1042` and `c_1042` onto the same key — and the value behind this key
+    // is an OAuth access token plus an authenticated Axios client, so that
+    // collision hands one tenant another tenant's credentials. Percent-encoding
+    // is injective, so distinct tenant ids stay distinct while the NUL
+    // separator still cannot appear inside a component.
+    // (serac-platform's deriveTenantId() emits `c:<id>` / `o:<id>` / `si:<n>`,
+    // so colon-bearing tenant ids are the normal case, not an exotic one.)
+    return tenantScopedKey(context.tenantId ?? STDIO_TENANT, urlKey)
   }
 
   /**

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/scripted-exec.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/scripted-exec.ts
@@ -13,6 +13,7 @@ import { randomBytes } from "crypto"
 import type { AxiosInstance } from "axios"
 import type { ServiceNowContext } from "./types.js"
 import { getAuthenticatedClient } from "./auth.js"
+import { STDIO_TENANT, tenantScopedKey } from "./tenant-scope.js"
 
 const ENDPOINT_SERVICE_ID = "snow_flow_exec"
 const ENDPOINT_PATH = "/execute"
@@ -25,11 +26,12 @@ const ENDPOINT_PATH = "/execute"
  */
 const endpointCache = new Map<string, { url: string }>()
 
-const getEndpointCacheKey = (context: ServiceNowContext): string => {
-  const rawTenant = context.tenantId ?? "stdio"
-  const tenant = rawTenant.replace(/[\x00:]/g, "_")
-  return `${tenant}\x00${context.instanceUrl}`
-}
+const getEndpointCacheKey = (context: ServiceNowContext): string =>
+  // Was `rawTenant.replace(/[\x00:]/g, "_")` before joining. That is lossy:
+  // `c:1042` and `c_1042` mapped to one key, so the sanitiser meant to stop a
+  // separator spoof introduced a collision of its own. tenantScopedKey escapes
+  // instead of replacing, which is injective.
+  tenantScopedKey(context.tenantId ?? STDIO_TENANT, context.instanceUrl)
 
 const OPERATION_SCRIPT = `(function process(request, response) {
   var body = request.body.data;

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tenant-scope.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tenant-scope.ts
@@ -1,0 +1,76 @@
+/**
+ * The tenancy rule for every piece of cross-request state in this package,
+ * in one place.
+ *
+ *   stdio — single-tenant by construction: one process, one user, one set of
+ *           ServiceNow credentials. The `"stdio"` sentinel is a real tenant
+ *           boundary there, so in-process state may be shared across requests.
+ *   http  — multi-tenant by design: one process serves every customer. A
+ *           missing tenantId is therefore never a licence to fall back to a
+ *           shared literal — two customers would land in the same bucket,
+ *           which is a cross-tenant leak, not a cache miss.
+ *
+ * Two functions, and the split between them is the point:
+ *
+ *   resolveTenantScope() — WHO is this request? Returns the raw tenant id,
+ *     the stdio sentinel, or `undefined` for "cannot be placed in a tenant".
+ *     It returns the id verbatim so that every reader and writer of the same
+ *     store computes the same string. (An earlier revision percent-encoded
+ *     here; `handlers/list-tools.ts` and `handlers/call-tool.ts` read the same
+ *     store with the raw id, so the encoding put the writer and the readers in
+ *     different namespaces — `tool_search` reported `[ENABLED]` for tools the
+ *     next `tools/list` did not return.)
+ *
+ *   tenantScopedKey()   — WHERE does this go? Composes a flat cache key out of
+ *     a scope plus whatever else the cache is keyed on. Escaping belongs here,
+ *     at the composition site, because composition is the only place a
+ *     separator can be spoofed.
+ *
+ * This module has no imports and no module-level state on purpose: everything
+ * that keys state on a tenant can depend on it without a cycle.
+ */
+
+/**
+ * Sentinel tenant ID used for the single-user stdio transport. Never valid as
+ * a fallback in HTTP context.
+ */
+export const STDIO_TENANT = "stdio"
+
+/**
+ * Returns the scope to key state on, or `undefined` when the caller cannot be
+ * placed in a tenant. `undefined` means fail closed: refuse the operation, or
+ * skip the shared state and do the work uncached. Never substitute a constant.
+ *
+ * A context with no `origin` at all (an embedder calling a tool executor
+ * directly) counts as unprovable — we cannot show it is single-tenant.
+ */
+export function resolveTenantScope(context: { tenantId?: string; origin?: "stdio" | "http" }): string | undefined {
+  if (context.tenantId) return context.tenantId
+  if (context.origin === "stdio") return STDIO_TENANT
+  return undefined
+}
+
+/**
+ * Compose a flat cache key from a tenant scope and any further components.
+ *
+ * Every component is percent-encoded before being joined with a NUL, so:
+ *
+ *   - the separator cannot appear inside a component, and no component can
+ *     therefore address another component's slot. The shape that matters is
+ *     not the obvious one: tenant `1042` + instance `X\x00Y` and tenant
+ *     `1042\x00X` + instance `Y` both flatten to `1042\x00X\x00Y` under naive
+ *     concatenation — one tenant reading another tenant's entry;
+ *   - the mapping is injective, unlike the `.replace(/[\x00:]/g, "_")` these
+ *     call sites used to do. That replacement mapped `c:1042` and `c_1042`
+ *     onto one key — and in `shared/auth.ts` the value behind that key is an
+ *     OAuth token and an authenticated Axios client, so the collision it was
+ *     written to prevent was the collision it caused. `encodeURIComponent`
+ *     escapes `%` itself, so distinct inputs stay distinct.
+ *
+ * `undefined` components normalise to the empty string rather than the string
+ * "undefined", so a caller with no instance URL cannot collide with one whose
+ * instance URL is literally "undefined".
+ */
+export function tenantScopedKey(scope: string, ...parts: Array<string | undefined>): string {
+  return [scope, ...parts].map((part) => encodeURIComponent(part ?? "")).join("\x00")
+}

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
@@ -14,6 +14,18 @@
  * stdio context; HTTP callers must always pass the resolved tenant ID
  * (`ctx.serviceNow.tenantId`). See also `ToolSessionStore`.
  *
+ * Callers should derive that ID with `resolveTenantScope()` from
+ * `shared/tenant-scope.ts` (re-exported below) rather than writing
+ * `context.tenantId ?? "stdio"` inline: the helper fails closed on a
+ * multi-tenant transport instead of quietly parking an unidentified caller in
+ * the shared stdio bucket. The default parameter is kept only for the
+ * single-tenant stdio embedders (`src/enterprise-proxy/*`) that call these
+ * functions with no tenant at all.
+ *
+ * The store keys on (tenant, session) with nested maps, never with a composed
+ * string, so the scope goes in verbatim. Caches that DO flatten a tenant into
+ * one string key must compose it with `tenantScopedKey()`.
+ *
  * @see https://www.anthropic.com/engineering/advanced-tool-use
  */
 
@@ -22,6 +34,13 @@ import * as path from "path"
 import * as os from "os"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 import { FileToolSessionStore, type ToolSessionStore } from "./tool-session-store.js"
+import { STDIO_TENANT } from "./tenant-scope.js"
+
+// Re-exported so callers that already reach for the tenancy rule through this
+// module keep working. `shared/tenant-scope.ts` is the definition; it is
+// import-free so that low-level modules (auth.ts, scripted-exec.ts) can key on
+// a tenant without depending on the tool index.
+export { STDIO_TENANT, resolveTenantScope, tenantScopedKey } from "./tenant-scope.js"
 
 /**
  * Tool index entry - lightweight representation for search
@@ -33,12 +52,6 @@ export interface ToolIndexEntry {
   keywords: string[]
   deferred: boolean
 }
-
-/**
- * Sentinel tenant ID used when no explicit tenant is provided. Safe for
- * stdio (single-user) but never valid in HTTP context.
- */
-const STDIO_TENANT = "stdio"
 
 /**
  * Active session store. Defaults to file-backed for stdio; the HTTP

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-session-store.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-session-store.ts
@@ -18,6 +18,7 @@ import * as fs from "fs"
 import * as path from "path"
 import * as os from "os"
 import { mcpDebug } from "../../shared/mcp-debug.js"
+import { STDIO_TENANT } from "./tenant-scope.js"
 import { TenantScopedCache } from "./tenant-scoped-cache.js"
 
 export interface ToolSessionStore {
@@ -52,13 +53,28 @@ const getStdioDataDir = (): string => {
 const sanitize = (id: string): string => id.replace(/[^a-zA-Z0-9-_]/g, "_")
 
 /**
- * File-backed store used by the stdio transport.
+ * File-backed store used by the stdio transport. **stdio only.**
  *
  * Layout: `{dataDir}/enabled-tools/{sanitize(tenantId)}/{sanitize(sessionId)}.json`
  *
  * The tenant directory is included even for stdio (where tenantId is the
  * sentinel `"stdio"`) so that a future multi-user stdio deployment — or
  * dev-switching between stdio contexts — never crosses streams.
+ *
+ * It is not usable in a multi-tenant server, and now says so instead of
+ * silently doing the wrong thing. Two reasons:
+ *
+ *   1. `sanitize()` is lossy — `c:1042` and `c_1042` both become `c_1042`, so
+ *      the directory that is supposed to be the tenant boundary can merge two
+ *      tenants;
+ *   2. it writes tenant state to container-local disk, which for a horizontally
+ *      scaled HTTP deployment is neither shared nor cleaned up.
+ *
+ * `transports/http.ts` installs `MemoryToolSessionStore` for exactly this
+ * reason, but it does so as a side effect of `createHttpApp()`. An embedder
+ * that builds its own server from the `./server` export never triggers that
+ * and would otherwise inherit this store by default. The guard below turns
+ * that footgun into an error at the first write.
  */
 export class FileToolSessionStore implements ToolSessionStore {
   private readonly baseDir: string
@@ -68,6 +84,13 @@ export class FileToolSessionStore implements ToolSessionStore {
   }
 
   private fileFor(tenantId: string, sessionId: string): string {
+    if (tenantId !== STDIO_TENANT) {
+      throw new Error(
+        `FileToolSessionStore is stdio-only and was asked for tenant "${tenantId}". ` +
+          `A multi-tenant server must install a tenant-safe store — ` +
+          `setSessionStore(new MemoryToolSessionStore()) — before serving requests.`,
+      )
+    }
     return path.join(this.baseDir, sanitize(tenantId), `${sanitize(sessionId)}.json`)
   }
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/update-set-guard.ts
@@ -15,6 +15,7 @@
 
 import { type MCPToolDefinition } from "./types.js"
 import { isWriteTool, SKIP_ACTIONS, SKIP_TOOLS } from "./instance-map-hook.js"
+import { STDIO_TENANT, tenantScopedKey } from "./tenant-scope.js"
 
 // Write tools in these categories mutate process data (incidents, CIs,
 // assets, cases, ...), not configuration — ServiceNow does not capture them
@@ -87,12 +88,16 @@ const MAX_ENTRIES = 5000
 // never cross tenants; pruned by age once the map grows.
 const guardState = new Map<string, GuardEntry>()
 
+// Composed through tenantScopedKey so no component can address another's slot:
+// with raw concatenation, tenant `42` + session `a\x00https://x` and tenant
+// `42\x00a` + session `https://x` were the same key, which for a *guard* means
+// one caller inheriting another's lifted prod-write / update-set state.
 export function guardKey(
   tenantId: string | undefined,
   sessionId: string | undefined,
   instanceUrl: string | undefined,
 ): string {
-  return `${tenantId ?? "stdio"}\x00${sessionId ?? "stdio"}\x00${instanceUrl ?? ""}`
+  return tenantScopedKey(tenantId ?? STDIO_TENANT, sessionId ?? STDIO_TENANT, instanceUrl)
 }
 
 function entry(key: string): GuardEntry {
@@ -167,7 +172,22 @@ function pruneAsserted(): void {
 }
 
 export function driftScope(tenantId: string | undefined, instanceUrl: string | undefined): string {
-  return `${tenantId ?? "stdio"}\x00${instanceUrl ?? ""}`
+  return tenantScopedKey(tenantId ?? STDIO_TENANT, instanceUrl)
+}
+
+/**
+ * The drift scope for a guard key, i.e. the same key with the session segment
+ * dropped. `observeUpdateSetTool` only has the guard key to hand.
+ *
+ * Both keys are built from already-escaped segments joined by NUL, so taking
+ * segments 0 and 2 and re-joining them reproduces `driftScope()` exactly —
+ * which is only true because the escaping happens per segment, before the
+ * join. Doing this by hand on raw segments is how a tenant id containing the
+ * separator would shift the segment boundaries.
+ */
+function driftScopeOfGuardKey(key: string): string {
+  const parts = key.split("\x00")
+  return `${parts[0] ?? encodeURIComponent(STDIO_TENANT)}\x00${parts[2] ?? ""}`
 }
 
 /** True when the instance current we last asserted differs from `sysId`. */
@@ -219,8 +239,7 @@ export function observeUpdateSetTool(
     // sync-off variants returned early above), so the instance current for
     // this (tenant, instance) is now this set. Record it for drift detection.
     if (typeof data.sys_id === "string") {
-      const parts = key.split("\x00")
-      markCurrentAsserted(`${parts[0] ?? "stdio"}\x00${parts[2] ?? ""}`, data.sys_id)
+      markCurrentAsserted(driftScopeOfGuardKey(key), data.sys_id)
     }
   }
   // NOTE: a "current" observation deliberately does NOT lift the guard.

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/__tests__/no-module-state-outside-shared.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/__tests__/no-module-state-outside-shared.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Multi-tenant invariant test for `tools/`, `handlers/` and `transports/`.
+ *
+ * Companion to `shared/__tests__/no-module-state.test.ts`, which scans only
+ * the flat `shared/` directory. That gap is how the blast-radius discovery
+ * cache — `tools/blast-radius/shared/deep-search.ts`, a process-global Map
+ * shared by every tenant — went unnoticed. This walks the rest of the tree
+ * recursively so the next one doesn't.
+ *
+ * Note the matcher below accepts `new Map<...>(` as well as `new Map(`. The
+ * generic form is how every cache in this codebase is actually written, and a
+ * matcher that misses it is a matcher that never fires.
+ *
+ * What counts as suspect:
+ *   - `let` / `var` at module scope (mutable reference)
+ *   - `new Map` / `Set` / `WeakMap` / `WeakSet` at module scope, with or
+ *     without type arguments
+ *
+ * Indented lines (class bodies, function bodies) and the interiors of
+ * template literals (ServiceNow ES5 snippets legitimately use `var`) are
+ * ignored, matching the shared/ test.
+ */
+
+import { describe, test } from "@jest/globals"
+import * as fs from "fs"
+import * as path from "path"
+
+const ROOT = path.resolve(__dirname, "..", "..")
+const SCANNED_DIRS = ["tools", "handlers", "transports"]
+
+interface AllowedPattern {
+  /** Path relative to servicenow-mcp-unified/, POSIX separators. */
+  file: string
+  pattern: RegExp
+  reason: string
+}
+
+const ALLOWLIST: AllowedPattern[] = [
+  {
+    file: "tools/blast-radius/shared/deep-search.ts",
+    pattern: /^const discoveryCache = new Map</,
+    reason:
+      "Keys are composed tenant-first by the caller — see discoveryCacheKey() in " +
+      "tools/blast-radius/snow_blast_radius_dependents.ts, pinned by its __tests__",
+  },
+  {
+    file: "tools/blast-radius/shared/metadata-tables.ts",
+    pattern: /^export const GLIDE_RECORD_BUILTINS = new Set\(/,
+    reason: "Static metadata — GlideRecord built-in method names used to filter false-positive hits",
+  },
+  {
+    file: "tools/operations/snow_record_manage.ts",
+    pattern: /^export var (version|author) = /,
+    reason: "Tool metadata strings, never reassigned — `var` is a leftover from the SDK migration",
+  },
+  {
+    file: "tools/operations/snow_manage_group_membership.ts",
+    pattern: /^export var (version|author) = /,
+    reason: "Tool metadata strings, never reassigned — `var` is a leftover from the SDK migration",
+  },
+  {
+    file: "tools/flow-designer/contract/drift-check.ts",
+    pattern: /^const referenced = new Set<string>\(\)|^let checked = 0/,
+    reason: "One-shot CLI script (top-level await, never imported by the server) — no request path",
+  },
+]
+
+const listFiles = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === "__tests__" ? [] : listFiles(full)
+    }
+    return entry.isFile() && entry.name.endsWith(".ts") ? [full] : []
+  })
+
+describe("Multi-tenant invariants outside shared/", () => {
+  test("no unexpected module-level mutable state", () => {
+    const violations: string[] = []
+
+    for (const dir of SCANNED_DIRS) {
+      for (const absolute of listFiles(path.join(ROOT, dir))) {
+        const relative = path.relative(ROOT, absolute).split(path.sep).join("/")
+        const lines = fs.readFileSync(absolute, "utf-8").split("\n")
+
+        // Parity check on backticks: ServiceNow scripts embedded in template
+        // literals legitimately use `var` at column 0.
+        let insideTemplate = false
+
+        for (let i = 0; i < lines.length; i++) {
+          const raw = lines[i]
+          const backtickCount = (raw.match(/`/g) ?? []).length
+          const startedInsideTemplate = insideTemplate
+          if (backtickCount % 2 === 1) insideTemplate = !insideTemplate
+          if (startedInsideTemplate || insideTemplate) continue
+
+          // Skip indented lines — those live inside a class, function, or block.
+          if (raw.startsWith(" ") || raw.startsWith("\t")) continue
+
+          const stripped = raw.replace(/\s*\/\/.*$/, "").trimEnd()
+          if (stripped.length === 0) continue
+          if (stripped.startsWith("//") || stripped.startsWith("/*") || stripped.startsWith("*")) continue
+          if (/^(export\s+)?(async\s+)?(function|class|interface|type|namespace|enum)\s/.test(stripped)) continue
+
+          const isMutableLet = /^(export\s+)?(let|var)\s+/.test(stripped)
+          const isNewMapSet = /new\s+(Map|Set|WeakMap|WeakSet)\s*[<(]/.test(stripped)
+          if (!isMutableLet && !isNewMapSet) continue
+
+          const allowed = ALLOWLIST.some((a) => relative === a.file && a.pattern.test(stripped))
+          if (allowed) continue
+
+          violations.push(`${relative}:${i + 1}: ${stripped}`)
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const guidance =
+        "Unexpected module-level mutable state detected outside shared/.\n\n" +
+        "In the HTTP transport one process serves every tenant, so process-global\n" +
+        "state is shared between customers unless its key says otherwise.\n" +
+        "Options:\n" +
+        "  1. Wrap it in TenantScopedCache, or compose the key with\n" +
+        "     resolveTenantScope() + tenantScopedKey() from shared/tenant-scope.ts\n" +
+        "  2. Move the state into the per-request context\n" +
+        "  3. If it is genuinely tenant-agnostic (static metadata, a CLI script),\n" +
+        "     add it to `ALLOWLIST` in this file with a one-line reason.\n\n" +
+        "Violations:\n" +
+        violations.map((v) => `  ${v}`).join("\n")
+      throw new Error(guidance)
+    }
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/__tests__/discovery-cache-isolation.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/__tests__/discovery-cache-isolation.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Blast-radius Phase-2 discovery cache: cross-tenant isolation, end to end.
+ *
+ * Runs the real `searchDependents()` against the real process-global discovery
+ * cache in `shared/deep-search.ts`, keyed exactly the way the tool keys it
+ * (`discoveryCacheKey(context)`), with two tenants whose ServiceNow users see
+ * different things. The only stand-in is the ServiceNow REST client, which
+ * `searchDependents` takes as a parameter — it plays the instance, returning
+ * the rows that tenant's credentials would be allowed to read.
+ *
+ * Both failure directions of the old `sessionId || instanceUrl || "default"`
+ * key are covered:
+ *   1. confidentiality — a tenant inheriting another tenant's custom schema
+ *      and then querying those private table names;
+ *   2. correctness — a tenant with a narrow view priming the cache and
+ *      silently shrinking every other tenant's blast radius for the TTL.
+ *
+ * Each test uses its own instance URL: the cache is module state with a
+ * 5-minute TTL, so tests must not reuse keys.
+ */
+
+import { describe, test, expect, afterAll } from "@jest/globals"
+import { clearDiscoveryCache, searchDependents } from "../shared/deep-search"
+import { discoveryCacheKey } from "../snow_blast_radius_dependents"
+import { type ServiceNowContext } from "../../../shared/types"
+
+interface DictionaryRow {
+  name: string
+  element: string
+  internal_type: string
+}
+
+/** The (table, field) pairs tenant A's admin integration user can see. */
+const ADMIN_VIEW: DictionaryRow[] = [
+  { name: "u_acme_secret_engine", element: "script", internal_type: "script" },
+  { name: "u_acme_payroll_hook", element: "script", internal_type: "script" },
+]
+
+/** Tenant B's integration user is restricted and sees no custom script tables. */
+const RESTRICTED_VIEW: DictionaryRow[] = []
+
+/**
+ * Stands in for the ServiceNow instance. Answers the Phase-2 discovery query
+ * with whatever this caller's credentials are allowed to see, and records
+ * every table it was asked about so we can prove what leaked.
+ */
+const instanceFor = (visibleRows: DictionaryRow[]) => {
+  const calls: string[] = []
+  return {
+    calls,
+    get: async (url: string, config?: any) => {
+      calls.push(url)
+      const isDiscovery = config?.params?.sysparm_fields === "name,element,internal_type"
+      return { data: { result: isDiscovery ? visibleRows : [] } }
+    },
+    queriedDictionary(): boolean {
+      return calls.some((c) => c.includes("sys_dictionary"))
+    },
+    queriedTablesMatching(fragment: string): string[] {
+      return calls.filter((c) => c.includes(fragment))
+    },
+  }
+}
+
+const contextFor = (tenantId: string, instanceUrl: string): ServiceNowContext => ({
+  instanceUrl,
+  clientId: `client-${tenantId}`,
+  clientSecret: `secret-${tenantId}`,
+  tenantId,
+  origin: "http",
+})
+
+const searchOptions = { patterns: [{ like: "AcmeUtils" }], limit: 50, phase3Concurrency: 5 }
+
+const scan = (instance: ReturnType<typeof instanceFor>, context: ServiceNowContext) =>
+  searchDependents(instance, discoveryCacheKey(context), searchOptions)
+
+describe("discovery cache — confidentiality", () => {
+  test("a second tenant on the same instance does not inherit the first tenant's schema", async () => {
+    const shared = "https://confidentiality.service-now.com"
+    const admin = instanceFor(ADMIN_VIEW)
+    const restricted = instanceFor(RESTRICTED_VIEW)
+
+    const a = await scan(admin, contextFor("tenant-a", shared))
+    const b = await scan(restricted, contextFor("tenant-b", shared))
+
+    // Tenant A primes the cache with its own view.
+    expect(a.stats.phase_2.cached).toBe(false)
+    expect(a.stats.phase_2.discovered_pairs).toBe(ADMIN_VIEW.length)
+
+    // Tenant B must do its own discovery, not read A's entry.
+    expect(b.stats.phase_2.cached).toBe(false)
+    expect(b.stats.phase_2.discovered_pairs).toBe(RESTRICTED_VIEW.length)
+    expect(restricted.queriedDictionary()).toBe(true)
+
+    // And must never have been handed A's private custom table names.
+    expect(restricted.queriedTablesMatching("u_acme")).toEqual([])
+    expect(b.stats.phase_3.tables).toBe(0)
+  })
+})
+
+describe("discovery cache — correctness", () => {
+  test("a narrow tenant priming the cache does not shrink another tenant's blast radius", async () => {
+    const shared = "https://correctness.service-now.com"
+    const restricted = instanceFor(RESTRICTED_VIEW)
+    const admin = instanceFor(ADMIN_VIEW)
+
+    const b = await scan(restricted, contextFor("tenant-b", shared))
+    const a = await scan(admin, contextFor("tenant-a", shared))
+
+    expect(b.stats.phase_2.discovered_pairs).toBe(0)
+
+    // The admin tenant still discovers and scans its own long tail. Under the
+    // old shared key this was 0 pairs / 0 tables for five minutes, and the
+    // result still looked like a complete answer.
+    expect(admin.queriedDictionary()).toBe(true)
+    expect(a.stats.phase_2.cached).toBe(false)
+    expect(a.stats.phase_2.discovered_pairs).toBe(ADMIN_VIEW.length)
+    expect(a.stats.phase_3.tables).toBe(ADMIN_VIEW.length)
+    expect(admin.queriedTablesMatching("u_acme_secret_engine").length).toBe(1)
+  })
+})
+
+describe("discovery cache — the cache still caches", () => {
+  test("the same tenant reuses its entry on a second scan", async () => {
+    const instanceUrl = "https://reuse.service-now.com"
+    const first = instanceFor(ADMIN_VIEW)
+    const second = instanceFor(ADMIN_VIEW)
+    const context = contextFor("tenant-a", instanceUrl)
+
+    const one = await scan(first, context)
+    const two = await scan(second, context)
+
+    expect(one.stats.phase_2.cached).toBe(false)
+    expect(two.stats.phase_2.cached).toBe(true)
+    expect(second.queriedDictionary()).toBe(false)
+    expect(two.stats.phase_2.discovered_pairs).toBe(ADMIN_VIEW.length)
+  })
+
+  test("two chats in one tenant share the entry — the key ignores the session", async () => {
+    const instanceUrl = "https://sessions.service-now.com"
+    const chatOne = instanceFor(ADMIN_VIEW)
+    const chatTwo = instanceFor(ADMIN_VIEW)
+    const base = contextFor("tenant-a", instanceUrl)
+
+    const one = await scan(chatOne, { ...base, sessionId: "user-42" })
+    const two = await scan(chatTwo, { ...base, sessionId: "user-99" })
+
+    expect(one.stats.phase_2.cached).toBe(false)
+    expect(two.stats.phase_2.cached).toBe(true)
+    expect(chatTwo.queriedDictionary()).toBe(false)
+  })
+})
+
+describe("discovery cache — bounded growth", () => {
+  // The TTL only gates freshness on READ: before pruning, an entry whose
+  // tenant never came back was never deleted, only ever overwritten. Each
+  // entry holds up to 5000 dictionary rows, and the credential-fingerprint
+  // fallback mints a new key on every OAuth token rotation, so "one entry per
+  // (tenant, instance)" was not a bound in the one long-lived process this
+  // matters in — the multi-tenant HTTP server.
+  afterAll(() => clearDiscoveryCache())
+
+  test("distinct tenants past the ceiling evict the oldest, not the newest", async () => {
+    clearDiscoveryCache()
+    const shared = "https://bounded.service-now.com"
+    const scanAs = (tenant: string) => scan(instanceFor(RESTRICTED_VIEW), contextFor(tenant, shared))
+
+    const first = "tenant-0000"
+    await scanAs(first)
+    expect((await scanAs(first)).stats.phase_2.cached).toBe(true)
+
+    // MAX_DISCOVERY_ENTRIES is 500; go past it with live (unexpired) entries
+    // so the age-out branch cannot do the work and only the ceiling can.
+    for (let i = 1; i <= 600; i++) await scanAs(`tenant-${String(i).padStart(4, "0")}`)
+
+    // The oldest is gone — a cache that never evicts would still hit here.
+    expect((await scanAs(first)).stats.phase_2.cached).toBe(false)
+    // The most recent is still there, so the eviction is oldest-first and the
+    // cache has not simply been emptied.
+    expect((await scanAs("tenant-0600")).stats.phase_2.cached).toBe(true)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/__tests__/discovery-cache-key.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/__tests__/discovery-cache-key.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tenant-scoping invariants for the blast-radius Phase-2 discovery cache key.
+ *
+ * `shared/deep-search.ts` holds the discovery cache in a process-global Map
+ * that nothing else scopes, so the key built here is the entire isolation
+ * boundary between tenants. These tests pin the property a future refactor is
+ * most likely to break quietly: two tenants must never produce the same key,
+ * and one tenant must keep producing the same key so the cache still works.
+ *
+ * The bug being pinned: the key used to be
+ * `context.sessionId || context.instanceUrl || "default"`, which put every
+ * tenant on a shared instance into one entry.
+ */
+
+import { describe, test, expect } from "@jest/globals"
+import { discoveryCacheKey } from "../snow_blast_radius_dependents"
+import { type ServiceNowContext } from "../../../shared/types"
+
+const SHARED_INSTANCE = "https://shared.service-now.com"
+
+const contextFor = (overrides: Partial<ServiceNowContext>): ServiceNowContext => ({
+  instanceUrl: SHARED_INSTANCE,
+  clientId: "oauth-client",
+  clientSecret: "oauth-secret",
+  ...overrides,
+})
+
+const tenantA = contextFor({ tenantId: "1042", origin: "http" })
+const tenantB = contextFor({ tenantId: "2087", origin: "http" })
+
+describe("discoveryCacheKey — tenant isolation", () => {
+  test("two tenants on the same instance never share a key", () => {
+    expect(discoveryCacheKey(tenantA)).not.toBe(discoveryCacheKey(tenantB))
+  })
+
+  test("the same tenant on the same instance always shares a key (the cache still caches)", () => {
+    expect(discoveryCacheKey(tenantA)).toBe(discoveryCacheKey(contextFor({ tenantId: "1042", origin: "http" })))
+  })
+
+  test("one tenant across two instances gets two keys", () => {
+    const otherInstance = contextFor({ tenantId: "1042", origin: "http", instanceUrl: "https://other.service-now.com" })
+    expect(discoveryCacheKey(tenantA)).not.toBe(discoveryCacheKey(otherInstance))
+  })
+
+  test("the session is not part of the key — two chats in one tenant reuse the entry", () => {
+    const chatOne = contextFor({ tenantId: "1042", origin: "http", sessionId: "user-42" })
+    const chatTwo = contextFor({ tenantId: "1042", origin: "http", sessionId: "user-99" })
+    expect(discoveryCacheKey(chatOne)).toBe(discoveryCacheKey(chatTwo))
+    expect(discoveryCacheKey(chatOne)).toBe(discoveryCacheKey(tenantA))
+  })
+
+  test("regression: the key is never the bare instance URL and never the literal 'default'", () => {
+    // Both were reachable before: `sessionId || instanceUrl || "default"`.
+    for (const ctx of [tenantA, tenantB, contextFor({ origin: "stdio", tenantId: "stdio" })]) {
+      expect(discoveryCacheKey(ctx)).not.toBe(SHARED_INSTANCE)
+      expect(discoveryCacheKey(ctx)).not.toBe("default")
+    }
+  })
+
+  test("every key carries its tenant in the first segment", () => {
+    expect(discoveryCacheKey(tenantA).split("\x00")[0]).toBe("1042")
+    expect(discoveryCacheKey(tenantB).split("\x00")[0]).toBe("2087")
+  })
+})
+
+describe("discoveryCacheKey — separator spoofing", () => {
+  test("a tenant id cannot smuggle the separator to land in another tenant's slot", () => {
+    const honest = contextFor({ tenantId: "1042", origin: "http" })
+    const spoofer = contextFor({ tenantId: `1042\x00${SHARED_INSTANCE}`, origin: "http", instanceUrl: "" })
+    expect(discoveryCacheKey(spoofer)).not.toBe(discoveryCacheKey(honest))
+  })
+
+  test("tenant ids that differ only in separator characters stay distinct", () => {
+    // A lossy `.replace(/[\x00:]/g, "_")` would map both of these to "1_2".
+    const colon = contextFor({ tenantId: "1:2", origin: "http" })
+    const nul = contextFor({ tenantId: "1\x002", origin: "http" })
+    expect(discoveryCacheKey(colon)).not.toBe(discoveryCacheKey(nul))
+  })
+
+  test("the shift that naive concatenation cannot survive: NUL moved between the two halves", () => {
+    // THIS is the shape that actually breaks a `${tenant}\x00${instance}` key.
+    // Both of these flatten to the identical string "1042\x00X\x00Y" without
+    // escaping, so tenant `1042\x00X` reads tenant `1042`'s entry. The two
+    // spoofing tests above pass on the unescaped implementation as well
+    // (their inputs differ in more than the separator's position), so without
+    // this case the escaping is unpinned.
+    const honest = contextFor({ tenantId: "1042", origin: "http", instanceUrl: "X\x00Y" })
+    const spoofer = contextFor({ tenantId: "1042\x00X", origin: "http", instanceUrl: "Y" })
+    expect(discoveryCacheKey(spoofer)).not.toBe(discoveryCacheKey(honest))
+  })
+})
+
+describe("discoveryCacheKey — transports", () => {
+  // Components are percent-encoded before being joined, so the key is opaque —
+  // assert the properties, and reconstruct rather than hand-writing the string.
+  const expectedKey = (tenant: string, instance: string): string =>
+    `${encodeURIComponent(tenant)}\x00${encodeURIComponent(instance)}`
+
+  test("stdio is single-tenant: a stable key, so the cache works across requests", () => {
+    const stdioOne = contextFor({ tenantId: "stdio", origin: "stdio" })
+    const stdioTwo = contextFor({ tenantId: "stdio", origin: "stdio", sessionId: "ses_abc" })
+    expect(discoveryCacheKey(stdioOne)).toBe(expectedKey("stdio", SHARED_INSTANCE))
+    expect(discoveryCacheKey(stdioTwo)).toBe(discoveryCacheKey(stdioOne))
+  })
+
+  test("stdio without an explicit tenantId still resolves to the stdio sentinel", () => {
+    expect(discoveryCacheKey(contextFor({ origin: "stdio" }))).toBe(expectedKey("stdio", SHARED_INSTANCE))
+  })
+
+  test("a tenant-less HTTP caller does not land in the stdio bucket", () => {
+    const unscoped = contextFor({ origin: "http" })
+    expect(discoveryCacheKey(unscoped)).not.toBe(discoveryCacheKey(contextFor({ origin: "stdio" })))
+    expect(discoveryCacheKey(unscoped).startsWith("cred\x00")).toBe(true)
+  })
+})
+
+describe("discoveryCacheKey — fail-closed fallback", () => {
+  // Reached only by an embedder calling the executor directly: both handlers
+  // refuse an HTTP request whose resolver left tenantId empty. It must still
+  // not degrade into a shared key.
+  const unscoped = (overrides: Partial<ServiceNowContext>): ServiceNowContext =>
+    contextFor({ origin: undefined, tenantId: undefined, ...overrides })
+
+  test("different credentials on the same instance get different keys", () => {
+    const one = unscoped({ clientId: "client-one", refreshToken: "rt-one" })
+    const two = unscoped({ clientId: "client-two", refreshToken: "rt-two" })
+    expect(discoveryCacheKey(one)).not.toBe(discoveryCacheKey(two))
+  })
+
+  test("the same credentials get the same key — bounded, one entry per identity", () => {
+    const one = unscoped({ refreshToken: "rt-one" })
+    const two = unscoped({ refreshToken: "rt-one" })
+    expect(discoveryCacheKey(one)).toBe(discoveryCacheKey(two))
+  })
+
+  test("a rotated refresh token is a different identity", () => {
+    expect(discoveryCacheKey(unscoped({ refreshToken: "rt-old" }))).not.toBe(
+      discoveryCacheKey(unscoped({ refreshToken: "rt-new" })),
+    )
+  })
+
+  test("basic-auth users on one shared OAuth app are not merged", () => {
+    const alice = unscoped({ username: "alice", password: "pw-alice" })
+    const bob = unscoped({ username: "bob", password: "pw-bob" })
+    expect(discoveryCacheKey(alice)).not.toBe(discoveryCacheKey(bob))
+  })
+
+  test("the fingerprint does not leak the secrets it is built from", () => {
+    const key = discoveryCacheKey(unscoped({ clientSecret: "super-secret-value", password: "hunter2" }))
+    expect(key).not.toContain("super-secret-value")
+    expect(key).not.toContain("hunter2")
+    expect(key).toMatch(/^cred\x00[0-9a-f]{64}$/)
+  })
+
+  test("two tenants sharing an instance's OAuth app are separated by their access token", () => {
+    // This is the only shape that actually reaches this branch in production.
+    // serac-platform's runOssBlastRadius() builds exactly this context — no
+    // tenantId, no origin — and takes clientId/clientSecret off the *instance*
+    // record, so two tenants pointed at one shared instance present identical
+    // OAuth client credentials. The access token is their only distinguishing
+    // secret; a fingerprint that omits it merges them into one cache entry and
+    // hands tenant B tenant A's private table names.
+    const platformContext = (accessToken: string): ServiceNowContext => ({
+      instanceUrl: SHARED_INSTANCE,
+      accessToken,
+      clientId: "instance-wide-client",
+      clientSecret: "instance-wide-secret",
+      sessionId: "org-33-7",
+    })
+    expect(discoveryCacheKey(platformContext("token-tenant-a"))).not.toBe(
+      discoveryCacheKey(platformContext("token-tenant-b")),
+    )
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/shared/deep-search.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/shared/deep-search.ts
@@ -84,6 +84,39 @@ interface DiscoveryCacheEntry {
 const discoveryCache = new Map<string, DiscoveryCacheEntry>()
 const DISCOVERY_TTL_MS = 5 * 60 * 1000
 
+/**
+ * Hard ceiling on distinct cache keys. The TTL only gated freshness on read:
+ * an expired entry was overwritten if the same key came back and otherwise
+ * retained forever. Each entry holds up to 5000 (table, field) rows, and the
+ * credential-fingerprint fallback in `discoveryCacheKey()` mints a fresh key
+ * on every OAuth token rotation, so "one entry per (tenant, instance)" was not
+ * in fact a bound. Prune on write, expired-first.
+ */
+const MAX_DISCOVERY_ENTRIES = 500
+
+function pruneDiscoveryCache(): void {
+  if (discoveryCache.size < MAX_DISCOVERY_ENTRIES) return
+  const now = Date.now()
+  for (const [key, value] of discoveryCache) {
+    if (value.expiresAt <= now) discoveryCache.delete(key)
+  }
+  // Every entry still live: evict oldest-first (Map iterates in insertion
+  // order) until back under the ceiling, so the cache cannot grow without
+  // limit even under continuous token rotation.
+  for (const key of discoveryCache.keys()) {
+    if (discoveryCache.size < MAX_DISCOVERY_ENTRIES) break
+    discoveryCache.delete(key)
+  }
+}
+
+/**
+ * Drop every cached discovery entry. Test-only seam — the cache is otherwise
+ * process-global, so a test that primes it would leak into the next one.
+ */
+export function clearDiscoveryCache(): void {
+  discoveryCache.clear()
+}
+
 /** Types in sys_dictionary.internal_type that indicate script-bearing fields. */
 const SCRIPT_INTERNAL_TYPES = ["script", "script_plain", "script_server", "xml", "condition_string"]
 
@@ -223,6 +256,7 @@ async function getDiscoveredPairs(
         internal_type: String(r.internal_type || ""),
       }))
       .filter((p: any) => p.table && p.field)
+    pruneDiscoveryCache()
     discoveryCache.set(cacheKey, { pairs, expiresAt: Date.now() + DISCOVERY_TTL_MS })
     return { pairs, cached: false }
   } catch {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/snow_blast_radius_dependents.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/blast-radius/snow_blast_radius_dependents.ts
@@ -15,9 +15,11 @@
  * (discovered dynamically via sys_dictionary).
  */
 
+import { createHash, randomBytes } from "crypto"
 import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
 import { getAuthenticatedClient } from "../../shared/auth.js"
 import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+import { resolveTenantScope, tenantScopedKey } from "../../shared/tenant-scope.js"
 import { ARTIFACT_TABLE_MAP } from "./shared/metadata-tables.js"
 import { searchDependents, type SearchPattern } from "./shared/deep-search.js"
 
@@ -42,6 +44,96 @@ const OUT_OF_SCOPE_SURFACES: string[] = [
 const SCOPE_CAVEAT =
   "Scan covers all script-bearing fields ServiceNow's sys_dictionary marks as script/condition. " +
   "Surfaces listed in out_of_scope_surfaces are NOT searched — verify those manually before any delete or rename decision."
+
+/**
+ * Per-process salt for the credential fingerprint below. Random per boot, so a
+ * digest carries no meaning outside this process and cannot be matched against
+ * a precomputed table if it ever surfaces in a heap dump. Immutable and
+ * tenant-agnostic: safe module-level state.
+ */
+const FINGERPRINT_SALT = randomBytes(16).toString("hex")
+
+/**
+ * Fingerprint of the identity whose ACLs decide what Phase 2 can see. Two
+ * callers share a fingerprint only when they are literally the same
+ * ServiceNow identity on the same instance, in which case a shared cache
+ * entry discloses nothing either side could not read itself.
+ *
+ * `accessToken` is in here and it is the field that matters most. The one
+ * embedder that reaches this fallback is serac-platform's
+ * `runOssBlastRadius()`, which passes `{instanceUrl, accessToken, clientId,
+ * clientSecret, sessionId}` and no tenantId. Its clientId/clientSecret come
+ * off the *instance* record, so two tenants pointed at one shared instance
+ * present identical OAuth client credentials — the access token is their only
+ * distinguishing secret. Leaving it out of the digest merged them into one
+ * cache entry and handed tenant B tenant A's private `u_*` table names.
+ *
+ * A rotated token yields a new fingerprint, i.e. a cold cache rather than a
+ * stale one. That is the safe direction, and `pruneDiscoveryCache()` in
+ * deep-search.ts caps the entries a rotating token can accumulate.
+ */
+const credentialFingerprint = (context: ServiceNowContext): string =>
+  createHash("sha256")
+    .update(
+      [
+        FINGERPRINT_SALT,
+        context.instanceUrl ?? "",
+        context.clientId ?? "",
+        context.clientSecret ?? "",
+        context.accessToken ?? "",
+        context.refreshToken ?? "",
+        context.username ?? "",
+        context.password ?? "",
+      ].join("\x00"),
+    )
+    .digest("hex")
+
+/**
+ * Key for the Phase-2 `sys_dictionary` discovery cache in deep-search.ts.
+ *
+ * That cache is a process-global Map, so this key *is* the isolation boundary.
+ * What it holds is every script-bearing (table, field) pair visible to the
+ * credentials that made the request — up to 5000 rows, custom `u_*` tables
+ * included. Sharing an entry across tenants breaks in both directions:
+ *
+ *   - confidentiality: tenant B inherits tenant A's schema and then issues
+ *     Phase-3 queries against A's private table names;
+ *   - correctness, and this is the worse one: a tenant whose integration user
+ *     sees little primes a short (or empty) pair list, and for the next five
+ *     minutes every other tenant on that instance silently scans zero
+ *     long-tail tables. Phase 1 still runs, so the answer looks complete —
+ *     an under-reported blast radius on the one tool whose output decides
+ *     "is it safe to delete this?".
+ *
+ * The correct axis is (tenant, instance), never session. Within a tenant every
+ * user authenticates as the same ServiceNow integration user per instance, so
+ * their dictionary view is identical and sharing is the whole point; a session
+ * id neither isolates tenants (it is not a tenant) nor reuses anything (a key
+ * per chat guarantees a cold cache). The previous key —
+ * `sessionId || instanceUrl || "default"` — got both halves wrong: it fell
+ * back to a bare instance URL that every tenant on a shared instance collides
+ * on, and to the literal `"default"` that every caller collides on.
+ */
+export const discoveryCacheKey = (context: ServiceNowContext): string => {
+  const tenant = resolveTenantScope(context)
+  // stdio resolves to the "stdio" sentinel: that transport is single-tenant by
+  // construction (one process, one user, one credential set), so in-process
+  // sharing across requests is legitimate there. HTTP always carries a real
+  // tenant id — handlers/call-tool.ts refuses the request otherwise.
+  //
+  // tenantScopedKey escapes both halves, so a tenant id containing the NUL
+  // separator cannot address another tenant's slot: tenant `1042` on instance
+  // `X\x00Y` and tenant `1042\x00X` on instance `Y` are distinct keys.
+  if (tenant) return tenantScopedKey(tenant, context.instanceUrl)
+  // No provable tenant (an embedder calling this executor directly). Falling
+  // back to a shared literal is exactly the leak described above, so fail
+  // closed onto the identity that actually governs visibility. Bounded: one
+  // entry per distinct credential set, not one per call. Colliding with the
+  // tenant branch would take a tenant literally named "cred" whose instanceUrl
+  // equals the digest — and FINGERPRINT_SALT is random per boot, so that
+  // digest is not predictable from outside the process.
+  return tenantScopedKey("cred", credentialFingerprint(context))
+}
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_blast_radius_dependents",
@@ -221,9 +313,10 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       return createErrorResult("Could not determine search patterns for the artifact")
     }
 
-    // Step 2: Deep search via 3-phase engine.
-    const cacheKey = context.sessionId || context.instanceUrl || "default"
-    const { dependents, stats } = await searchDependents(client, cacheKey, {
+    // Step 2: Deep search via 3-phase engine. The key scopes the shared
+    // Phase-2 discovery cache — see discoveryCacheKey() for why it is
+    // (tenant, instance) and not the session.
+    const { dependents, stats } = await searchDependents(client, discoveryCacheKey(context), {
       patterns,
       limit,
       scopeFilterSysId: search_scope === "same_app" && artifactScope ? artifactScope : undefined,

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/__tests__/tool-search-enablement.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/__tests__/tool-search-enablement.test.ts
@@ -1,0 +1,344 @@
+/**
+ * `tool_search` / `tool_execute`: session-enablement honesty and tenant scoping.
+ *
+ * Two properties are pinned here, both of which a refactor breaks silently:
+ *
+ *   1. The enabled-tools store is per (tenant, session). Two tenants that
+ *      happen to share a session id — the portal derives it from the portal
+ *      user id, so collisions across deployments are not exotic — must never
+ *      see each other's enablement.
+ *   2. `tool_search` only reports enabling what the next request will honour.
+ *      On a server whose catalog is registered non-deferred (which is what
+ *      `transports/http-entry.ts` does, deliberately) enabling changes
+ *      nothing, so the tool must not say it enabled anything.
+ *
+ * Everything runs against the real `MemoryToolSessionStore` — the same
+ * tenant-scoped store the HTTP transport installs — so the assertions are
+ * about real stored state, not about what the code intended to store.
+ */
+
+import { describe, test, expect, beforeEach, beforeAll, afterAll } from "@jest/globals"
+import { tool_search_exec, tool_execute_exec } from "../index"
+import { ToolSearch, setSessionStore } from "../../../shared/tool-search"
+import { FileToolSessionStore, MemoryToolSessionStore } from "../../../shared/tool-session-store"
+import { toolRegistry } from "../../../shared/tool-registry"
+import { listTools } from "../../../handlers/list-tools"
+import { MCPPromptManager } from "../../../../shared/mcp-prompt-manager"
+import { type RequestContext, type ServiceNowContext } from "../../../shared/types"
+
+const SESSION = "user-42"
+
+/** Same session id in both tenants — the collision the store must survive. */
+const tenantA: ServiceNowContext = {
+  instanceUrl: "https://tenant-a.service-now.com",
+  clientId: "a",
+  clientSecret: "a",
+  tenantId: "1042",
+  origin: "http",
+  sessionId: SESSION,
+}
+
+const tenantB: ServiceNowContext = { ...tenantA, instanceUrl: "https://tenant-b.service-now.com", tenantId: "2087" }
+
+const stdioContext: ServiceNowContext = {
+  instanceUrl: "https://dev12345.service-now.com",
+  clientId: "a",
+  clientSecret: "a",
+  tenantId: "stdio",
+  origin: "stdio",
+  sessionId: "ses_local",
+}
+
+const INDEXED = [
+  { id: "snow_query_incidents", description: "Query incidents", category: "itsm", keywords: ["incident"] },
+  { id: "snow_create_incident", description: "Create an incident", category: "itsm", keywords: ["incident"] },
+]
+
+const registerIndex = (deferred: boolean): void => {
+  ToolSearch.clearIndex()
+  ToolSearch.registerTools(INDEXED.map((entry) => ({ ...entry, deferred })))
+}
+
+beforeEach(() => {
+  // The tenant-scoped in-memory store the HTTP transport installs. Also keeps
+  // the suite off the developer's ~/.local/share tool-enablement files.
+  setSessionStore(new MemoryToolSessionStore())
+})
+
+afterAll(() => {
+  // `ToolSearch.clearIndex()` / `registerTools()` / `setSessionStore()` all
+  // mutate process globals. Put them back so a future suite that expects a
+  // populated index or the default file-backed store is not silently
+  // order-dependent on this one.
+  ToolSearch.clearIndex()
+  setSessionStore(new FileToolSessionStore())
+})
+
+describe("tool_search — a deferred catalog (stdio): enablement is real, so say so", () => {
+  beforeEach(() => registerIndex(true))
+
+  test("writes the hits to the session store and reports them", async () => {
+    const result = await tool_search_exec({ query: "incident" }, stdioContext)
+
+    expect(result.enabled).toBe(true)
+    expect(result.enabled_tools).toEqual(["snow_query_incidents", "snow_create_incident"])
+    expect(result.usage_hint).toContain("are now ENABLED for this session")
+    expect(result.tools.map((t: any) => t.status)).toEqual(["[ENABLED]", "[ENABLED]"])
+
+    const stored = await ToolSearch.getEnabledTools("ses_local", "stdio")
+    expect(Array.from(stored).sort()).toEqual(["snow_create_incident", "snow_query_incidents"])
+  })
+
+  test("reported status matches what the rest of the server will compute", async () => {
+    const result = await tool_search_exec({ query: "incident" }, stdioContext)
+    for (const tool of result.tools) {
+      expect(tool.status).toBe(await ToolSearch.getToolStatus("ses_local", tool.name, "stdio"))
+    }
+  })
+
+  test("enable:false changes nothing and claims nothing", async () => {
+    const result = await tool_search_exec({ query: "incident", enable: false }, stdioContext)
+
+    expect(result.enabled).toBe(false)
+    expect(result.usage_hint).not.toContain("ENABLED")
+    expect(result.tools.map((t: any) => t.status)).toEqual(["[DEFERRED]", "[DEFERRED]"])
+    expect((await ToolSearch.getEnabledTools("ses_local", "stdio")).size).toBe(0)
+  })
+
+  test("a later search reports tools an earlier search enabled", async () => {
+    await tool_search_exec({ query: "query incidents", limit: 1 }, stdioContext)
+    const second = await tool_search_exec({ query: "incident", enable: false }, stdioContext)
+
+    const byName = Object.fromEntries(second.tools.map((t: any) => [t.name, t.status]))
+    expect(byName["snow_query_incidents"]).toBe("[ENABLED]")
+    expect(byName["snow_create_incident"]).toBe("[DEFERRED]")
+  })
+})
+
+describe("tool_search — a non-deferred catalog (HTTP as shipped): claim nothing, store nothing", () => {
+  beforeEach(() => registerIndex(false))
+
+  test("does not touch session state", async () => {
+    const result = await tool_search_exec({ query: "incident" }, tenantA)
+
+    expect(result.enabled).toBe(false)
+    expect(result.enabled_tools).toEqual([])
+    expect((await ToolSearch.getEnabledTools(SESSION, "1042")).size).toBe(0)
+  })
+
+  test("does not tell the model it enabled anything", async () => {
+    const result = await tool_search_exec({ query: "incident" }, tenantA)
+
+    expect(result.usage_hint).not.toContain("ENABLED")
+    expect(result.usage_hint).toContain("No session state was changed")
+    expect(result.tools.map((t: any) => t.status)).toEqual(["[AVAILABLE]", "[AVAILABLE]"])
+  })
+})
+
+describe("tool_search — tenant scoping", () => {
+  beforeEach(() => registerIndex(true))
+
+  test("two tenants sharing a session id do not share enabled tools", async () => {
+    await tool_search_exec({ query: "incident" }, tenantA)
+
+    expect((await ToolSearch.getEnabledTools(SESSION, "1042")).size).toBe(2)
+    expect((await ToolSearch.getEnabledTools(SESSION, "2087")).size).toBe(0)
+
+    const forB = await tool_search_exec({ query: "incident", enable: false }, tenantB)
+    expect(forB.tools.map((t: any) => t.status)).toEqual(["[DEFERRED]", "[DEFERRED]"])
+  })
+
+  test("an HTTP request with no tenant refuses to enable rather than sharing a bucket", async () => {
+    const unscoped: ServiceNowContext = { ...tenantA, tenantId: undefined }
+    const result = await tool_search_exec({ query: "incident" }, unscoped)
+
+    expect(result.enabled).toBe(false)
+    expect(result.enabled_tools).toEqual([])
+    expect(result.usage_hint).toContain("no tenant scope")
+    expect(result.tools.map((t: any) => t.status)).toEqual(["[DEFERRED]", "[DEFERRED]"])
+    // Nothing was parked in the stdio sentinel bucket either.
+    expect((await ToolSearch.getEnabledTools(SESSION, "stdio")).size).toBe(0)
+  })
+
+  test("a request with no session id says the tools stayed deferred", async () => {
+    const sessionless: ServiceNowContext = { ...tenantA, sessionId: undefined }
+    const result = await tool_search_exec({ query: "incident" }, sessionless)
+
+    expect(result.enabled).toBe(false)
+    expect(result.usage_hint).toContain("no session id")
+    expect(result.usage_hint).not.toContain("are now ENABLED")
+    expect(result.tools.map((t: any) => t.status)).toEqual(["[DEFERRED]", "[DEFERRED]"])
+  })
+
+  test("stdio without an explicit tenant still gets its single-tenant bucket", async () => {
+    const result = await tool_search_exec({ query: "incident" }, { ...stdioContext, tenantId: undefined })
+
+    expect(result.enabled).toBe(true)
+    expect((await ToolSearch.getEnabledTools("ses_local", "stdio")).size).toBe(2)
+  })
+})
+
+describe("tool_execute — the enablement gate is tenant-scoped too", () => {
+  beforeAll(async () => {
+    await toolRegistry.initialize()
+  })
+
+  beforeEach(() => {
+    ToolSearch.clearIndex()
+    ToolSearch.registerTools([
+      {
+        id: "snow_query_table",
+        description: "Query any table",
+        category: "operations",
+        keywords: ["query", "table"],
+        deferred: true,
+      },
+    ])
+  })
+
+  test("a tool enabled by one tenant is not executable by another with the same session", async () => {
+    await tool_search_exec({ query: "snow_query_table" }, tenantA)
+    expect(await ToolSearch.getToolStatus(SESSION, "snow_query_table", "1042")).toBe("[ENABLED]")
+
+    const result = await tool_execute_exec({ tool: "snow_query_table", args: { table: "incident" } }, tenantB)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("must be enabled first")
+    expect(result.status).toBe("[DEFERRED]")
+  })
+
+  test("a tenant-less HTTP request cannot execute a deferred tool at all", async () => {
+    await tool_search_exec({ query: "snow_query_table" }, tenantA)
+
+    const result = await tool_execute_exec(
+      { tool: "snow_query_table", args: { table: "incident" } },
+      { ...tenantA, tenantId: undefined },
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("must be enabled first")
+  })
+
+  test("a tenant-less request does not INHERIT the stdio bucket that a real stdio session filled", async () => {
+    // The test above passes even without the fail-closed rule, because the
+    // bucket a non-failing version falls back into ("stdio") happens to be
+    // empty there — it refuses for the wrong reason. Fill that bucket under
+    // the SAME session id first, and only a genuinely fail-closed
+    // implementation still refuses.
+    await tool_search_exec({ query: "snow_query_table" }, { ...stdioContext, sessionId: SESSION })
+    expect(await ToolSearch.getToolStatus(SESSION, "snow_query_table", "stdio")).toBe("[ENABLED]")
+
+    const result = await tool_execute_exec(
+      { tool: "snow_query_table", args: { table: "incident" } },
+      { ...tenantA, tenantId: undefined },
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("must be enabled first")
+  })
+})
+
+describe("tool_search — the registry-fallback branch", () => {
+  // `searchResults.length === 0` sends tool_search to a direct registry scan.
+  // Hits there usually have NO index entry, and both list-tools.ts and
+  // canExecuteTool() treat an unknown tool as deferred — so they DO need
+  // enabling. Nothing exercised this branch, which left the `?? true` default
+  // in enablementIsHonoured() free to become `?? false` with a green suite.
+  beforeAll(async () => {
+    await toolRegistry.initialize()
+  })
+
+  beforeEach(() => {
+    // A populated index that cannot match the query below, so the search falls
+    // through to the registry while `indexStats.total > 0` stays true.
+    ToolSearch.clearIndex()
+    ToolSearch.registerTools([
+      { id: "snow_query_incidents", description: "Query incidents", category: "itsm", keywords: [], deferred: true },
+    ])
+  })
+
+  test("enables registry hits that have no index entry, and says so", async () => {
+    const result = await tool_search_exec({ query: "snow_query_table" }, stdioContext)
+
+    expect(ToolSearch.getToolFromIndex("snow_query_table")).toBeUndefined()
+    expect(result.enabled).toBe(true)
+    expect(result.enabled_tools).toContain("snow_query_table")
+    expect(result.usage_hint).toContain("are now ENABLED for this session")
+
+    const stored = await ToolSearch.getEnabledTools("ses_local", "stdio")
+    expect(stored.has("snow_query_table")).toBe(true)
+  })
+
+  test("what it enabled there is executable — the two paths agree on 'unknown means deferred'", async () => {
+    const before = await tool_execute_exec({ tool: "snow_query_table", args: {} }, stdioContext)
+    expect(before.success).toBe(false)
+    expect(before.error).toContain("must be enabled first")
+
+    await tool_search_exec({ query: "snow_query_table" }, stdioContext)
+
+    // Past the gate now. The executor itself fails on credentials (no live
+    // instance), which is a different failure and the one we want to see.
+    const after = await tool_execute_exec({ tool: "snow_query_table", args: {} }, stdioContext)
+    expect(after.error ?? "").not.toContain("must be enabled first")
+  })
+})
+
+describe("tool_search writes the scope that tools/list reads", () => {
+  // The regression this pins: the writer resolved its scope with
+  // `encodeURIComponent(tenantId)` while both readers used the raw id, so on a
+  // tenant id containing a character encodeURIComponent touches, tool_search
+  // reported [ENABLED] and the very next tools/list omitted the tool. The
+  // portal's deriveTenantId() emits `c:<customerId>` / `o:<organizationId>`,
+  // and ":" is exactly such a character — so this was production-shaped, not
+  // theoretical. Driving the real listTools handler is the point: asserting
+  // against ToolSearch directly would just re-run the writer's own arithmetic.
+  const COLON_TENANT = "c:1042"
+
+  const contextWithTenant = (tenantId: string): RequestContext => ({
+    sessionId: SESSION,
+    origin: "http",
+    serviceNow: {
+      instanceUrl: "https://tenant-a.service-now.com",
+      clientId: "a",
+      clientSecret: "a",
+      tenantId,
+      origin: "http",
+      sessionId: SESSION,
+    },
+  })
+
+  const listFor = async (tenantId: string): Promise<string[]> => {
+    const handler = listTools({
+      resolveContext: async () => contextWithTenant(tenantId),
+      promptManager: new MCPPromptManager("test"),
+    })
+    const response = await handler({})
+    return response.tools.map((tool: any) => tool.name)
+  }
+
+  beforeAll(async () => {
+    await toolRegistry.initialize()
+  })
+
+  beforeEach(() => {
+    ToolSearch.clearIndex()
+    ToolSearch.registerTools([
+      { id: "snow_query_table", description: "Query any table", category: "operations", keywords: [], deferred: true },
+    ])
+  })
+
+  test("a tool enabled for a colon-bearing tenant actually appears in that tenant's tools/list", async () => {
+    expect(await listFor(COLON_TENANT)).not.toContain("snow_query_table")
+
+    const search = await tool_search_exec({ query: "snow_query_table" }, contextWithTenant(COLON_TENANT).serviceNow)
+    expect(search.enabled_tools).toContain("snow_query_table")
+    expect(search.tools.map((t: any) => t.status)).toContain("[ENABLED]")
+
+    expect(await listFor(COLON_TENANT)).toContain("snow_query_table")
+  })
+
+  test("and it does not appear for a different tenant sharing the session id", async () => {
+    await tool_search_exec({ query: "snow_query_table" }, contextWithTenant(COLON_TENANT).serviceNow)
+    expect(await listFor("c:2087")).not.toContain("snow_query_table")
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
@@ -15,12 +15,37 @@
  * - Enabled tools are persisted to disk and restored on restart
  * - This allows filtering tools/list to only show enabled tools
  *
+ * ...but only where enablement is actually honoured. See
+ * `enablementIsHonoured()` below: on a server that registered its catalog as
+ * non-deferred (which is exactly what transports/http-entry.ts does, so the
+ * portal gets the full tool list) enabling a tool changes nothing, and
+ * `tool_search` must not report that it did.
+ *
+ * Transport split, stated once:
+ * - stdio is single-tenant — one process, one user — so per-session state is
+ *   real state and lives on disk (`FileToolSessionStore`).
+ * - HTTP is multi-tenant — one process, every customer — so a request we
+ *   cannot place in a tenant gets no shared session state at all.
+ *
+ * The enabled-tools store is reached through `resolveTenantScope()` from
+ * `shared/tenant-scope.ts` here AND in both of its readers
+ * (`handlers/list-tools.ts`, `handlers/call-tool.ts`) — writer and readers have
+ * to agree on the scope string or this tool reports `[ENABLED]` for tools the
+ * next `tools/list` omits. Flat cache keys elsewhere in the package
+ * (`shared/auth.ts`, `shared/scripted-exec.ts`, `shared/update-set-guard.ts`,
+ * `tools/blast-radius/.../deep-search.ts`) compose that scope with
+ * `tenantScopedKey()`. Note what is NOT claimed: `handlers/call-tool.ts`
+ * deliberately skips the deferred check on HTTP (the portal budgets tools
+ * client-side), so the enabled set is a stdio mechanism that HTTP merely
+ * refuses to corrupt.
+ *
  * @see https://www.anthropic.com/engineering/advanced-tool-use
  */
 
 import { type MCPToolDefinition, type ServiceNowContext } from "../../shared/types.js"
 import { toolRegistry } from "../../shared/tool-registry.js"
 import { ToolSearch } from "../../shared/tool-search.js"
+import { STDIO_TENANT, resolveTenantScope } from "../../shared/tenant-scope.js"
 import { isWriteTool } from "../../shared/instance-map-hook.js"
 import {
   guardKey,
@@ -57,12 +82,21 @@ This tool searches through ALL 235+ available tools including:
 - Reporting (dashboards, KPIs, reports)
 - And many more specialized tools
 
-IMPORTANT: After this tool returns, the found tools become IMMEDIATELY AVAILABLE.
-You can call them directly via tool_execute by their exact tool name.
+Each hit carries a status, and that status — not this description — is the
+authority on whether you can call it:
+- [AVAILABLE] — already callable on this server; nothing had to be enabled.
+- [ENABLED]   — deferred, and enabled for this session (by this call or an
+                earlier one). Callable now.
+- [DEFERRED]  — still NOT callable. This happens when the request carries no
+                session id, or no resolvable tenant on a multi-tenant server;
+                usage_hint says which. tool_execute will refuse it.
+
+The response also reports what this call actually changed: enabled_tools lists
+the tools it wrote into session state, and is empty when it wrote nothing.
 
 Example workflow:
 1. tool_search({query: "incident query"})
-   → Returns: snow_query_incidents, snow_query_table, ... [ENABLED]
+   → Returns: snow_query_incidents [ENABLED], snow_query_table [ENABLED]
 2. tool_execute({tool: "snow_query_incidents", args: {query: "priority=1"}})
    → Executes the tool and returns results`,
   inputSchema: {
@@ -81,7 +115,8 @@ Example workflow:
       enable: {
         type: "boolean",
         description:
-          "Enable found tools for this session (default: true). When enabled, tools are marked [ENABLED] and can be called directly.",
+          "Enable found deferred tools for this session (default: true). Only tools this server actually gates on the enabled set are written; " +
+          "on a server that lists its whole catalog there is nothing to enable and the hits come back [AVAILABLE]. Set false to search without touching session state.",
         default: true,
       },
     },
@@ -101,16 +136,127 @@ function allowedOnTransport(definition: { transports?: string[] } | undefined, o
   return transports.includes(origin ?? "http")
 }
 
+/**
+ * Does enabling this tool change anything the rest of the server will honour?
+ *
+ * Only two kinds of tool are gated on the enabled-set:
+ *   - index entries flagged `deferred: true` — handlers/list-tools.ts hides
+ *     them until they are enabled, and canExecuteTool() refuses them;
+ *   - tools missing from the index entirely — both of those code paths
+ *     default an unknown tool to deferred.
+ *
+ * Everything else is already listed and already callable, so writing it into
+ * the session store is a write nobody reads. `transports/http-entry.ts`
+ * registers the entire catalog with `deferred: false` (deliberately: the
+ * portal does its own client-side tool budgeting), which means on the shipped
+ * HTTP server this returns false for every tool and `tool_search` stops
+ * touching session state altogether — matching the "no session state is
+ * retained between requests" contract in transports/http.ts.
+ */
+const enablementIsHonoured = (toolId: string): boolean => ToolSearch.getToolFromIndex(toolId)?.deferred ?? true
+
+interface EnablementOutcome {
+  /** Tool IDs actually written to the session store by this call. */
+  enabled: string[]
+  /** Everything enabled for this (tenant, session) after the write. */
+  enabledSet: Set<string>
+  /** Hits that needed enabling but did not get it — see `reason`. */
+  pending: number
+  reason: "enabled" | "nothing-deferred" | "no-session" | "no-tenant-scope" | "not-requested"
+}
+
+/**
+ * Write the subset of `toolIds` whose enablement is honoured, then read the
+ * store back so reported statuses come from the store rather than from what
+ * we hoped we did.
+ *
+ * Fail closed on a missing tenant scope: enabling into a shared bucket is how
+ * one tenant ends up steering another tenant's tool list, so we skip the write
+ * and report the refusal instead of quietly claiming success.
+ */
+async function applyEnablement(
+  toolIds: string[],
+  sessionId: string | undefined,
+  tenantScope: string | undefined,
+  enableRequested: boolean,
+): Promise<EnablementOutcome> {
+  const honoured = toolIds.filter(enablementIsHonoured)
+  // Read the store even when we write nothing: a tool an earlier tool_search
+  // enabled is still [ENABLED], and saying otherwise is the same class of lie.
+  const readEnabled = async (): Promise<Set<string>> =>
+    sessionId && tenantScope ? await ToolSearch.getEnabledTools(sessionId, tenantScope) : new Set<string>()
+
+  if (!enableRequested) {
+    return { enabled: [], enabledSet: await readEnabled(), pending: 0, reason: "not-requested" }
+  }
+  if (honoured.length === 0) {
+    return { enabled: [], enabledSet: await readEnabled(), pending: 0, reason: "nothing-deferred" }
+  }
+  if (!sessionId) {
+    return { enabled: [], enabledSet: new Set<string>(), pending: honoured.length, reason: "no-session" }
+  }
+  if (!tenantScope) {
+    return { enabled: [], enabledSet: new Set<string>(), pending: honoured.length, reason: "no-tenant-scope" }
+  }
+  await ToolSearch.enableTools(sessionId, honoured, tenantScope)
+  console.error(`[tool_search] Enabled ${honoured.length} deferred tool(s) for ${tenantScope}/${sessionId}`)
+  return { enabled: honoured, enabledSet: await readEnabled(), pending: 0, reason: "enabled" }
+}
+
+/**
+ * Status label for one hit, derived from the same two facts the rest of the
+ * server uses (`ToolSearch.getToolStatus`): is it deferred, and is it in this
+ * (tenant, session)'s enabled set.
+ */
+const statusFor = (toolId: string, enabledSet: Set<string>): "[AVAILABLE]" | "[ENABLED]" | "[DEFERRED]" => {
+  if (!enablementIsHonoured(toolId)) return "[AVAILABLE]"
+  return enabledSet.has(toolId) ? "[ENABLED]" : "[DEFERRED]"
+}
+
+/**
+ * The sentence appended to `usage_hint`. It states what this call did to
+ * session state — including "nothing", which is the honest answer on a server
+ * whose catalog is not deferred.
+ */
+const enablementNote = (outcome: EnablementOutcome, firstTool: string | undefined): string => {
+  if (outcome.reason === "enabled") {
+    return (
+      `\n\n✓ ${outcome.enabled.length} tool(s) are now ENABLED for this session.\n` +
+      `Call them via tool_execute. Example:\ntool_execute({tool: "${outcome.enabled[0]}", args: {...}})`
+    )
+  }
+  if (outcome.reason === "no-tenant-scope") {
+    return (
+      `\n\n⚠ ${outcome.pending} deferred tool(s) were NOT enabled: this request carries no tenant scope, ` +
+      `and session state shared across tenants is a leak. Re-issue with a resolved tenantId (HTTP) or over stdio.`
+    )
+  }
+  if (outcome.reason === "no-session") {
+    return (
+      `\n\n⚠ ${outcome.pending} deferred tool(s) were NOT enabled: this request carries no session id, ` +
+      `so there is nothing to attach the enablement to. They stay [DEFERRED] and tool_execute will refuse them.`
+    )
+  }
+  if (outcome.reason === "nothing-deferred") {
+    return (
+      `\n\nNo session state was changed — these tools are already available on this server. ` +
+      `Call them directly: tool_execute({tool: "${firstTool ?? "snow_query_table"}", args: {...}})`
+    )
+  }
+  return ""
+}
+
 export async function tool_search_exec(
   args: { query: string; limit?: number; enable?: boolean },
   context: ServiceNowContext,
 ): Promise<any> {
   const limit = args.limit || 10
-  const enableTools = args.enable !== false // Default to true
+  const enableRequested = args.enable !== false // Default to true
   const sessionId = context.sessionId
   // Tenant-scope every ToolSearch call so two HTTP tenants with the same
-  // session ID cannot enable each other's tools. Stdio fallback is "stdio".
-  const tenantId = context.tenantId ?? "stdio"
+  // session ID cannot enable each other's tools. `undefined` means the caller
+  // cannot be placed in a tenant — it then gets no shared session state.
+  const tenantScope = resolveTenantScope(context)
 
   // Use ToolSearch.search() for consistent behavior with snow-flow
   // This searches the tool index populated at server startup
@@ -167,12 +313,16 @@ export async function tool_search_exec(
       }
     }
 
-    // Enable and format fallback results
-    if (enableTools && sessionId) {
-      const toolNames = fallbackResults.map((r) => r.tool.name)
-      await ToolSearch.enableTools(sessionId, toolNames, tenantId)
-      console.error(`[tool_search] Enabled ${toolNames.length} tools for session ${sessionId}`)
-    }
+    // Enable and format fallback results. These hits come from the registry,
+    // not the index, so many of them have no index entry at all — those DO
+    // need enabling (list-tools and canExecuteTool treat unknown tools as
+    // deferred), which is why the decision is per-tool and not per-branch.
+    const outcome = await applyEnablement(
+      fallbackResults.map((r) => r.tool.name),
+      sessionId,
+      tenantScope,
+      enableRequested,
+    )
 
     const formattedTools = fallbackResults.map((r, i) => {
       const params = r.tool.inputSchema?.properties || {}
@@ -182,11 +332,10 @@ export async function tool_search_exec(
         const type = prop.type || "any"
         return `    ${isRequired ? "*" : ""}${name}: ${type}${prop.description ? ` - ${prop.description.substring(0, 80)}` : ""}`
       })
-      const status = enableTools && sessionId ? "[ENABLED]" : "[AVAILABLE]"
       return {
         rank: i + 1,
         name: r.tool.name,
-        status,
+        status: statusFor(r.tool.name, outcome.enabledSet),
         domain: r.domain,
         description: r.tool.description.substring(0, 200) + (r.tool.description.length > 200 ? "..." : ""),
         parameters: paramList.length > 0 ? paramList.slice(0, 5) : ["(no parameters)"],
@@ -194,29 +343,32 @@ export async function tool_search_exec(
       }
     })
 
-    const enabledMsg =
-      enableTools && sessionId
-        ? `\n\n✓ ${fallbackResults.length} tool(s) are now ENABLED for this session.\nCall them via tool_execute. Example:\ntool_execute({tool: "${fallbackResults[0]?.tool.name}", args: {...}})`
-        : ""
+    const enabledMsg = enablementNote(outcome, fallbackResults[0]?.tool.name)
 
     return {
       success: true,
       query: args.query,
       count: fallbackResults.length,
-      enabled: enableTools && !!sessionId,
+      // Reports what this call did to session state, not what it was asked to do.
+      enabled: outcome.enabled.length > 0,
+      enabled_tools: outcome.enabled,
       sessionId: sessionId || null,
       tools: formattedTools,
       usage_hint: `To use a tool, call: tool_execute({tool: "${fallbackResults[0]?.tool.name}", args: {...}})${enabledMsg}`,
     }
   }
 
-  // Process results from ToolSearch.search()
-  // Enable found tools for this session if requested and sessionId is available
-  if (enableTools && sessionId) {
-    const toolIDs = searchResults.map((t) => t.id)
-    await ToolSearch.enableTools(sessionId, toolIDs, tenantId)
-    console.error(`[tool_search] Enabled ${toolIDs.length} tools for session ${sessionId}`)
-  }
+  // Process results from ToolSearch.search().
+  // Only the deferred hits are written to the session store — enabling a tool
+  // that is already listed and already callable is a write nobody reads, and
+  // reporting it as "now ENABLED" would be a promise the next request cannot
+  // keep. See enablementIsHonoured().
+  const outcome = await applyEnablement(
+    searchResults.map((t) => t.id),
+    sessionId,
+    tenantScope,
+    enableRequested,
+  )
 
   // Format results with schema info from toolRegistry
   const formattedTools = searchResults.map((entry, i) => {
@@ -231,13 +383,12 @@ export async function tool_search_exec(
       return `    ${isRequired ? "*" : ""}${name}: ${type}${prop.description ? ` - ${prop.description.substring(0, 80)}` : ""}`
     })
 
-    // Determine status based on deferred flag and enable setting
-    const status = entry.deferred ? (enableTools && sessionId ? "[ENABLED]" : "[DEFERRED]") : "[AVAILABLE]"
-
     return {
       rank: i + 1,
       name: entry.id,
-      status,
+      // Read out of the session store, so [ENABLED] also covers tools a
+      // previous tool_search in this session enabled.
+      status: statusFor(entry.id, outcome.enabledSet),
       domain: entry.category,
       description: entry.description + (entry.description.length >= 200 ? "..." : ""),
       parameters: paramList.length > 0 ? paramList.slice(0, 5) : ["(no parameters)"],
@@ -245,17 +396,15 @@ export async function tool_search_exec(
     }
   })
 
-  // Build enabled message (consistent with snow-flow)
-  const enabledMsg =
-    enableTools && sessionId
-      ? `\n\n✓ ${searchResults.length} tool(s) are now ENABLED for this session.\nCall them via tool_execute. Example:\ntool_execute({tool: "${searchResults[0]?.id}", args: {...}})`
-      : ""
+  const enabledMsg = enablementNote(outcome, searchResults[0]?.id)
 
   return {
     success: true,
     query: args.query,
     count: searchResults.length,
-    enabled: enableTools && !!sessionId,
+    // Reports what this call did to session state, not what it was asked to do.
+    enabled: outcome.enabled.length > 0,
+    enabled_tools: outcome.enabled,
     sessionId: sessionId || null,
     tools: formattedTools,
     usage_hint: `To use a tool, call: tool_execute({tool: "${searchResults[0]?.id}", args: {...}})${enabledMsg}`,
@@ -307,8 +456,8 @@ export async function tool_execute_exec(
   const toolName = args.tool
   const toolArgs = args.args || {}
   const sessionId = context.sessionId
-  // See tool_search_exec — tenantId scopes every ToolSessionStore lookup.
-  const tenantId = context.tenantId ?? "stdio"
+  // See tool_search_exec — the tenant scope keys every ToolSessionStore lookup.
+  const tenantScope = resolveTenantScope(context)
 
   // Get tool from registry
   const tool = toolRegistry.getTool(toolName)
@@ -388,10 +537,16 @@ export async function tool_execute_exec(
     }
   }
 
-  // Check if tool is deferred and needs to be enabled first
-  const canExecute = await ToolSearch.canExecuteTool(sessionId, toolName, tenantId)
+  // Check if tool is deferred and needs to be enabled first.
+  // Without a provable tenant we must not read some other tenant's enabled
+  // set, so we look the tool up with no session: always-available tools still
+  // run, deferred ones fail closed. (`tenantScope ?? STDIO_TENANT` is then
+  // never consulted — no session means no store lookup.)
+  const enablementSession = tenantScope ? sessionId : undefined
+  const storeScope = tenantScope ?? STDIO_TENANT
+  const canExecute = await ToolSearch.canExecuteTool(enablementSession, toolName, storeScope)
   if (!canExecute) {
-    const toolStatus = await ToolSearch.getToolStatus(sessionId, toolName, tenantId)
+    const toolStatus = await ToolSearch.getToolStatus(enablementSession, toolName, storeScope)
     const queryHint = toolName.replace("snow_", "").replace(/_/g, " ")
     return {
       success: false,


### PR DESCRIPTION
Targets `chore/extract-skills-package` (#274), not main — it builds on the skills/prompts separation.

## The release has been silently dead since 2026-06-08

`tsconfig.build.json` asked for `bun-types` while the package never declared `@types/bun` — the only one of 21 packages that didn't. So `tsc` failed `TS2688`, `build-for-publish.ts` aborted before rewriting exports, and `publish-npm.yml` carried `continue-on-error: true`. **Every release went green while publishing nothing.**

serac-platform pins `0.1.0` and imports `./blast-radius`, so it has been running two-month-old MCP code, and nothing shipped from this repo could reach it. That is the "platform consumes the OSS" contract, broken without a single red tick.

Now: the package builds from its own directory with its own toolchain, and the publish prep verifies its own output (`rewrote 27 published entrypoints to dist/ — all present`) instead of assuming. `publish-mcp.yml` releases on its own trigger, versioned from its own `package.json` rather than `packages/opencode`, and gates on `dist` existing. The step is removed from opencode's workflow so there is one path. **0.2.0**, because 0.1.0 is taken.

## State: the premise was half wrong, and the half that was wrong mattered

The investigation disproved my framing. `sessionId` **is** populated on HTTP, and the enabled-tools store **is** tenant-scoped and does persist across requests. Three narrower things were actually broken:

| | What was wrong |
|---|---|
| `handlers/call-tool.ts` | Passed `sessionId` on the **meta** dispatch path, dropped it on the **direct** path — which is the path production uses. The same tool saw two different contexts depending on how it was called. |
| blast-radius cache | Keyed on `sessionId ?? instanceUrl ?? "default"`. Two tenants on a shared instance shared a cache — a real cross-tenant leak. Re-keyed on `(tenant, instance)`. |
| `tool_search` | Told users "N tools are now ENABLED for this session" while the HTTP index marks everything `deferred: false`, so nothing ever read the set. Write-only. A tool must not claim an effect the next request will not honour. |

The endpoint-cache sanitiser was lossy the same way — it replaced `:` and NUL with `_`, so `c:1042` and `c_1042` collided. `tenantScopedKey` escapes instead, which is injective.

## Verified by running it

- `bun run build` exits 0, emits `dist` for all 27 entrypoints
- `npm pack`, install the tarball **outside the repo**, `import "@serac-labs/servicenow-mcp/blast-radius"` → exactly the **14 symbols** serac-platform destructures
- `bun test` **163 pass / 0 fail** (was 104 — the MCP's tests also never ran in CI; there was no `test:ci`)
- `bun turbo typecheck` 25/25

## What only you can do

The npm **trusted-publishing binding** for `@serac-labs/servicenow-mcp` has to be created in the npm UI before the first release. And only an actual run proves the workflow end to end — I can parse the YAML and check the gates, not execute Actions.

## Honest gaps

One builder agent died on its output schema after writing its files, so `publish-mcp.yml` exists but its own report does not. I read and ran what I could; the workflow's real behaviour is unproven until it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)