### PR TITLE
chore(mcp): 0.2.1, to publish under the latest dist-tag

### DIFF
--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@serac-labs/servicenow-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unified ServiceNow MCP server (437 snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
`0.2.0` went out under `next` and production has been verified against it. Moving the tag afterwards needs a 2FA one-time password from the CLI, and the account has no authenticator to produce one — npm is also restricting the token-based bypass that used to cover this.

Publishing `0.2.1` straight to `latest` through the release workflow sidesteps that entirely rather than working around it: **OIDC trusted publishing authenticates as the GitHub workflow, not as a user**, so no token and no OTP is involved. That is exactly what the binding is for, and this is the first time the path to `latest` gets exercised at all.

## No code change

The content is `0.2.0` — the scripted-exec admin guard, the tenant-scoped blast-radius cache, the packaging fixes. That is already running in production via the platform's pinned `0.2.0`, so this changes nothing about what executes; it changes what `npm i @serac-labs/servicenow-mcp` resolves to.

Today it resolves to **June's 0.1.0**, which is now the only thing serac ships and does not contain the security guard.

## After merge

Actions → *Publish servicenow-mcp* → Run workflow → `dist_tag: latest`.

Then `npm i @serac-labs/servicenow-mcp` in a clean directory should give 0.2.1 with `gs.hasRole('admin')` present in `dist/servicenow-mcp-unified/shared/scripted-exec.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)