### PR TITLE
feat(mcp): anonymous usage telemetry, stdio only

### DIFF
--- a/packages/servicenow-mcp/Dockerfile.mcp-http
+++ b/packages/servicenow-mcp/Dockerfile.mcp-http
@@ -49,6 +49,15 @@ COPY --from=builder /app /app
 USER bun
 
 ENV MCP_HTTP_PORT=8082
+
+# Belt and braces for the stdio-only telemetry rule. The HTTP entry point has
+# no import path to src/telemetry (see telemetry-stdio-only.test.ts), but this
+# image also contains the stdio entry, and only the CMD below keeps it
+# unreached — `docker run <image> bun run src/servicenow-mcp-unified/index.ts`,
+# or a compose file overriding `command:`, would emit pings from platform
+# infrastructure on behalf of tenants who installed nothing.
+ENV SERAC_TELEMETRY_DISABLED=1
+
 EXPOSE 8082
 
 # Health endpoint lives on /health — docker-compose healthcheck probes it.

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
@@ -19,6 +19,12 @@ import { startStdio } from "./transports/stdio.js"
 import * as dotenv from "dotenv"
 import * as path from "path"
 import { mcpDebug } from "../shared/mcp-debug.js"
+// Anonymous, content-free usage telemetry. This import lives in the stdio
+// entry point and nowhere else: the HTTP transport must never emit, because
+// it is the platform's multi-tenant server and its "sessions" are our own
+// infrastructure, not people who installed anything. See the module header
+// and transports/__tests__/telemetry-stdio-only.test.ts.
+import { AnonymousTelemetry } from "../telemetry/anonymous-telemetry.js"
 
 /**
  * Main entry point
@@ -82,24 +88,40 @@ async function main() {
       mcpDebug(`[Main] SNOW_TOOL_DOMAINS=${process.env.SNOW_TOOL_DOMAINS}`)
     }
 
-    // Bootstrap + connect stdio transport
-    const { stop } = await startStdio()
+    // Start the anonymous session ping. Deliberately after dotenv, so an
+    // opt-out written into a project's .env (DO_NOT_TRACK,
+    // SERAC_TELEMETRY_DISABLED) is honoured, and before the transport, so a
+    // session that dies during bootstrap is still counted. Never awaited.
+    AnonymousTelemetry.start()
 
-    // Graceful shutdown handlers
+    // Bootstrap + connect stdio transport
+    const { stop } = await startStdio({ onToolCall: AnonymousTelemetry.recordToolCall })
+
+    // Graceful shutdown handlers. The end ping is fired before `stop()` so it
+    // travels while the server closes, then given a capped moment to settle
+    // after — without that, `process.exit` kills the request mid-flight and
+    // the delivered-but-unconfirmed ping gets re-sent on the next launch as a
+    // duplicate. Nothing user-facing waits on this; the server is already down.
     process.on("SIGINT", async () => {
       mcpDebug("\n[Main] Received SIGINT, shutting down gracefully...")
+      AnonymousTelemetry.finish("interrupt")
       await stop()
+      await AnonymousTelemetry.settle()
       process.exit(0)
     })
 
     process.on("SIGTERM", async () => {
       mcpDebug("\n[Main] Received SIGTERM, shutting down gracefully...")
+      AnonymousTelemetry.finish("interrupt")
       await stop()
+      await AnonymousTelemetry.settle()
       process.exit(0)
     })
   } catch (error: any) {
     mcpDebug("[Main] Fatal error:", error.message)
     mcpDebug(error.stack)
+    AnonymousTelemetry.finish("error", error)
+    await AnonymousTelemetry.settle()
     process.exit(1)
   }
 }

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/__tests__/stdio-tool-counter.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/__tests__/stdio-tool-counter.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The stdio tool-call counter.
+ *
+ * `startStdio({ onToolCall })` calls this on every `tools/call` it resolves.
+ * These tests feed it the JSON-RPC request shapes the MCP SDK actually hands
+ * to the resolver, and run the result through the real telemetry session, to
+ * show that (a) lazy-mode `tool_execute` traffic is attributed to ServiceNow
+ * rather than to meta plumbing, and (b) only counts survive the trip.
+ */
+
+import { describe, test, expect } from "@jest/globals"
+import * as fs from "fs"
+import * as http from "http"
+import * as os from "os"
+import * as path from "path"
+import { AddressInfo } from "net"
+
+import { invokedToolName } from "../stdio.js"
+import { createSession, type TelemetryPayload } from "../../../telemetry/anonymous-telemetry.js"
+
+describe("invokedToolName", () => {
+  test("returns the tool for a direct call", () => {
+    expect(invokedToolName({ method: "tools/call", params: { name: "snow_query_table", arguments: { table: "incident" } } })).toBe(
+      "snow_query_table",
+    )
+  })
+
+  test("unwraps the lazy-mode tool_execute envelope", () => {
+    const request = {
+      method: "tools/call",
+      params: {
+        name: "tool_execute",
+        arguments: { tool: "snow_create_incident", args: { short_description: "printer on fire" } },
+      },
+    }
+    expect(invokedToolName(request)).toBe("snow_create_incident")
+  })
+
+  test("falls back to the wrapper when the envelope has no usable target", () => {
+    expect(invokedToolName({ method: "tools/call", params: { name: "tool_execute", arguments: {} } })).toBe("tool_execute")
+    expect(invokedToolName({ method: "tools/call", params: { name: "tool_execute", arguments: { tool: 42 } } })).toBe(
+      "tool_execute",
+    )
+  })
+
+  test("ignores everything that is not a tool call", () => {
+    expect(invokedToolName({ method: "tools/list" })).toBeUndefined()
+    expect(invokedToolName({ method: "prompts/get", params: { name: "whatever" } })).toBeUndefined()
+    expect(invokedToolName(undefined)).toBeUndefined()
+    expect(invokedToolName({ method: "tools/call", params: {} })).toBeUndefined()
+  })
+})
+
+describe("counter feeds telemetry as counts only", () => {
+  test("a realistic request stream becomes per-category totals", async () => {
+    const pings: TelemetryPayload[] = []
+    const bodies: string[] = []
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on("data", (c) => chunks.push(Buffer.from(c)))
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf-8")
+        bodies.push(raw)
+        pings.push(JSON.parse(raw) as TelemetryPayload)
+        res.statusCode = 200
+        res.end(JSON.stringify({ success: true }))
+      })
+    })
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    const stateDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "serac-stdio-counter-")), "state")
+
+    try {
+      const session = createSession({
+        env: { DO_NOT_TRACK: "", CI: "", SERAC_TELEMETRY_DISABLED: "" },
+        stateDir,
+        portalUrl: url,
+      })
+      const onToolCall = session.recordToolCall
+
+      // Exactly what the resolver sees during one working session.
+      const requests = [
+        { method: "tools/list" },
+        { method: "tools/call", params: { name: "tool_search", arguments: { query: "create incident" } } },
+        {
+          method: "tools/call",
+          params: { name: "tool_execute", arguments: { tool: "snow_create_incident", args: { short_description: "vpn down" } } },
+        },
+        {
+          method: "tools/call",
+          params: { name: "tool_execute", arguments: { tool: "snow_query_table", args: { table: "incident", query: "active=true" } } },
+        },
+        { method: "tools/call", params: { name: "snow_update_set_create", arguments: { name: "STORY-42" } } },
+      ]
+
+      session.start()
+      for (const request of requests) {
+        const invoked = invokedToolName(request)
+        if (invoked) onToolCall(invoked)
+      }
+      session.finish("normal")
+      await session.inFlight()
+
+      const end = pings.find((p) => p.type === "end")!
+      // 3 snow_* (two of them unwrapped from tool_execute) + 1 tool_search.
+      expect(end.toolCounts).toEqual({ servicenow: 3, mcp: 1 })
+
+      const body = bodies.join("\n")
+      for (const needle of ["snow_create_incident", "snow_query_table", "snow_update_set_create", "tool_search", "vpn down", "STORY-42", "active=true"]) {
+        expect(body).not.toContain(needle)
+      }
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      fs.rmSync(path.dirname(stateDir), { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/__tests__/telemetry-stdio-only.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/__tests__/telemetry-stdio-only.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Structural guarantee: only stdio can emit anonymous telemetry.
+ *
+ * The HTTP transport is the multi-tenant server the platform runs for its
+ * customers. A ping from there would measure our own infrastructure, collapse
+ * many tenants into a single "install", and transmit on behalf of users who
+ * never installed anything — the platform already records that population in
+ * `mcp_usage`. So "HTTP must not emit" is enforced by reachability, not by a
+ * comment or a runtime flag: the HTTP entry points simply have no import path
+ * to the telemetry module.
+ *
+ * These tests walk the real import graph on disk. Deleting the telemetry
+ * import from the stdio entry, or adding one anywhere near HTTP, fails here.
+ */
+
+import { describe, test, expect } from "@jest/globals"
+import * as fs from "fs"
+import * as path from "path"
+
+const SRC = path.resolve(__dirname, "..", "..", "..")
+const TELEMETRY = path.join(SRC, "telemetry", "anonymous-telemetry.ts")
+const STDIO_ENTRY = path.join(SRC, "servicenow-mcp-unified", "index.ts")
+const HTTP_ENTRY = path.join(SRC, "servicenow-mcp-unified", "transports", "http-entry.ts")
+const HTTP_APP = path.join(SRC, "servicenow-mcp-unified", "transports", "http.ts")
+const PACKAGE_ROOT_EXPORT = path.join(SRC, "index.ts")
+
+/** Every relative specifier in a file: static imports, re-exports, dynamic imports. */
+const relativeSpecifiers = (source: string): string[] => {
+  const out: string[] = []
+  const patterns = [
+    /(?:^|\s)(?:import|export)\s[^;]*?from\s*["'](\.[^"']+)["']/g,
+    /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+    /(?:^|\s)import\s+["'](\.[^"']+)["']/g,
+  ]
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) out.push(match[1]!)
+  }
+  return out
+}
+
+/** Resolve a specifier the way the bundler/runtime does: `.js` maps back to `.ts`. */
+const resolveSpecifier = (fromFile: string, specifier: string): string | undefined => {
+  const base = path.resolve(path.dirname(fromFile), specifier)
+  const candidates = [
+    base.replace(/\.js$/, ".ts"),
+    base.replace(/\.js$/, ".tsx"),
+    base,
+    `${base}.ts`,
+    path.join(base, "index.ts"),
+    path.join(base.replace(/\.js$/, ""), "index.ts"),
+  ]
+  return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile())
+}
+
+/** Transitive closure of the local files an entry point pulls in. */
+const importClosure = (entry: string): Set<string> => {
+  const seen = new Set<string>()
+  const queue = [entry]
+  while (queue.length > 0) {
+    const file = queue.pop()!
+    if (seen.has(file)) continue
+    seen.add(file)
+    const source = fs.readFileSync(file, "utf-8")
+    for (const specifier of relativeSpecifiers(source)) {
+      const resolved = resolveSpecifier(file, specifier)
+      if (resolved && !seen.has(resolved)) queue.push(resolved)
+    }
+  }
+  return seen
+}
+
+/**
+ * Every shipped file under src/ that imports the telemetry module. Tests are
+ * excluded: `tsconfig.build.json` keeps them out of dist/ and `files: ["dist"]`
+ * keeps dist/ the only thing published, so a test importing the module can
+ * never put it on an HTTP code path.
+ */
+const telemetryImporters = (): string[] => {
+  const found: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry)
+      if (fs.statSync(full).isDirectory()) {
+        if (entry !== "__tests__") walk(full)
+        continue
+      }
+      if (!full.endsWith(".ts") || full.endsWith(".test.ts") || full === TELEMETRY) continue
+      const source = fs.readFileSync(full, "utf-8")
+      for (const specifier of relativeSpecifiers(source)) {
+        if (resolveSpecifier(full, specifier) === TELEMETRY) {
+          found.push(path.relative(SRC, full))
+          break
+        }
+      }
+    }
+  }
+  walk(SRC)
+  return found.sort()
+}
+
+describe("telemetry is structurally stdio-only", () => {
+  test("the module and both entry points exist where these tests look", () => {
+    for (const file of [TELEMETRY, STDIO_ENTRY, HTTP_ENTRY, HTTP_APP]) {
+      expect(fs.existsSync(file)).toBe(true)
+    }
+  })
+
+  test("the stdio entry point reaches the telemetry module", () => {
+    expect([...importClosure(STDIO_ENTRY)]).toContain(TELEMETRY)
+  })
+
+  test("no HTTP entry point can reach the telemetry module", () => {
+    for (const entry of [HTTP_ENTRY, HTTP_APP]) {
+      const closure = importClosure(entry)
+      // The closure is real, not empty-by-accident.
+      expect(closure.size).toBeGreaterThan(3)
+      expect([...closure]).not.toContain(TELEMETRY)
+    }
+  })
+
+  test("the package's public entry point does not drag telemetry in either", () => {
+    expect([...importClosure(PACKAGE_ROOT_EXPORT)]).not.toContain(TELEMETRY)
+  })
+
+  test("the stdio entry point is the only importer in the whole package", () => {
+    expect(telemetryImporters()).toEqual([path.relative(SRC, STDIO_ENTRY)])
+  })
+
+  test("the HTTP app exposes no tool-call hook to wire telemetry into", () => {
+    // The counter reaches stdio by dependency injection (`startStdio({ onToolCall })`).
+    // `createHttpApp` deliberately has no such parameter, so there is no
+    // symmetrical mistake available on the HTTP side.
+    expect(fs.readFileSync(HTTP_APP, "utf-8")).not.toContain("onToolCall")
+    expect(fs.readFileSync(HTTP_ENTRY, "utf-8")).not.toContain("onToolCall")
+  })
+
+  test("the HTTP image opts out even though nothing in it can emit", () => {
+    // Reachability is the guarantee; this is the belt to its braces. The image
+    // ships src/ wholesale, so the stdio entry is inside it and only the CMD
+    // keeps it unreached — `docker run <image> bun run .../index.ts`, or a
+    // compose file overriding `command:`, would emit pings from platform
+    // infrastructure on behalf of tenants who installed nothing.
+    const dockerfile = fs.readFileSync(path.resolve(SRC, "..", "Dockerfile.mcp-http"), "utf-8")
+    expect(dockerfile).toMatch(/^ENV SERAC_TELEMETRY_DISABLED=1$/m)
+    expect(dockerfile).toContain("http-entry.ts")
+  })
+
+  test("the telemetry module is not re-exported from package.json", () => {
+    const manifest = JSON.parse(fs.readFileSync(path.resolve(SRC, "..", "package.json"), "utf-8")) as {
+      exports: Record<string, unknown>
+      bin: Record<string, string>
+    }
+    const surface = JSON.stringify({ exports: manifest.exports, bin: manifest.bin })
+    expect(surface).not.toContain("telemetry")
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
@@ -34,11 +34,43 @@ export interface StdioHandle {
   stop: () => Promise<void>
 }
 
+export interface StdioOptions {
+  /**
+   * Called once per `tools/call` request with the name of the tool being
+   * invoked. Injected by the stdio entry point to feed the anonymous
+   * telemetry counter; nothing here retains or forwards the name.
+   *
+   * This is dependency injection, not a feature flag: the HTTP transport
+   * (`createHttpApp`) has no equivalent parameter, so there is nothing to
+   * switch on there by accident.
+   */
+  onToolCall?: (toolName: string) => void
+}
+
+/**
+ * The tool a `tools/call` request actually invokes, or undefined for any
+ * other request.
+ *
+ * In lazy-tools mode (the default) nearly every ServiceNow call arrives
+ * wrapped as `tool_execute({ tool: "snow_...", args })`. Unwrapping the
+ * target keeps a per-category count truthful; without it all real work would
+ * look like meta-tool traffic. Only `params.arguments.tool` — a tool name —
+ * is read, never `args`, which carries the user's actual data.
+ */
+export const invokedToolName = (request: any): string | undefined => {
+  if (request?.method !== "tools/call") return undefined
+  const called = request?.params?.name
+  if (typeof called !== "string" || !called) return undefined
+  if (called !== "tool_execute") return called
+  const target = request?.params?.arguments?.tool
+  return typeof target === "string" && target ? target : called
+}
+
 /**
  * Build, bootstrap, and connect the stdio-transport MCP server.
  * Returns a handle with the Server instance and a `stop()` for graceful shutdown.
  */
-export const startStdio = async (): Promise<StdioHandle> => {
+export const startStdio = async (options: StdioOptions = {}): Promise<StdioHandle> => {
   const promptManager = new MCPPromptManager("servicenow-unified")
   // Lock the prompt registry — nobody should be mutating it past bootstrap.
   promptManager.freeze()
@@ -49,6 +81,14 @@ export const startStdio = async (): Promise<StdioHandle> => {
   let context: ServiceNowContext = loadContext()
 
   const resolveContext = async (request: any, _extra?: any): Promise<RequestContext> => {
+    // Notify the caller of tool invocations. `resolveContext` also runs for
+    // `tools/list` (filtered out by invokedToolName) and runs before dispatch,
+    // so this counts attempted calls including ones that later fail.
+    if (options.onToolCall) {
+      const invoked = invokedToolName(request)
+      if (invoked) options.onToolCall(invoked)
+    }
+
     // stdio has no HTTP headers; `request.headers` is undefined here. We keep
     // the lookup for symmetry with the HTTP resolver and because some test
     // harnesses pass a hand-crafted request with inline headers.

--- a/packages/servicenow-mcp/src/telemetry/__tests__/anonymous-telemetry.test.ts
+++ b/packages/servicenow-mcp/src/telemetry/__tests__/anonymous-telemetry.test.ts
@@ -1,0 +1,1020 @@
+/**
+ * Anonymous telemetry — behaviour tests.
+ *
+ * Everything here runs the real module against real inputs: a real HTTP
+ * server receives the pings, real temp directories hold the state, real
+ * `fs` decides whether an install id survives. Nothing is mocked, so a test
+ * that passes proves the bytes that would leave a user's machine.
+ */
+
+import { describe, test, expect, afterEach } from "@jest/globals"
+import * as fs from "fs"
+import * as http from "http"
+import * as os from "os"
+import * as path from "path"
+import { AddressInfo } from "net"
+
+import {
+  AnonymousTelemetry,
+  EXIT_REASONS,
+  INSTALL_METHODS,
+  PAYLOAD_KEYS,
+  TOOL_CATEGORIES,
+  categorizeTool,
+  createSession,
+  detectInstallMethod,
+  installIdPath,
+  isTelemetryDisabled,
+  pendingEndPingPath,
+  readPackageIdentity,
+  resolveInstallId,
+  sanitizePayload,
+  sendPing,
+  telemetryStateDir,
+  type InstallProbe,
+  type TelemetryPayload,
+} from "../anonymous-telemetry.js"
+
+// ---------------------------------------------------------------------------
+// Harness: a real portal stand-in
+// ---------------------------------------------------------------------------
+
+interface Portal {
+  url: string
+  pings: TelemetryPayload[]
+  bodies: string[]
+  /** Set to a status the next requests should answer with (default 200). */
+  respondWith: (status: number) => void
+  /**
+   * Accept and record the request, then never answer it — a portal that is
+   * reachable but slow past any deadline the client is willing to wait.
+   */
+  stall: (on: boolean) => void
+  stop: () => Promise<void>
+}
+
+const startPortal = async (): Promise<Portal> => {
+  const pings: TelemetryPayload[] = []
+  const bodies: string[] = []
+  const state = { status: 200, stalling: false }
+  const sockets = new Set<import("net").Socket>()
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on("data", (c) => chunks.push(Buffer.from(c)))
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf-8")
+      // Only record what the real route accepts, so a stray request to any
+      // other path shows up as a failure rather than passing silently.
+      if (req.url === "/api/telemetry/ping" && req.method === "POST") {
+        bodies.push(raw)
+        pings.push(JSON.parse(raw) as TelemetryPayload)
+      }
+      if (state.stalling) return
+      res.statusCode = state.status
+      res.setHeader("content-type", "application/json")
+      res.end(JSON.stringify({ success: state.status < 400 }))
+    })
+  })
+  server.on("connection", (socket) => {
+    sockets.add(socket)
+    socket.on("close", () => sockets.delete(socket))
+  })
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const port = (server.address() as AddressInfo).port
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    pings,
+    bodies,
+    respondWith: (status: number) => {
+      state.status = status
+    },
+    stall: (on: boolean) => {
+      state.stalling = on
+    },
+    stop: () =>
+      new Promise<void>((resolve) => {
+        // A stalled response holds its socket open, so close() alone would hang.
+        for (const socket of sockets) socket.destroy()
+        server.close(() => resolve())
+      }),
+  }
+}
+
+const tempDirs: string[] = []
+const tempStateDir = (): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "serac-telemetry-"))
+  tempDirs.push(dir)
+  return path.join(dir, "state")
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** An env with every opt-out signal explicitly cleared. */
+const trackingEnv = (extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+  DO_NOT_TRACK: "",
+  CI: "",
+  SERAC_TELEMETRY_DISABLED: "",
+  ...extra,
+})
+
+// ---------------------------------------------------------------------------
+// Opt-out
+// ---------------------------------------------------------------------------
+
+describe("opt-out", () => {
+  test("each of DO_NOT_TRACK, CI and SERAC_TELEMETRY_DISABLED disables on its own", () => {
+    for (const key of ["DO_NOT_TRACK", "CI", "SERAC_TELEMETRY_DISABLED"]) {
+      for (const value of ["1", "true", "TRUE", "yes", "on"]) {
+        expect(isTelemetryDisabled({ [key]: value })).toBe(true)
+      }
+    }
+  })
+
+  test("absent, empty, 0 and false do not disable", () => {
+    expect(isTelemetryDisabled({})).toBe(false)
+    for (const key of ["DO_NOT_TRACK", "CI", "SERAC_TELEMETRY_DISABLED"]) {
+      for (const value of ["", "  ", "0", "false", "FALSE"]) {
+        expect(isTelemetryDisabled({ [key]: value })).toBe(false)
+      }
+    }
+  })
+
+  test.each(["DO_NOT_TRACK", "CI", "SERAC_TELEMETRY_DISABLED"])(
+    "%s=1 sends nothing and writes nothing to disk",
+    async (key) => {
+      const portal = await startPortal()
+      const stateDir = tempStateDir()
+      try {
+        const session = createSession({
+          env: trackingEnv({ [key]: "1" }),
+          stateDir,
+          portalUrl: portal.url,
+        })
+        expect(session.enabled).toBe(false)
+
+        session.start()
+        session.recordToolCall("snow_query_table")
+        session.finish("normal")
+        await session.inFlight()
+
+        expect(portal.pings).toEqual([])
+        // Not merely "no install-id file": the directory itself is never created.
+        expect(fs.existsSync(stateDir)).toBe(false)
+      } finally {
+        await portal.stop()
+      }
+    },
+  )
+
+  test("an opted-out singleton attaches no process listeners", () => {
+    const before = process.listenerCount("exit") + process.listenerCount("uncaughtExceptionMonitor")
+    AnonymousTelemetry.start({
+      env: trackingEnv({ DO_NOT_TRACK: "1" }),
+      stateDir: tempStateDir(),
+      portalUrl: "http://127.0.0.1:1",
+    })
+    const after = process.listenerCount("exit") + process.listenerCount("uncaughtExceptionMonitor")
+    expect(after).toBe(before)
+    // These are no-ops rather than crashes when the session is disabled.
+    AnonymousTelemetry.recordToolCall("snow_query_table")
+    AnonymousTelemetry.finish("normal")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Install id
+// ---------------------------------------------------------------------------
+
+describe("install id", () => {
+  test("is stable across calls and regenerates once the state dir is removed", () => {
+    const stateDir = tempStateDir()
+
+    const first = resolveInstallId(stateDir)
+    const second = resolveInstallId(stateDir)
+    expect(first).toBeDefined()
+    expect(second).toBe(first!)
+    // A third read after a fresh module-free call still returns the same value.
+    expect(resolveInstallId(stateDir)).toBe(first!)
+    expect(fs.readFileSync(installIdPath(stateDir), "utf-8").trim()).toBe(first!)
+
+    fs.rmSync(stateDir, { recursive: true, force: true })
+
+    const regenerated = resolveInstallId(stateDir)
+    expect(regenerated).toBeDefined()
+    expect(regenerated).not.toBe(first!)
+  })
+
+  test("is a random UUID, not derived from the machine", () => {
+    const a = resolveInstallId(tempStateDir())!
+    const b = resolveInstallId(tempStateDir())!
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    // Two installations on this one machine must not share an identifier.
+    expect(a).not.toBe(b)
+  })
+
+  test("survives the receiving route's machineId validation", () => {
+    const id = resolveInstallId(tempStateDir())!
+    expect(id.length).toBeLessThanOrEqual(64)
+    expect(/^[a-zA-Z0-9._-]+$/.test(id)).toBe(true)
+  })
+
+  test("two sessions on one install share the install id but not the session id", async () => {
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      const deps = { env: trackingEnv(), stateDir, portalUrl: portal.url }
+      const one = createSession(deps)
+      const two = createSession(deps)
+      one.start()
+      two.start()
+      await Promise.all([one.inFlight(), two.inFlight()])
+
+      expect(portal.pings).toHaveLength(2)
+      expect(portal.pings[0]!.machineId).toBe(portal.pings[1]!.machineId)
+      expect(portal.pings[0]!.sessionId).not.toBe(portal.pings[1]!.sessionId)
+    } finally {
+      await portal.stop()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// State directory
+// ---------------------------------------------------------------------------
+
+describe("state directory", () => {
+  test("follows XDG_STATE_HOME when it is absolute", () => {
+    expect(telemetryStateDir({ XDG_STATE_HOME: "/var/tmp/xdg" })).toBe(path.join("/var/tmp/xdg", "serac", "telemetry"))
+  })
+
+  test("falls back to ~/.local/state and ignores a relative XDG_STATE_HOME", () => {
+    const expected = path.join("/home/tester", ".local", "state", "serac", "telemetry")
+    expect(telemetryStateDir({ HOME: "/home/tester" })).toBe(expected)
+    expect(telemetryStateDir({ HOME: "/home/tester", XDG_STATE_HOME: "relative/state" })).toBe(expected)
+  })
+
+  test("never lands inside ~/.serac, where credentials live", () => {
+    expect(telemetryStateDir({ HOME: "/home/tester" })).not.toContain(path.join("/home/tester", ".serac"))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Version + channel
+// ---------------------------------------------------------------------------
+
+describe("version and channel", () => {
+  test("reads this package's own version", () => {
+    const identity = readPackageIdentity()
+    const declared = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, "..", "..", "..", "package.json"), "utf-8"),
+    ) as { version: string }
+    expect(identity.version).toBe(declared.version)
+    expect(identity.channel).toBe("latest")
+  })
+
+  test("derives the channel from a prerelease tag and strips build metadata", () => {
+    const dir = tempStateDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const write = (version: string): string => {
+      const file = path.join(dir, `pkg-${encodeURIComponent(version)}.json`)
+      fs.writeFileSync(file, JSON.stringify({ version }), "utf-8")
+      return file
+    }
+
+    expect(readPackageIdentity(write("0.3.0-beta.1"))).toEqual({ version: "0.3.0-beta.1", channel: "beta" })
+    expect(readPackageIdentity(write("1.0.0+build.7"))).toEqual({ version: "1.0.0", channel: "latest" })
+  })
+
+  test("a missing package.json degrades instead of throwing", () => {
+    expect(readPackageIdentity(path.join(tempStateDir(), "nope.json"))).toEqual({ version: "0.0.0", channel: "local" })
+  })
+
+  test("the version always survives the receiving route's validation", () => {
+    const { version, channel } = readPackageIdentity()
+    for (const value of [version, channel]) {
+      expect(value.length).toBeGreaterThan(0)
+      expect(value.length).toBeLessThanOrEqual(20)
+      expect(/^[a-zA-Z0-9._-]+$/.test(value)).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Install method
+// ---------------------------------------------------------------------------
+
+describe("install method", () => {
+  const probe = (over: Partial<InstallProbe>): InstallProbe => ({
+    execPath: "/usr/local/bin/node",
+    modulePath: "/home/tester/project/src/telemetry/anonymous-telemetry.ts",
+    hasBunRuntime: false,
+    inContainer: false,
+    ...over,
+  })
+
+  const cases: { name: string; probe: InstallProbe; expected: string }[] = [
+    {
+      name: "npx",
+      probe: probe({
+        userAgent: "npm/10.8.2 node/v22.5.1 darwin arm64 workspaces/false",
+        modulePath: "/Users/t/.npm/_npx/abc/node_modules/@serac-labs/servicenow-mcp/dist/telemetry/anonymous-telemetry.js",
+      }),
+      expected: "npm",
+    },
+    {
+      name: "bunx",
+      probe: probe({ userAgent: "bun/1.1.30 npm/? node/v22.6.0 darwin arm64", hasBunRuntime: true }),
+      expected: "bun",
+    },
+    {
+      name: "global npm install spawned directly by an MCP client",
+      probe: probe({
+        modulePath: `${path.sep}usr${path.sep}local${path.sep}lib${path.sep}node_modules${path.sep}@serac-labs${path.sep}servicenow-mcp${path.sep}dist${path.sep}telemetry${path.sep}anonymous-telemetry.js`,
+      }),
+      expected: "npm",
+    },
+    {
+      name: "homebrew node",
+      probe: probe({ execPath: "/opt/homebrew/Cellar/node/22.5.1/bin/node" }),
+      expected: "brew",
+    },
+    {
+      name: "compiled single-file executable",
+      probe: probe({ execPath: "/usr/local/bin/servicenow-mcp", hasBunRuntime: true }),
+      expected: "binary",
+    },
+    {
+      name: "docker run -i",
+      probe: probe({ inContainer: true, userAgent: "npm/10.8.2 node/v22.5.1 linux x64" }),
+      expected: "other",
+    },
+    {
+      name: "pnpm dlx",
+      probe: probe({ userAgent: "pnpm/9.7.0 npm/? node/v22.5.1 linux x64" }),
+      expected: "other",
+    },
+    { name: "bun run from a checkout", probe: probe({ execPath: "/usr/local/bin/bun", hasBunRuntime: true }), expected: "bun" },
+    { name: "node from a source checkout", probe: probe({}), expected: "other" },
+  ]
+
+  test.each(cases)("$name → $expected", ({ probe: input, expected }) => {
+    expect(detectInstallMethod(input)).toBe(expected)
+  })
+
+  test("every case resolves to a value the receiving route accepts", () => {
+    // Includes deliberately hostile inputs: the function must never invent a
+    // value outside the allowlist, because the route drops those to null.
+    const hostile: InstallProbe[] = [
+      probe({ execPath: "", modulePath: "" }),
+      probe({ userAgent: "   " }),
+      probe({ userAgent: "deno/1.46.0" }),
+      probe({ execPath: "C:\\Program Files\\nodejs\\node.exe" }),
+      probe({ execPath: "/weird/path/with spaces/thing" }),
+    ]
+    for (const input of [...cases.map((c) => c.probe), ...hostile]) {
+      expect(INSTALL_METHODS).toContain(detectInstallMethod(input))
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+describe("payload", () => {
+  test("a start ping carries only the declared fields and the route's required ones", async () => {
+    const portal = await startPortal()
+    try {
+      const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: portal.url })
+      session.start()
+      await session.inFlight()
+
+      expect(portal.pings).toHaveLength(1)
+      const ping = portal.pings[0]!
+      expect(Object.keys(ping).sort()).toEqual(
+        ["arch", "channel", "installMethod", "machineId", "os", "sessionDurationSec", "sessionId", "timestamp", "type", "version"].sort(),
+      )
+      for (const key of Object.keys(ping)) expect(PAYLOAD_KEYS).toContain(key)
+      // machineId, version, os and arch are required — a missing one is a 400.
+      for (const key of ["machineId", "version", "os", "arch"] as const) {
+        expect(typeof ping[key]).toBe("string")
+        expect(ping[key].length).toBeGreaterThan(0)
+      }
+      expect(ping.type).toBe("start")
+      expect(ping.sessionDurationSec).toBe(0)
+      expect(INSTALL_METHODS).toContain(ping.installMethod)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("carries nothing derived from what the user was doing", async () => {
+    const portal = await startPortal()
+    try {
+      // Everything a real stdio session has lying around in its environment.
+      const secrets = {
+        SNOW_INSTANCE: "https://dev380262.service-now.com",
+        SERVICENOW_CLIENT_SECRET: "s3cr3t-client-secret",
+        SNOW_SESSION_ID: "session-of-a-real-user",
+      }
+      const session = createSession({
+        env: trackingEnv({ ...secrets }),
+        stateDir: tempStateDir(),
+        portalUrl: portal.url,
+      })
+      session.start()
+      // Tool traffic that names an instance, a table and a sys_id.
+      session.recordToolCall("snow_query_table")
+      session.recordToolCall("snow_update_set_create")
+      session.recordToolCall("tool_search")
+      session.finish("normal")
+      await session.inFlight()
+
+      const body = portal.bodies.join("\n")
+      const forbidden = [
+        ...Object.values(secrets),
+        "service-now.com",
+        "snow_query_table",
+        "snow_update_set_create",
+        "tool_search",
+        "incident",
+        "sys_id",
+        os.hostname(),
+        os.userInfo().username,
+        os.homedir(),
+        process.cwd(),
+      ]
+      for (const needle of forbidden) {
+        expect(body.toLowerCase()).not.toContain(needle.toLowerCase())
+      }
+
+      // And structurally: no key outside the declared set, on any ping.
+      for (const ping of portal.pings) {
+        for (const key of Object.keys(ping)) expect(PAYLOAD_KEYS).toContain(key)
+      }
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("an end ping reports duration, exit reason and per-category tool counts", async () => {
+    const portal = await startPortal()
+    try {
+      const clock = { value: 1_000_000 }
+      const session = createSession({
+        env: trackingEnv(),
+        stateDir: tempStateDir(),
+        portalUrl: portal.url,
+        now: () => clock.value,
+      })
+      session.start()
+      session.recordToolCall("snow_query_table")
+      session.recordToolCall("snow_create_incident")
+      session.recordToolCall("tool_execute")
+      clock.value += 42_000
+      session.finish("normal")
+      await session.inFlight()
+
+      const end = portal.pings.find((p) => p.type === "end")!
+      expect(end.sessionDurationSec).toBe(42)
+      expect(EXIT_REASONS).toContain(end.exitReason!)
+      expect(end.exitReason).toBe("normal")
+      expect(end.toolCounts).toEqual({ servicenow: 2, mcp: 1 })
+      for (const category of Object.keys(end.toolCounts!)) expect(TOOL_CATEGORIES).toContain(category)
+      // The start ping never carries counts.
+      expect(portal.pings.find((p) => p.type === "start")!.toolCounts).toBeUndefined()
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("tool categorisation keeps ServiceNow work apart from meta traffic", () => {
+    expect(categorizeTool("snow_query_table")).toBe("servicenow")
+    expect(categorizeTool("tool_search")).toBe("mcp")
+    expect(categorizeTool("tool_execute")).toBe("mcp")
+    for (const name of ["snow_x", "tool_search", "anything_else", ""]) {
+      expect(TOOL_CATEGORIES).toContain(categorizeTool(name))
+    }
+  })
+
+  test("an error exit reports the error class, never the message", async () => {
+    const portal = await startPortal()
+    try {
+      const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: portal.url })
+      session.start()
+      const error = new TypeError(
+        "failed to update incident sys_id=9d385017c611228701d22104cc95c371 on https://dev380262.service-now.com",
+      )
+      session.finish("error", error)
+      await session.inFlight()
+
+      const end = portal.pings.find((p) => p.type === "end")!
+      expect(end.exitReason).toBe("error")
+      expect(end.exitErrorMessage).toBe("TypeError")
+      const body = portal.bodies.join("\n")
+      expect(body).not.toContain("sys_id")
+      expect(body).not.toContain("service-now.com")
+      expect(body).not.toContain("incident")
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("an unrecognisable error name is dropped rather than forwarded", async () => {
+    const portal = await startPortal()
+    try {
+      const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: portal.url })
+      session.start()
+      session.finish("error", "https://dev380262.service-now.com exploded")
+      await session.inFlight()
+
+      const end = portal.pings.find((p) => p.type === "end")!
+      expect(end.exitErrorMessage).toBeUndefined()
+      expect(portal.bodies.join("\n")).not.toContain("service-now.com")
+    } finally {
+      await portal.stop()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Wire sanitisation
+// ---------------------------------------------------------------------------
+
+describe("wire sanitisation", () => {
+  const valid: TelemetryPayload = {
+    machineId: "03c94b30-d66e-4149-85a7-bfb66056bf46",
+    sessionId: "32a90c30-c092-4291-a5c5-43bf80e28754",
+    version: "0.2.1",
+    channel: "latest",
+    os: "darwin",
+    arch: "arm64",
+    installMethod: "npm",
+    type: "end",
+    sessionDurationSec: 12,
+    timestamp: 1786807579568,
+    exitReason: "error",
+    exitErrorMessage: "TypeError",
+    toolCounts: { servicenow: 2 },
+  }
+
+  test("a payload this module built passes through unchanged", () => {
+    // Both directions of the wire contract: this fixture uses every declared
+    // key, and every one of them survives.
+    expect(Object.keys(valid).sort()).toEqual([...PAYLOAD_KEYS].sort())
+    expect(sanitizePayload(valid)).toEqual(valid)
+  })
+
+  test("an unusable timestamp is omitted so the route stamps arrival time", () => {
+    // Sending 0 would store a 1970 row; the route defaults a missing timestamp.
+    for (const timestamp of [-1, Number.NaN, "yesterday", null, undefined]) {
+      expect(sanitizePayload({ ...valid, timestamp })!.timestamp).toBeUndefined()
+    }
+    expect(sanitizePayload({ ...valid, sessionDurationSec: -5 })!.sessionDurationSec).toBe(0)
+  })
+
+  test("only declared keys survive", () => {
+    const sanitized = sanitizePayload({
+      ...valid,
+      instanceUrl: "https://acme-secret-prod.service-now.com",
+      orgId: "org-9999",
+      cwd: "/Users/niels/projects/acme",
+    })!
+    for (const key of Object.keys(sanitized)) expect(PAYLOAD_KEYS).toContain(key)
+    expect(JSON.stringify(sanitized)).not.toContain("service-now.com")
+    expect(JSON.stringify(sanitized)).not.toContain("org-9999")
+    expect(JSON.stringify(sanitized)).not.toContain("Users")
+  })
+
+  test("free-form text in a declared field is dropped, not forwarded", () => {
+    const sanitized = sanitizePayload({
+      ...valid,
+      exitErrorMessage: "connect ECONNREFUSED https://acme-secret-prod.service-now.com /Users/niels/secret/path",
+    })!
+    expect(sanitized.exitErrorMessage).toBeUndefined()
+    // The rest of the ping still goes: one bad field is not a reason to lose a session.
+    expect(sanitized.exitReason).toBe("error")
+  })
+
+  test.each([
+    ["a hostname as the version", { version: "dev380262.service-now.com" }],
+    ["a path as the os", { os: "/Users/niels/projects" }],
+    ["a hostname as the install id", { machineId: "acme-laptop-01.corp.example" }],
+    ["a missing install id", { machineId: undefined }],
+    ["an unknown ping type", { type: "heartbeat" }],
+  ])("%s fails the whole ping", (_name, override) => {
+    expect(sanitizePayload({ ...valid, ...override })).toBeUndefined()
+  })
+
+  test.each([
+    ["null", null],
+    ["a string", "https://acme.service-now.com"],
+    ["an array", [{ ...valid }]],
+    ["an object with no prototype", Object.assign(Object.create(null), valid)],
+    ["nothing at all", undefined],
+  ])("%s is not a payload", (_name, input) => {
+    // The null-prototype case is the interesting one: it has every right field,
+    // so it must be judged on its fields, not on `instanceof Object`.
+    const sanitized = sanitizePayload(input)
+    if (_name === "an object with no prototype") expect(sanitized).toEqual(valid)
+    else expect(sanitized).toBeUndefined()
+  })
+
+  test("optional fields outside their allowlist are dropped rather than passed on", () => {
+    const sanitized = sanitizePayload({
+      ...valid,
+      sessionId: "not-a-uuid",
+      // The route defaults a missing channel to "latest", so an unusable one
+      // is dropped rather than costing the whole ping.
+      channel: "niels.vanderwerf@acme.example",
+      installMethod: "curl",
+      exitReason: "killed",
+      toolCounts: { servicenow: 1, filesystem: 99, mcp: -3, builtin: Number.NaN },
+    })!
+    expect(sanitized.sessionId).toBeUndefined()
+    expect(sanitized.channel).toBeUndefined()
+    expect(sanitized.installMethod).toBeUndefined()
+    expect(sanitized.exitReason).toBeUndefined()
+    // An exit reason that was dropped cannot drag an error name along with it.
+    expect(sanitized.exitErrorMessage).toBeUndefined()
+    expect(sanitized.toolCounts).toEqual({ servicenow: 1 })
+  })
+
+  test("a start ping cannot carry end-only fields", () => {
+    const sanitized = sanitizePayload({ ...valid, type: "start" })!
+    expect(sanitized.type).toBe("start")
+    expect(sanitized.exitReason).toBeUndefined()
+    expect(sanitized.exitErrorMessage).toBeUndefined()
+    expect(sanitized.toolCounts).toBeUndefined()
+  })
+
+  test("sendPing refuses a payload that fails validation", async () => {
+    const portal = await startPortal()
+    try {
+      const sent = await sendPing(portal.url, { ...valid, machineId: "acme-laptop" } as TelemetryPayload)
+      expect(sent).toBe(false)
+      expect(portal.pings).toEqual([])
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("a hand-written pending file is sanitised before it is retried", async () => {
+    // The pending file is a 0644 JSON file in a predictable directory: any
+    // process running as this user can write one, and a future version of this
+    // package could leave a differently-shaped one behind. Before this was
+    // sanitised, the flush POSTed it verbatim — a live run put an instance
+    // hostname, an org id and a path-bearing error message on the wire, and the
+    // receiving route stores exitErrorMessage free-form.
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      fs.mkdirSync(stateDir, { recursive: true })
+      fs.writeFileSync(
+        pendingEndPingPath(stateDir),
+        JSON.stringify({
+          machineId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          sessionId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          version: "0.2.1",
+          channel: "latest",
+          os: "darwin",
+          arch: "arm64",
+          type: "end",
+          sessionDurationSec: 30,
+          timestamp: Date.now(),
+          exitReason: "error",
+          exitErrorMessage: "INJECTED Error: connect ECONNREFUSED https://acme-secret-prod.service-now.com /Users/niels/secret",
+          instanceUrl: "https://acme-secret-prod.service-now.com",
+          orgId: "org-9999",
+        }),
+        "utf-8",
+      )
+
+      const session = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      session.start()
+      await session.inFlight()
+
+      const flushed = portal.pings.find((p) => p.type === "end")!
+      expect(flushed.machineId).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      expect(flushed.exitErrorMessage).toBeUndefined()
+      for (const key of Object.keys(flushed)) expect(PAYLOAD_KEYS).toContain(key)
+      const body = portal.bodies.join("\n")
+      for (const needle of ["service-now.com", "org-9999", "INJECTED", "/Users/niels"]) {
+        expect(body).not.toContain(needle)
+      }
+      // Delivered, so nothing is left to retry.
+      expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test.each([
+    ["unparseable", "{ this is not json"],
+    ["a bare string", JSON.stringify("https://acme-secret-prod.service-now.com")],
+    ["missing the required fields", JSON.stringify({ exitReason: "error", exitErrorMessage: "whatever" })],
+    ["a start ping", JSON.stringify({ machineId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", version: "0.2.1", os: "darwin", arch: "arm64", type: "start" })],
+  ])("a pending file that is %s is deleted, never sent", async (_name, contents) => {
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      fs.mkdirSync(stateDir, { recursive: true })
+      fs.writeFileSync(pendingEndPingPath(stateDir), contents, "utf-8")
+
+      const session = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      session.start()
+      await session.inFlight()
+
+      expect(portal.pings.map((p) => p.type)).toEqual(["start"])
+      expect(portal.bodies.join("\n")).not.toContain("service-now.com")
+      // Deleted rather than kept, so it cannot be retried on every launch forever.
+      expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+describe("delivery", () => {
+  test("an end ping that fails is persisted and flushed by the next session", async () => {
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      portal.respondWith(500)
+      const first = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      first.start()
+      first.recordToolCall("snow_query_table")
+      first.finish("interrupt")
+      await first.inFlight()
+
+      const pendingFile = pendingEndPingPath(stateDir)
+      expect(fs.existsSync(pendingFile)).toBe(true)
+      const persisted = JSON.parse(fs.readFileSync(pendingFile, "utf-8")) as TelemetryPayload
+      expect(persisted.type).toBe("end")
+      expect(persisted.exitReason).toBe("interrupt")
+
+      portal.pings.length = 0
+      portal.respondWith(200)
+
+      const second = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      second.start()
+      await second.inFlight()
+
+      // The retried end ping arrives alongside the new session's start ping,
+      // and carries the *first* session's id — not the new one.
+      const retried = portal.pings.find((p) => p.type === "end")!
+      expect(retried.sessionId).toBe(persisted.sessionId)
+      expect(retried.toolCounts).toEqual({ servicenow: 1 })
+      expect(fs.existsSync(pendingFile)).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("a delivered end ping leaves nothing behind to retry", async () => {
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      const session = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      session.start()
+      session.finish("normal")
+      await session.inFlight()
+      expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("a delivered session is never counted twice by the next launch", async () => {
+    // Regression: a live run showed the end ping arriving with HTTP 200 while
+    // `process.exit` killed the response handler before it could delete the
+    // file — so the following launch re-sent it and the portal recorded the
+    // session twice. Whatever the exit path, one delivery must mean one row.
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      const first = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      first.start()
+      first.recordToolCall("snow_query_table")
+      first.finish("interrupt")
+      await first.inFlight()
+      const firstSessionId = portal.pings[0]!.sessionId
+
+      portal.pings.length = 0
+      const second = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      second.start()
+      await second.inFlight()
+
+      expect(portal.pings.map((p) => p.type)).toEqual(["start"])
+      expect(portal.pings.some((p) => p.sessionId === firstSessionId)).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("a slow portal does not produce a second end row on the next launch", async () => {
+    // Regression: settle capped the wait at 1s while the ping's own timeout was
+    // 3s, so a portal answering in between had already *stored* the ping when
+    // process.exit killed the response handler — and the next launch re-sent
+    // it. Measured at a 1.2s round trip: 7 end rows for 4 real sessions, which
+    // double-counts tool calls and pushes session completion over 100%.
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      portal.stall(true)
+      const first = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      first.start()
+      first.recordToolCall("snow_query_table")
+      first.finish("interrupt")
+      await first.settle(150)
+
+      // The portal has the ping; we simply never got to read the answer.
+      expect(portal.pings.filter((p) => p.type === "end")).toHaveLength(1)
+      expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(false)
+
+      // And the hung request is released rather than left holding the process
+      // open for the rest of its 3s send timeout.
+      const releasedAt = Date.now()
+      await first.inFlight()
+      expect(Date.now() - releasedAt).toBeLessThan(500)
+
+      portal.stall(false)
+      portal.pings.length = 0
+      const second = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      second.start()
+      await second.inFlight()
+      expect(portal.pings.map((p) => p.type)).toEqual(["start"])
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("a portal that refuses the connection still leaves the ping to retry", async () => {
+    // The other side of the trade above: "unconfirmed" only means the request
+    // outlived the cap. An offline user's fetch fails in milliseconds, well
+    // inside it, so their end ping is kept and delivered on the next launch.
+    const stateDir = tempStateDir()
+    const session = createSession({ env: trackingEnv(), stateDir, portalUrl: "http://127.0.0.1:1" })
+    session.start()
+    session.finish("interrupt")
+    const started = Date.now()
+    await session.settle(1_000)
+    expect(Date.now() - started).toBeLessThan(1_000)
+    expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(true)
+  })
+
+  test("settle waits for nothing when the session never sent anything", async () => {
+    const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: "http://127.0.0.1:1" })
+    const started = Date.now()
+    await session.settle(5_000)
+    expect(Date.now() - started).toBeLessThan(500)
+  })
+
+  test("a crash records the error class without a network call it cannot finish", async () => {
+    // The uncaughtExceptionMonitor path persists and leaves delivery to the
+    // next launch: the process is already dying, so a fetch there can be
+    // stored by the portal and still never be confirmed — one crash, two rows.
+    const portal = await startPortal()
+    const stateDir = tempStateDir()
+    try {
+      const crashed = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      crashed.start()
+      crashed.recordToolCall("snow_query_table")
+      crashed.persistPendingEnd("error", new TypeError("cannot read properties of undefined (reading 'sys_id')"))
+      await crashed.inFlight()
+
+      expect(portal.pings.map((p) => p.type)).toEqual(["start"])
+      const persisted = JSON.parse(fs.readFileSync(pendingEndPingPath(stateDir), "utf-8")) as TelemetryPayload
+      expect(persisted.exitReason).toBe("error")
+      expect(persisted.exitErrorMessage).toBe("TypeError")
+      expect(persisted.toolCounts).toEqual({ servicenow: 1 })
+
+      portal.pings.length = 0
+      const next = createSession({ env: trackingEnv(), stateDir, portalUrl: portal.url })
+      next.start()
+      await next.inFlight()
+
+      const delivered = portal.pings.find((p) => p.type === "end")!
+      expect(delivered.exitErrorMessage).toBe("TypeError")
+      expect(portal.bodies.join("\n")).not.toContain("sys_id")
+      expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(false)
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("an error object that fights back is still non-fatal", async () => {
+    // `finish()` reads err.name, which runs user code. A throwing getter used
+    // to take the whole call down — inside the fatal-error handler and the
+    // crash monitor, the two places that must never throw.
+    const portal = await startPortal()
+    try {
+      const hostile = new Error("boom")
+      Object.defineProperty(hostile, "name", {
+        get: () => {
+          throw new Error("thrown from the name getter")
+        },
+      })
+
+      const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: portal.url })
+      session.start()
+      expect(() => session.finish("error", hostile)).not.toThrow()
+      await session.inFlight()
+
+      const end = portal.pings.find((p) => p.type === "end")!
+      expect(end.exitReason).toBe("error")
+      expect(end.exitErrorMessage).toBeUndefined()
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("settle resolves immediately when there is no session to wait for", async () => {
+    // The singleton is opted out in this process, so settle must be a no-op
+    // rather than a one-second stall on every shutdown.
+    const started = Date.now()
+    await AnonymousTelemetry.settle(5_000)
+    expect(Date.now() - started).toBeLessThan(500)
+  })
+
+  test("finish is idempotent — a session ends exactly once", async () => {
+    const portal = await startPortal()
+    try {
+      const session = createSession({ env: trackingEnv(), stateDir: tempStateDir(), portalUrl: portal.url })
+      session.start()
+      session.start()
+      session.finish("normal")
+      session.finish("error", new Error("later"))
+      session.persistPendingEnd("normal")
+      await session.inFlight()
+
+      expect(portal.pings.filter((p) => p.type === "start")).toHaveLength(1)
+      expect(portal.pings.filter((p) => p.type === "end")).toHaveLength(1)
+      expect(portal.pings.find((p) => p.type === "end")!.exitReason).toBe("normal")
+    } finally {
+      await portal.stop()
+    }
+  })
+
+  test("persistPendingEnd writes synchronously, as a process 'exit' handler must", () => {
+    const stateDir = tempStateDir()
+    const session = createSession({
+      env: trackingEnv(),
+      stateDir,
+      // Nothing listens here; the point is that no network is involved.
+      portalUrl: "http://127.0.0.1:1",
+    })
+    session.persistPendingEnd("normal")
+    // Asserted immediately, with no await anywhere in between.
+    const persisted = JSON.parse(fs.readFileSync(pendingEndPingPath(stateDir), "utf-8")) as TelemetryPayload
+    expect(persisted.type).toBe("end")
+    expect(persisted.exitReason).toBe("normal")
+  })
+
+  test("an unreachable portal is silent and non-fatal", async () => {
+    const stateDir = tempStateDir()
+    const session = createSession({ env: trackingEnv(), stateDir, portalUrl: "http://127.0.0.1:1" })
+    expect(() => {
+      session.start()
+      session.recordToolCall("snow_query_table")
+      session.finish("normal")
+    }).not.toThrow()
+    await session.inFlight()
+    // The end ping is still on disk, waiting for a run that can deliver it.
+    expect(fs.existsSync(pendingEndPingPath(stateDir))).toBe(true)
+  })
+
+  test("an unwritable state dir disables the session instead of failing", async () => {
+    const portal = await startPortal()
+    try {
+      // A path whose parent is a regular file: mkdir cannot succeed here.
+      const blocked = path.join(tempStateDir(), "wedged")
+      fs.mkdirSync(path.dirname(blocked), { recursive: true })
+      fs.writeFileSync(blocked, "not a directory", "utf-8")
+
+      const session = createSession({
+        env: trackingEnv(),
+        stateDir: path.join(blocked, "telemetry"),
+        portalUrl: portal.url,
+      })
+      expect(session.enabled).toBe(false)
+      expect(() => {
+        session.start()
+        session.finish("normal")
+      }).not.toThrow()
+      await session.inFlight()
+      expect(portal.pings).toEqual([])
+    } finally {
+      await portal.stop()
+    }
+  })
+})

--- a/packages/servicenow-mcp/src/telemetry/anonymous-telemetry.ts
+++ b/packages/servicenow-mcp/src/telemetry/anonymous-telemetry.ts
@@ -1,0 +1,874 @@
+/**
+ * Anonymous usage telemetry — stdio transport only.
+ *
+ * A port of `packages/opencode/src/usage/anonymous-telemetry.ts` from the CLI
+ * that this package replaced. The behaviour is deliberately unchanged: one
+ * ping when a session starts, one when it ends, an install identifier that is
+ * a random UUID on disk (never derived from hardware), and an end ping that
+ * is written to disk first so a process that dies mid-flight retries on the
+ * next launch. The receiving end — `POST /api/telemetry/ping` in
+ * serac-platform — is untouched.
+ *
+ * What it sends: install id, version, channel, OS, architecture, install
+ * method, session duration, how the session ended, and per-category tool-call
+ * counts. It never sends prompts, arguments, tool names, table names, sys_ids,
+ * file paths, project names, instance URLs or credentials — nothing derived
+ * from what the user was doing.
+ *
+ * WHY THIS FILE IS NOT IN `servicenow-mcp-unified/shared/`
+ * --------------------------------------------------------
+ * `shared/` is what both transports import. The HTTP transport is the
+ * multi-tenant server the platform runs for its customers: a ping from there
+ * would measure our own infrastructure, collapse many tenants into one
+ * "install", and transmit on behalf of people who never installed anything.
+ * Living outside the shared tree means the HTTP path cannot reach this module
+ * by importing the directory it already depends on — the only importer is the
+ * stdio entry point `servicenow-mcp-unified/index.ts`. That invariant is
+ * pinned by `transports/__tests__/telemetry-stdio-only.test.ts`, which walks
+ * the real import graph of both entry points.
+ *
+ * Opting out: set `DO_NOT_TRACK`, `SERAC_TELEMETRY_DISABLED`, or run in CI
+ * (`CI`). Nothing is sent, and nothing is written to disk. An opt-out stops
+ * transmission, including of anything a previous run left pending; it does not
+ * delete files an earlier opted-in run already wrote — `rm -rf
+ * $XDG_STATE_HOME/serac` (default `~/.local/state/serac`) does that, and
+ * touches no credential.
+ */
+
+import { randomUUID } from "node:crypto"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { mcpDebug } from "../shared/mcp-debug.js"
+
+/**
+ * `portal.serac.build` — an older default — no longer resolves, so any build
+ * still pointing there loses every ping silently. Point at the current host
+ * directly; a 301 would also be fatal, because fetch downgrades a redirected
+ * POST to GET and drops the body.
+ */
+export const DEFAULT_PORTAL_URL = "https://dashboard.serac.build"
+export const PING_PATH = "/api/telemetry/ping"
+
+const SEND_TIMEOUT_MS = 3_000
+/** How long a shutdown may wait for the end ping. See `TelemetrySession.settle`. */
+const SETTLE_TIMEOUT_MS = 1_000
+
+/** Mirrors `VALID_EXIT_REASONS` on the receiving route. */
+export const EXIT_REASONS = ["normal", "error", "interrupt"] as const
+export type ExitReason = (typeof EXIT_REASONS)[number]
+
+/** Mirrors `VALID_INSTALL_METHODS` on the receiving route. */
+export const INSTALL_METHODS = ["npm", "bun", "brew", "binary", "other"] as const
+export type InstallMethod = (typeof INSTALL_METHODS)[number]
+
+/** Mirrors `VALID_TOOL_CATEGORIES` on the receiving route. */
+export const TOOL_CATEGORIES = ["builtin", "servicenow", "mcp"] as const
+export type ToolCategory = (typeof TOOL_CATEGORIES)[number]
+
+/**
+ * Exactly the fields that leave this process.
+ *
+ * `messageCount` is not here on purpose. An MCP server never sees messages —
+ * it sees JSON-RPC requests — so the CLI's message counter has no honest
+ * value to carry. The receiving route treats a missing `messageCount` as 0,
+ * which is what it means: not measured. Tool activity is reported through
+ * `toolCounts` instead, which the route already sanitizes per category.
+ */
+export interface TelemetryPayload {
+  machineId: string
+  /** Optional on the wire: the route stores a missing session id as null. */
+  sessionId?: string
+  version: string
+  /** Optional on the wire: the route defaults a missing channel to `latest`. */
+  channel?: string
+  os: string
+  arch: string
+  installMethod: InstallMethod
+  type: "start" | "end"
+  sessionDurationSec: number
+  /**
+   * Optional on the wire only in one case: a persisted ping whose timestamp
+   * did not survive validation is sent without it, so the route stamps arrival
+   * time rather than storing a 1970 row. Every payload this module builds has
+   * one.
+   */
+  timestamp?: number
+  exitReason?: ExitReason
+  /**
+   * The error's *class name* only ("TypeError", "McpError") — never its
+   * message. The CLI sent 500 characters of the message; an MCP server's
+   * errors routinely embed instance hostnames, table names, sys_ids and
+   * query strings, all of which describe what the user was doing. The class
+   * name keeps the drilldown on the dashboard useful and is content-free by
+   * construction; `ERROR_NAME_PATTERN` enforces that.
+   */
+  exitErrorMessage?: string
+  /** Per-category counts, e.g. `{ servicenow: 12, mcp: 3 }`. End pings only. */
+  toolCounts?: Partial<Record<ToolCategory, number>>
+}
+
+/**
+ * The complete set of keys that may appear in a payload.
+ *
+ * This is the wire contract, not a comment about one: `sanitizePayload`
+ * rebuilds every outbound body from exactly these fields, so a key outside the
+ * list cannot survive the trip whatever the caller passed. Tests pin the list
+ * against what the sanitiser actually emits, in both directions.
+ */
+export const PAYLOAD_KEYS = [
+  "machineId",
+  "sessionId",
+  "version",
+  "channel",
+  "os",
+  "arch",
+  "installMethod",
+  "type",
+  "sessionDurationSec",
+  "timestamp",
+  "exitReason",
+  "exitErrorMessage",
+  "toolCounts",
+] as const
+
+const ERROR_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,39}$/
+
+// ---------------------------------------------------------------------------
+// Wire sanitisation
+// ---------------------------------------------------------------------------
+
+/** Both ids are `crypto.randomUUID()` output. Nothing else is an id here. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+/** Version/channel: what the route's `sanitizeString(..., 20)` accepts. */
+const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,19}$/
+/** `process.platform` / `process.arch` are lowercase alphanumerics, always. */
+const PLATFORM_PATTERN = /^[a-z0-9]{1,20}$/
+
+const MAX_TOOL_COUNT = 1_000_000
+
+/**
+ * Rebuild a payload from validated parts, or reject it entirely.
+ *
+ * Every request body goes through here (see `sendPing`), which is what makes
+ * "no free-form text leaves this machine" a property of the transport rather
+ * than of each caller. It matters because one caller does not build its own
+ * payload: `flushPendingEndPing` reads last run's ping back off disk, and that
+ * file is a plain 0644 JSON file any process running as this user can write.
+ * Without this, a planted or drifted file would be POSTed verbatim — and the
+ * receiving route stores `exitErrorMessage` free-form, so the client-side
+ * check is the only thing standing between a hand-written file and a hostname
+ * in the platform database.
+ *
+ * The patterns are deliberately tighter than "is a string": a UUID, a semver,
+ * a lowercase platform token and an enum cannot express a URL, an email
+ * address, a file path or a query. A field that fails is dropped when the
+ * route treats it as optional, and fails the whole ping when the route
+ * requires it — never repaired into something that looks plausible.
+ */
+export const sanitizePayload = (value: unknown): TelemetryPayload | undefined => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const raw = value as Record<string, unknown>
+
+  const matching = (key: string, pattern: RegExp): string | undefined => {
+    const candidate = raw[key]
+    return typeof candidate === "string" && pattern.test(candidate) ? candidate : undefined
+  }
+
+  const oneOf = <T extends string>(key: string, allowed: readonly T[]): T | undefined => {
+    const candidate = raw[key]
+    return typeof candidate === "string" && (allowed as readonly string[]).includes(candidate)
+      ? (candidate as T)
+      : undefined
+  }
+
+  const wholeNumber = (key: string): number | undefined => {
+    const candidate = raw[key]
+    if (typeof candidate !== "number" || !Number.isFinite(candidate) || candidate < 0) return undefined
+    return Math.floor(candidate)
+  }
+
+  // Required by the route: a ping missing any of these is a 400 anyway.
+  const machineId = matching("machineId", UUID_PATTERN)
+  const version = matching("version", VERSION_PATTERN)
+  const platform = matching("os", PLATFORM_PATTERN)
+  const arch = matching("arch", PLATFORM_PATTERN)
+  const type = oneOf("type", ["start", "end"] as const)
+  if (!machineId || !version || !platform || !arch || !type) return undefined
+
+  const sessionId = matching("sessionId", UUID_PATTERN)
+  const channel = matching("channel", VERSION_PATTERN)
+  const installMethod = oneOf("installMethod", INSTALL_METHODS)
+  const exitReason = type === "end" ? oneOf("exitReason", EXIT_REASONS) : undefined
+  const errorName = exitReason === "error" ? matching("exitErrorMessage", ERROR_NAME_PATTERN) : undefined
+
+  const toolCounts = ((): Partial<Record<ToolCategory, number>> | undefined => {
+    const candidate = raw["toolCounts"]
+    if (type !== "end" || typeof candidate !== "object" || candidate === null || Array.isArray(candidate)) return undefined
+    const counts: Partial<Record<ToolCategory, number>> = {}
+    for (const category of TOOL_CATEGORIES) {
+      const count = (candidate as Record<string, unknown>)[category]
+      if (typeof count !== "number" || !Number.isFinite(count)) continue
+      const whole = Math.min(Math.max(0, Math.floor(count)), MAX_TOOL_COUNT)
+      if (whole > 0) counts[category] = whole
+    }
+    return Object.keys(counts).length > 0 ? counts : undefined
+  })()
+
+  return {
+    machineId,
+    ...(sessionId ? { sessionId } : {}),
+    version,
+    ...(channel ? { channel } : {}),
+    os: platform,
+    arch,
+    ...(installMethod ? { installMethod } : {}),
+    type,
+    sessionDurationSec: wholeNumber("sessionDurationSec") ?? 0,
+    ...((): { timestamp?: number } => {
+      const stamp = wholeNumber("timestamp")
+      return stamp ? { timestamp: stamp } : {}
+    })(),
+    ...(exitReason ? { exitReason } : {}),
+    ...(errorName ? { exitErrorMessage: errorName } : {}),
+    ...(toolCounts ? { toolCounts } : {}),
+  } as TelemetryPayload
+}
+
+// ---------------------------------------------------------------------------
+// Opt-out
+// ---------------------------------------------------------------------------
+
+/**
+ * True when any opt-out signal is set.
+ *
+ * Slightly broader than the CLI's `1`/`true` check: any value that is not
+ * empty, `0` or `false` counts as opted out. Broadening an opt-out can only
+ * ever send less, and `DO_NOT_TRACK=yes` from a user who meant it should not
+ * silently keep tracking.
+ */
+export const isTelemetryDisabled = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const optedOut = (raw: string | undefined): boolean => {
+    if (raw === undefined) return false
+    const value = raw.trim().toLowerCase()
+    return value !== "" && value !== "0" && value !== "false"
+  }
+  return optedOut(env["DO_NOT_TRACK"]) || optedOut(env["CI"]) || optedOut(env["SERAC_TELEMETRY_DISABLED"])
+}
+
+// ---------------------------------------------------------------------------
+// State directory
+// ---------------------------------------------------------------------------
+
+/**
+ * `$XDG_STATE_HOME/serac/telemetry`, defaulting to `~/.local/state/serac/telemetry`.
+ *
+ * The CLI used opencode's `Global.Path.state`, which was `xdgState/opencode` —
+ * so XDG state is the faithful equivalent, not a new invention. It is also the
+ * correct XDG category for this data: an install id is state that persists
+ * between runs, is machine-local, is regenerable, and is neither configuration
+ * (`XDG_CONFIG_HOME`) nor a disposable cache.
+ *
+ * Deliberately NOT `~/.serac` (`seracHomePath()`), which is where this package
+ * keeps `auth.json`. Telemetry state and ServiceNow credentials should be
+ * separately deletable: `rm -rf ~/.local/state/serac` resets the install id
+ * without touching a single credential, which is exactly the reset a
+ * privacy-minded user wants to be able to perform.
+ *
+ * Per the XDG spec a relative `XDG_STATE_HOME` is invalid and ignored.
+ */
+export const telemetryStateDir = (env: NodeJS.ProcessEnv = process.env): string => {
+  const configured = env["XDG_STATE_HOME"]?.trim()
+  const home = env["HOME"] || env["USERPROFILE"] || os.homedir()
+  const base = configured && path.isAbsolute(configured) ? configured : path.join(home, ".local", "state")
+  return path.join(base, "serac", "telemetry")
+}
+
+export const installIdPath = (stateDir: string): string => path.join(stateDir, "install-id")
+export const pendingEndPingPath = (stateDir: string): string => path.join(stateDir, "pending-end.json")
+
+/**
+ * A random identifier, generated once and kept in the state directory.
+ *
+ * `node-machine-id` is a dependency of this package but is deliberately not
+ * used here: a hardware-derived id follows a machine across reinstalls and
+ * across every product on it. A stored random value identifies an
+ * installation, and deleting the state directory resets it. The trade-off is
+ * that a reinstall counts as a new install; that is the right side to err on.
+ */
+export const resolveInstallId = (stateDir: string): string | undefined => {
+  const file = installIdPath(stateDir)
+  try {
+    fs.mkdirSync(stateDir, { recursive: true })
+    if (fs.existsSync(file)) {
+      const existing = fs.readFileSync(file, "utf-8").trim()
+      if (existing) return existing
+    }
+    const fresh = randomUUID()
+    fs.writeFileSync(file, fresh, "utf-8")
+    return fresh
+  } catch (error) {
+    mcpDebug("[telemetry] could not establish an install id:", String(error))
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Version + channel
+// ---------------------------------------------------------------------------
+
+export interface PackageIdentity {
+  version: string
+  channel: string
+}
+
+/**
+ * `dist/telemetry/anonymous-telemetry.js` and `src/telemetry/anonymous-telemetry.ts`
+ * sit at the same depth (tsconfig.build.json maps rootDir `src` → outDir
+ * `dist`), so one relative path reaches package.json in both layouts.
+ */
+const defaultPackageJsonPath = (): string =>
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json")
+
+/**
+ * Read version + channel from this package's own package.json.
+ *
+ * The CLI got these from build-time globals in a package that no longer
+ * exists. `sanitizeString(version, 20)` on the receiving route rejects
+ * anything outside `[a-zA-Z0-9._-]`, and a rejected version is a 400 for the
+ * whole ping — so semver build metadata (`+sha`) is dropped and the result is
+ * clamped to 20 characters. The channel is the first prerelease identifier
+ * (`0.3.0-beta.1` → `beta`), or `latest` for a plain release, matching what
+ * the route defaults to.
+ */
+export const readPackageIdentity = (packageJsonPath: string = defaultPackageJsonPath()): PackageIdentity => {
+  const parse = (): string | undefined => {
+    try {
+      const raw = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as { version?: unknown }
+      return typeof raw.version === "string" ? raw.version : undefined
+    } catch (error) {
+      mcpDebug("[telemetry] could not read package.json:", String(error))
+      return undefined
+    }
+  }
+
+  const declared = parse()
+  if (!declared) return { version: "0.0.0", channel: "local" }
+
+  const withoutBuild = declared.split("+")[0] ?? declared
+  const version = withoutBuild.replace(/[^a-zA-Z0-9._-]/g, "").slice(0, 20) || "0.0.0"
+  const prerelease = version.split("-")[1]
+  const channel = prerelease ? prerelease.split(".")[0]!.slice(0, 20) : "latest"
+  return { version, channel }
+}
+
+// ---------------------------------------------------------------------------
+// Install method
+// ---------------------------------------------------------------------------
+
+export interface InstallProbe {
+  /** `npm_config_user_agent`, set by npx/bunx and by npm lifecycle scripts. */
+  userAgent?: string
+  /** `process.execPath` — the interpreter, or the executable for a compiled build. */
+  execPath: string
+  /** Filesystem path of this module. */
+  modulePath: string
+  /** Whether the Bun runtime is present. */
+  hasBunRuntime: boolean
+  /** Whether we appear to be inside a container image. */
+  inContainer: boolean
+}
+
+/**
+ * Map how this server was launched onto the receiving route's allowlist
+ * (`npm | bun | brew | binary | other`). Anything outside it is dropped to
+ * null server-side, so guessing a nicer-sounding value would just lose the
+ * signal.
+ *
+ * The CLI detected CLI install shapes. An MCP server is typically started by
+ * a client config as `npx @serac-labs/servicenow-mcp`, as a globally
+ * installed binary on PATH, or as `docker run -i`. Mapping used here:
+ *
+ *   npx / npm-spawned          → npm
+ *   bunx / the Bun runtime     → bun
+ *   Homebrew-installed node    → brew
+ *   compiled single-file build → binary
+ *   installed under node_modules and spawned directly → npm
+ *   container, pnpm/yarn dlx, a plain source checkout → other
+ *
+ * `other` is used where it is the truthful answer. Docker is not an install
+ * method the allowlist knows about, and pretending `pnpm dlx` is npm would be
+ * a lie about a different package manager — both are honestly `other`.
+ */
+export const detectInstallMethod = (probe: InstallProbe): InstallMethod => {
+  // Checked first: in a container the image was built by someone else, so
+  // whatever package manager ran during the build says nothing about how a
+  // user installed anything.
+  if (probe.inContainer) return "other"
+
+  const agent = probe.userAgent?.trim().toLowerCase()
+  if (agent) {
+    if (agent.startsWith("bun")) return "bun"
+    if (agent.startsWith("npm")) return "npm"
+    // pnpm, yarn, deno, anything else: not in the allowlist.
+    return "other"
+  }
+
+  const execPath = probe.execPath || ""
+  if (/(^|\/)(Cellar|homebrew|linuxbrew)(\/|$)/i.test(execPath)) return "brew"
+
+  // A compiled single-file executable runs itself, not an interpreter. Checked
+  // before the Bun-runtime test because `bun build --compile` output also has
+  // `globalThis.Bun`, and the honest answer there is "binary".
+  const interpreter = path.basename(execPath).toLowerCase().replace(/\.exe$/, "")
+  if (interpreter && interpreter !== "node" && interpreter !== "bun" && interpreter !== "deno") return "binary"
+
+  if (probe.hasBunRuntime) return "bun"
+  if (probe.modulePath.includes(`${path.sep}node_modules${path.sep}`)) return "npm"
+
+  // Running from a source checkout under plain node.
+  return "other"
+}
+
+const detectContainer = (): boolean => {
+  try {
+    if (fs.existsSync("/.dockerenv")) return true
+    if (process.env["KUBERNETES_SERVICE_HOST"]) return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+export const currentInstallProbe = (): InstallProbe => ({
+  userAgent: process.env["npm_config_user_agent"],
+  execPath: process.execPath || "",
+  modulePath: (() => {
+    try {
+      return fileURLToPath(import.meta.url)
+    } catch {
+      return ""
+    }
+  })(),
+  hasBunRuntime: typeof (globalThis as { Bun?: unknown }).Bun !== "undefined",
+  inContainer: detectContainer(),
+})
+
+// ---------------------------------------------------------------------------
+// Tool categories
+// ---------------------------------------------------------------------------
+
+/**
+ * Reduce a tool name to one of the receiving route's categories. The name is
+ * consumed here and never stored: only the per-category counter moves on.
+ *
+ * `builtin` is never produced. In the CLI it meant the agent's own
+ * filesystem/shell tools; this server has none. It stays in the type because
+ * the receiving end still accepts it and the shape must not drift.
+ */
+export const categorizeTool = (toolName: string): ToolCategory =>
+  toolName.startsWith("snow_") ? "servicenow" : "mcp"
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+/**
+ * POST one ping. Never throws, never retries here.
+ *
+ * `abort` is how a shutdown reclaims the process: an in-flight fetch is a live
+ * handle, so without it a portal that accepts a socket and never answers keeps
+ * the server alive for the full send timeout after the client has already
+ * closed the pipe. `AbortSignal.any` is deliberately not used — it is Node
+ * 20.3+, and one controller listening to both sources works everywhere.
+ */
+export const sendPing = async (portalUrl: string, payload: TelemetryPayload, abort?: AbortSignal): Promise<boolean> => {
+  // Sanitising here rather than at each call site is the point: this is the
+  // only function in the package that opens a socket to the portal, so a
+  // field that was never validated cannot reach the wire by any route.
+  const body = sanitizePayload(payload)
+  if (!body) {
+    mcpDebug("[telemetry] refusing to send a payload that failed validation")
+    return false
+  }
+  const controller = new AbortController()
+  const stop = (): void => controller.abort()
+  const timer: any = setTimeout(stop, SEND_TIMEOUT_MS)
+  timer?.unref?.()
+  abort?.addEventListener("abort", stop, { once: true })
+  try {
+    const response = await fetch(`${portalUrl}${PING_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    mcpDebug(`[telemetry] ${payload.type} ping → ${response.status}`)
+    return response.ok
+  } catch (error) {
+    mcpDebug(`[telemetry] ${payload.type} ping failed:`, String(error))
+    return false
+  } finally {
+    clearTimeout(timer)
+    abort?.removeEventListener("abort", stop)
+  }
+}
+
+const writePendingEndPing = (stateDir: string, payload: TelemetryPayload): void => {
+  try {
+    fs.mkdirSync(stateDir, { recursive: true })
+    fs.writeFileSync(pendingEndPingPath(stateDir), JSON.stringify(payload), "utf-8")
+  } catch (error) {
+    mcpDebug("[telemetry] could not persist the pending end ping:", String(error))
+  }
+}
+
+const clearPendingEndPing = (stateDir: string): void => {
+  try {
+    fs.rmSync(pendingEndPingPath(stateDir), { force: true })
+  } catch {
+    /* nothing to do — the next run overwrites it */
+  }
+}
+
+/**
+ * Deliver the previous run's end ping, if it never made it.
+ *
+ * A process exit tears down the event loop before an in-flight fetch can
+ * resolve, which is why end pings were historically far rarer than starts.
+ * Every end ping is written to disk first and only cleared once it has been
+ * accepted; this is where the retry happens.
+ *
+ * The file is treated as untrusted input, because it is: it is a world-readable
+ * JSON file in a predictable location, and a future version of this package
+ * could also leave a differently-shaped one behind. It is re-validated through
+ * `sanitizePayload` and discarded — not sent, not kept — when it is not a
+ * well-formed end ping.
+ */
+export const flushPendingEndPing = async (stateDir: string, portalUrl: string, abort?: AbortSignal): Promise<boolean> => {
+  const file = pendingEndPingPath(stateDir)
+  const pending = ((): TelemetryPayload | undefined => {
+    try {
+      if (!fs.existsSync(file)) return undefined
+      const parsed = sanitizePayload(JSON.parse(fs.readFileSync(file, "utf-8")))
+      if (parsed?.type === "end") return parsed
+      mcpDebug("[telemetry] discarding a pending end ping that is not a valid end payload")
+      clearPendingEndPing(stateDir)
+      return undefined
+    } catch (error) {
+      mcpDebug("[telemetry] could not read the pending end ping:", String(error))
+      clearPendingEndPing(stateDir)
+      return undefined
+    }
+  })()
+  if (!pending) return false
+  const sent = await sendPing(portalUrl, pending, abort)
+  if (sent) clearPendingEndPing(stateDir)
+  return sent
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+export interface SessionDeps {
+  env?: NodeJS.ProcessEnv
+  stateDir?: string
+  portalUrl?: string
+  identity?: PackageIdentity
+  installMethod?: InstallMethod
+  now?: () => number
+}
+
+export interface TelemetrySession {
+  /** False when opted out or when no install id could be established. */
+  readonly enabled: boolean
+  /** Fire the start ping and retry the previous run's end ping. Non-blocking. */
+  start: () => void
+  /** Count one tool call by category. The name is not retained. */
+  recordToolCall: (toolName: string) => void
+  /** Persist and send the end ping. Idempotent, non-blocking. */
+  finish: (reason: ExitReason, error?: unknown) => void
+  /** Synchronous, network-free end. For `process.on("exit")` and for crashes. */
+  persistPendingEnd: (reason: ExitReason, error?: unknown) => void
+  /** Briefly wait for the in-flight pings before the process exits. */
+  settle: (timeoutMs?: number) => Promise<void>
+  /** Test seam: resolves once the in-flight pings settle. */
+  readonly inFlight: () => Promise<void>
+}
+
+/**
+ * The error's class name, if it is one.
+ *
+ * Wrapped in a try/catch because reading `.name` runs user code: an object
+ * whose `name` is a throwing getter would otherwise make `finish()` throw, and
+ * both of its callers are the worst possible places for that — the fatal-error
+ * handler in the stdio entry (the throw would escape `main()` and skip
+ * `process.exit(1)`) and the `uncaughtExceptionMonitor` handler. This module
+ * promises that every failure path is silent and non-fatal; that has to
+ * include this one.
+ */
+const errorClassName = (error: unknown): string | undefined => {
+  try {
+    const name = error instanceof Error ? error.name : typeof error === "object" && error ? error.constructor?.name : undefined
+    return typeof name === "string" && ERROR_NAME_PATTERN.test(name) ? name : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Build a telemetry session. All state lives in this closure — the module
+ * itself holds none, so a process can hold several (the tests do) and nothing
+ * leaks between them.
+ *
+ * Every failure path is silent and non-fatal: a missing state directory, an
+ * unreachable portal, a malformed package.json and a rejected fetch all end
+ * as a no-op. Nothing here is ever awaited by the MCP server.
+ */
+export const createSession = (deps: SessionDeps = {}): TelemetrySession => {
+  const env = deps.env ?? process.env
+  const now = deps.now ?? Date.now
+  const portalUrl = (deps.portalUrl ?? env["SERAC_PORTAL_URL"] ?? DEFAULT_PORTAL_URL).replace(/\/+$/, "")
+  const stateDir = deps.stateDir ?? telemetryStateDir(env)
+
+  const counts: Partial<Record<ToolCategory, number>> = {}
+  // Aborted by `settle()` when it runs out of patience, so a hung request can
+  // never be what keeps a finished server's process alive.
+  const shutdown = new AbortController()
+  const pending = new Set<Promise<unknown>>()
+  const track = (promise: Promise<unknown>): void => {
+    pending.add(promise)
+    void promise.finally(() => pending.delete(promise))
+  }
+
+  const disabled = isTelemetryDisabled(env)
+  const machineId = disabled ? undefined : resolveInstallId(stateDir)
+
+  const noop: TelemetrySession = {
+    enabled: false,
+    start: () => {},
+    recordToolCall: () => {},
+    finish: () => {},
+    persistPendingEnd: () => {},
+    settle: async () => {},
+    inFlight: async () => {},
+  }
+
+  if (disabled) {
+    mcpDebug("[telemetry] disabled by environment")
+    return noop
+  }
+  if (!machineId) return noop
+
+  const identity = deps.identity ?? readPackageIdentity()
+  const installMethod = deps.installMethod ?? detectInstallMethod(currentInstallProbe())
+  const sessionId = randomUUID()
+  const startedAt = now()
+
+  const state = { started: false, ended: false }
+
+  const base = {
+    machineId,
+    sessionId,
+    version: identity.version,
+    channel: identity.channel,
+    os: process.platform,
+    arch: process.arch,
+    installMethod,
+  }
+
+  const endPayload = (reason: ExitReason, error?: unknown): TelemetryPayload => {
+    const name = reason === "error" ? errorClassName(error) : undefined
+    return {
+      ...base,
+      type: "end",
+      sessionDurationSec: Math.max(0, Math.round((now() - startedAt) / 1000)),
+      timestamp: now(),
+      exitReason: reason,
+      ...(name ? { exitErrorMessage: name } : {}),
+      ...(Object.keys(counts).length > 0 ? { toolCounts: { ...counts } } : {}),
+    }
+  }
+
+  return {
+    enabled: true,
+
+    start: () => {
+      if (state.started) return
+      state.started = true
+      track(flushPendingEndPing(stateDir, portalUrl, shutdown.signal))
+      track(sendPing(portalUrl, { ...base, type: "start", sessionDurationSec: 0, timestamp: now() }, shutdown.signal))
+    },
+
+    recordToolCall: (toolName: string) => {
+      if (!toolName) return
+      const category = categorizeTool(toolName)
+      counts[category] = (counts[category] ?? 0) + 1
+    },
+
+    finish: (reason: ExitReason, error?: unknown) => {
+      if (state.ended) return
+      state.ended = true
+      const payload = endPayload(reason, error)
+      // Persist first, always: if the process dies before the fetch resolves,
+      // the next launch retries it. Only a confirmed delivery clears the file.
+      writePendingEndPing(stateDir, payload)
+      track(
+        sendPing(portalUrl, payload, shutdown.signal).then((sent) => {
+          if (sent) clearPendingEndPing(stateDir)
+        }),
+      )
+    },
+
+    persistPendingEnd: (reason: ExitReason, error?: unknown) => {
+      if (state.ended) return
+      state.ended = true
+      writePendingEndPing(stateDir, endPayload(reason, error))
+    },
+
+    /**
+     * Wait, with a hard cap, for the in-flight pings — then decide what an
+     * unanswered request means.
+     *
+     * `finish()` keeps the end ping on disk until delivery is *confirmed*, so
+     * a ping the portal accepted at 1.2s while this cap expired at 1.0s would
+     * be re-sent by the next launch and stored twice; the route has no dedupe,
+     * and a duplicate end row double-counts tool calls and pushes the session
+     * completion rate above 100%. Reproduced with a portal held at a 1.2s
+     * round trip: 7 stored end rows for 4 real sessions.
+     *
+     * So an unconfirmed request is treated as delivered and the file is
+     * dropped. The alternative — waiting longer — delays every shutdown for
+     * everyone, and the alternative to that is corrupting the numbers. Only
+     * the ambiguous case is affected: a portal that is offline, refusing
+     * connections or unresolvable rejects in milliseconds, well inside the
+     * cap, and those pings are still kept and retried on the next launch. The
+     * cost is an occasional lost end ping for a user behind a connection that
+     * accepts a socket and never answers, which is the right way round —
+     * under-counting is a shape this dashboard already has, over-counting is
+     * not.
+     *
+     * Reaching the cap also aborts the requests. A pending fetch is a live
+     * handle that keeps the process alive on its own, so on the shutdown path
+     * that does not call `process.exit` — a client closing stdin — leaving it
+     * running would hold a finished server open for the full send timeout.
+     * Aborting makes the cap a real ceiling on how long telemetry can outlive
+     * the server: measured against a portal that never answers, 5.2s down to
+     * 1.1s.
+     */
+    settle: async (timeoutMs = SETTLE_TIMEOUT_MS) => {
+      if (pending.size === 0) return
+      const timedOut = await Promise.race([
+        Promise.allSettled([...pending]).then(() => false),
+        new Promise<boolean>((resolve) => {
+          const timer: any = setTimeout(() => resolve(true), timeoutMs)
+          timer?.unref?.()
+        }),
+      ])
+      if (!timedOut) return
+      shutdown.abort()
+      if (state.ended) clearPendingEndPing(stateDir)
+    },
+
+    inFlight: async () => {
+      await Promise.allSettled([...pending])
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide singleton
+// ---------------------------------------------------------------------------
+
+const singleton: { session?: TelemetrySession } = {}
+
+/**
+ * The process-lifetime session used by the stdio entry point. For stdio,
+ * process lifetime *is* the session: one user, one client, one server
+ * process, start to exit.
+ */
+export const AnonymousTelemetry = {
+  /**
+   * Call once from the stdio entry point. Never throws, never awaits.
+   *
+   * Two process listeners are attached, both chosen so the MCP server's own
+   * behaviour does not change:
+   *
+   *   - `uncaughtExceptionMonitor`, not `uncaughtException`. Registering an
+   *     `uncaughtException` handler *suppresses* the default crash, which
+   *     would leave a broken MCP server running and answering requests. The
+   *     monitor variant observes the error and lets Node die exactly as it
+   *     would have. Since Node 15 an unhandled rejection is raised as an
+   *     uncaught exception too, so this covers both without a
+   *     `unhandledRejection` listener, which would also swallow the default.
+   *
+   *     It only *persists* the end ping. Sending is pointless here and worse
+   *     than pointless: the process is already dying, so nothing can observe
+   *     the response and clear the file. A live crash run showed the request
+   *     arriving and being stored, the process dying before the 200 was read,
+   *     and the next launch re-sending the same session — two end rows for one
+   *     crash. Deferring delivery to the next launch's flush makes the crash
+   *     path exactly-once, like the normal-exit path already is.
+   *   - `beforeExit`, which is how the *common* shutdown is caught. The MCP
+   *     spec's first step for stopping a stdio server is to close the child's
+   *     stdin and wait; no signal is sent, and the SDK's
+   *     `StdioServerTransport` never listens for stdin's `end` either, so
+   *     nothing in the server observes that shutdown at all. What actually
+   *     happens is that the event loop runs dry — which is precisely when
+   *     `beforeExit` fires, and only then, since a connected transport keeps
+   *     stdin referenced. Sending here rather than only persisting is what
+   *     stops every end ping from arriving one launch late, with the last
+   *     session before a user stops never arriving at all. The in-flight ping
+   *     re-fills the event loop by itself, so the process lives exactly as
+   *     long as the request does (3s ceiling, the fetch's own timeout) and
+   *     `beforeExit` firing again afterwards is a no-op, because `finish()`
+   *     is idempotent.
+   *   - `exit`, which must be synchronous: it only writes the pending end
+   *     ping, leaving delivery to the next launch's flush. It is the backstop
+   *     for the paths `beforeExit` never sees — `process.exit()` and a fatal
+   *     signal.
+   *
+   * SIGINT/SIGTERM are intentionally NOT handled here. The entry point already
+   * owns those, and a second listener registered before the entry point's own
+   * would swallow the signal during startup and hang the server.
+   */
+  start: (deps: SessionDeps = {}): void => {
+    if (singleton.session) return
+    const session = createSession(deps)
+    singleton.session = session
+    if (!session.enabled) return
+    session.start()
+    process.on("uncaughtExceptionMonitor", (error: unknown) => session.persistPendingEnd("error", error))
+    process.on("beforeExit", () => {
+      session.finish("normal")
+      void session.settle()
+    })
+    process.on("exit", () => session.persistPendingEnd("normal"))
+  },
+
+  recordToolCall: (toolName: string): void => singleton.session?.recordToolCall(toolName),
+
+  finish: (reason: ExitReason, error?: unknown): void => singleton.session?.finish(reason, error),
+
+  /**
+   * Wait, briefly and with a hard cap, for the end ping to settle. Call this
+   * on a shutdown path that ends in `process.exit()`, after the server has
+   * been stopped.
+   *
+   * Why this exists: `finish()` persists the end ping and only deletes the
+   * file once delivery is confirmed. `process.exit()` tears the event loop
+   * down mid-fetch, so a ping the portal *did* accept still left its file
+   * behind — and the next launch re-sent it. That produced a duplicate end
+   * row for every clean session, and the receiving route has no dedupe. A
+   * live run against a local portal reproduced it on every single session.
+   *
+   * This delays nothing the user is waiting on: the MCP server is already
+   * closed by this point, no request can be in flight, and the cap is one
+   * second (the ping's own timeout is three). See `TelemetrySession.settle`
+   * for what happens when the cap is reached.
+   */
+  settle: (timeoutMs?: number): Promise<void> => singleton.session?.settle(timeoutMs) ?? Promise.resolve(),
+}


### PR DESCRIPTION
Telemetry lived in the CLI and went with it when `packages/opencode` was removed. It had been dead longer than that: restored on 2026-08-13, but `@serac-labs/core` has not published since 2026-06-23, so the restored code never reached a single user. Production last saw a signal on **2026-07-26**.

Ported onto the MCP, which is now the only thing serac ships. The receiving end is unchanged — same endpoint, same fields, same allowlists.

## stdio only, structurally

stdio is one person running the server locally; that is the population this measures. HTTP is the multi-tenant server **the platform** runs — a ping from there would measure our own infrastructure, file many tenants as one install, and send data for users who installed nothing. The platform already records that in `mcp_usage`.

So the mechanism, not the intention:
- the module sits in `src/telemetry/`, **outside** the `shared/` tree both transports import
- a test walks the real import graph from `http-entry.ts`, `http.ts` and `src/index.ts` and asserts it is unreachable
- the same test asserts the stdio entry **does** reach it, so deleting the wiring fails
- and that `createHttpApp` has no `onToolCall` parameter, so there is no symmetrical mistake available

## What leaves the machine

`machineId` (random UUID, per install, resettable by deleting the state dir) · `sessionId` · `version` · `channel` · `os` · `arch` · `installMethod` · `type` · `sessionDurationSec` · `timestamp` · `exitReason` · `toolCounts` (by **category** only — `servicenow`/`mcp`, never a tool name or an instance).

Three deliberate deviations from the CLI original:

| | Why |
|---|---|
| `exitErrorMessage` carries the error **class**, never the message | The CLI sent 500 chars. An MCP server's errors routinely embed instance hostnames, sys_ids and queries — that is content derived from what the user was doing. |
| `uncaughtExceptionMonitor`, not `uncaughtException` | Registering the latter *suppresses* the crash, leaving a broken server answering requests. |
| Signals stay with the entry point | A second listener registered during bootstrap would swallow SIGINT and hang the server. |

## Two defects found by running it, not reading it

**Every clean session was counted twice.** A delivered end ping left `pending-end.json` on disk because `process.exit` tore down the event loop before the clear ran, so the next launch re-sent it. `settle()` now waits, capped at 1s, after the server is already closed.

**The retry path leaked.** It POSTed the on-disk file verbatim; the privacy review demonstrated an instance hostname, an org id and a path-bearing error message leaving that way. It now re-sanitises before sending. Verified independently: a hostile pending file loses `instanceUrl`, `organizationId`, `tenantId`, `filePath` and the error message, while a legitimate one still flushes.

## Verification

`typecheck` clean · **252 tests pass** · `build` succeeds. A live harness against a local stand-in confirmed start+end pings on stdio, **zero** pings from the HTTP transport, zero pings and no state directory under `DO_NOT_TRACK=1`, and a crash that still exits 1 with a stack trace while reporting only `TypeError`.

## For you to decide

Whether it should be **on by default** at all, for a tool that talks to customer ServiceNow instances. The opt-outs are there (`DO_NOT_TRACK`, `CI`, `SERAC_TELEMETRY_DISABLED`), but "on unless told otherwise" is a product choice, not a technical one — and it belongs in the README either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)