### PR TITLE
ci: make releases deliberate, and stop them dying quietly

### DIFF
--- a/.github/workflows/publish-npm-test.yml
+++ b/.github/workflows/publish-npm-test.yml
@@ -46,8 +46,14 @@ jobs:
         with:
           node-version: "20"
 
+      # Pinned to a major, not `@latest`. npm 12 raised its floor to node >= 22
+      # and `@latest` picked it up the day it shipped, which killed this job with
+      # EBADENGINE in 27 seconds — and it stayed dead, because a release that
+      # fails is only noticed when someone goes looking. A major pin still clears
+      # the >= 11.5.1 that OIDC trusted publishing needs, without an engine
+      # requirement moving underneath us again.
       - name: Upgrade npm (required for OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Configure npm for OIDC publishing
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,13 +18,15 @@ name: Release
 #   postinstall.cjs -> downloads serac-core-<suffix>.{tar.gz,zip} for v<version>, verifies, extracts to bin/.opencode
 #   bin/opencode    -> execs bin/.opencode (its `cached` hook)
 
+# TRIGGER: tags only. Until 2026-08-15 this also fired on every push to main,
+# and "Determine release channel" mapped main straight to channel=stable /
+# npm_tag=latest — so any merge published a stable CLI release to `latest`
+# without anyone deciding to. That is how you ship by accident. A release is a
+# decision; tag it, or dispatch it.
 on:
   push:
     tags:
       - "v*"
-    branches:
-      - main
-      - dev
   workflow_dispatch:
     inputs:
       version:
@@ -64,6 +66,8 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
             echo "🏷️ Tag push - stable release"
           elif [[ $GITHUB_REF == refs/heads/main || $GITHUB_REF == refs/heads/production ]]; then
+            # Only reachable via workflow_dispatch now that the branch trigger
+            # is gone. Kept so a deliberate dispatch from main still works.
             echo "channel=stable" >> $GITHUB_OUTPUT
             echo "npm_tag=latest" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
@@ -84,8 +88,14 @@ jobs:
         with:
           node-version: "20"
 
+      # Pinned to a major, not `@latest`. npm 12 raised its floor to node >= 22
+      # and `@latest` picked it up the day it shipped, which killed this job with
+      # EBADENGINE in 27 seconds — and it stayed dead, because a release that
+      # fails is only noticed when someone goes looking. A major pin still clears
+      # the >= 11.5.1 that OIDC trusted publishing needs, without an engine
+      # requirement moving underneath us again.
       - name: Upgrade npm (required for OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Configure npm for OIDC publishing
         # Trusted Publisher is wired up on @serac-labs/core, so OIDC

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -8,9 +8,13 @@ name: Sync from opencode
 # compare link. On conflicts it notifies the same way. Nothing reaches main
 # without a human merge. The job never fails on a missing notification channel.
 
+# SCHEDULE REMOVED 2026-08-15. serac is being reduced to the ServiceNow MCP and
+# the skills; everything inherited from opencode is on its way out. A weekly job
+# that merges upstream back in works directly against that — it re-entangles the
+# code being detangled and generates review work for a base we are removing.
+# Left dispatchable rather than deleted: turning it back on is one click if the
+# direction changes, and the merge machinery here is not trivial to rebuild.
 on:
-  schedule:
-    - cron: "0 6 * * 1" # Mondays 06:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Three release pipelines turned out to be silently dead this week. This addresses the pattern rather than the instances.

| Pipeline | State found | Cause |
|---|---|---|
| `@serac-labs/servicenow-mcp` | dead 2 months | build broke, `continue-on-error` hid it (fixed in #277) |
| `test.yml` | **never ran once** | Blacksmith runners we do not have (fixed in #276) |
| `@serac-labs/core` (the CLI) | dead since 2026-06-23 | `npm@latest` → npm 12 → node >= 22 → EBADENGINE |

Each failed in a way nobody was told about. That is the actual defect.

## 1. npm pinned to a major

`publish-npm.yml` and `publish-npm-test.yml` ran `npm install -g npm@latest`. npm 12 raised its floor to node >= 22 while these jobs run node 20, so the step dies in 27 seconds. A major pin still clears the >= 11.5.1 that OIDC trusted publishing needs, without an engine requirement moving underneath us again. `publish-mcp.yml` already carries the same pin.

## 2. The CLI release no longer fires on pushes to main

This is the one worth reading twice. `Determine release channel` maps `refs/heads/main` to `channel=stable` / `npm_tag=latest` — so **every merge to main published a stable CLI release to `latest`**, with no one deciding to. The broken npm step was the only thing preventing it.

Tags only now, plus `workflow_dispatch` for a deliberate out-of-band release. The main branch is still handled in the channel logic so a dispatch from main works; it is just no longer reachable by merging.

## 3. The weekly upstream sync is off its schedule

serac is being reduced to the ServiceNow MCP and the skills. A job that merges opencode back in every Monday works against that — it re-entangles the code being detangled and generates review work for a base we are removing. Left dispatchable rather than deleted, so turning it back on is one click if the direction changes.

## What this does not do

It does not release anything. Fixing the pin makes the workflow *capable* of running again; whether the CLI ships, and at what version, is now a decision that requires a tag.

Worth noting `@serac-labs/core` is at 1.1.9 from 2026-06-23. If the CLI is staying, it wants a release. If it is going with `packages/opencode`, that is the moment to say so rather than quietly leaving it stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)