### PR TITLE
chore: replace Dependabot with self-hosted Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,13 +7,23 @@ name: Renovate
 # the execution inside our own Actions. Given this repo publishes an npm package
 # that talks to customer ServiceNow instances, that seemed the better trade.
 #
-# IT IS NOT FREE OF TRADE-OFFS. It needs RENOVATE_TOKEN — a PAT with
-# `public_repo`, or a token minted from an app you own. The default GITHUB_TOKEN
-# will NOT do: GitHub deliberately does not trigger workflows on pull requests
-# created with it, so Renovate's PRs would arrive with no CI at all and we would
-# be merging dependency bumps blind. So the choice is a third-party app, or a
-# long-lived credential in repo secrets. Neither is free; this one at least
-# keeps the code execution ours.
+# IT IS NOT FREE OF TRADE-OFFS. It needs RENOVATE_TOKEN. Fine-grained, scoped to
+# this repository: Contents read/write, Pull requests read/write, Metadata read.
+# Classic equivalent: `public_repo` alone — NOT full `repo`, which would also
+# reach private repositories this token has no business in.
+#
+# Deliberately NOT granted: `workflow`. Renovate would otherwise want to bump
+# the pinned action SHAs under .github/workflows, and a long-lived token that
+# can rewrite CI is a real escalation — whoever held it could redirect a build
+# to exfiltrate secrets. renovate.json routes github-actions updates to the
+# dependency dashboard instead, so we still hear about them and apply them by
+# hand.
+#
+# The default GITHUB_TOKEN will NOT do either: GitHub deliberately does not
+# trigger workflows on pull requests created with it, so Renovate's PRs would
+# arrive with no CI at all and we would be merging dependency bumps blind. So
+# the choice is a third-party app, or a long-lived credential in repo secrets.
+# Neither is free; this one at least keeps the code execution ours.
 #
 # Cost: the repo is public, so standard runners are unmetered. A run over two
 # packages and about a dozen dependencies takes a couple of minutes.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,78 @@
+name: Renovate
+
+# Self-hosted Renovate, rather than the hosted GitHub App.
+#
+# Same bot, same renovate.json — the only difference is who runs it. The App
+# means granting a third party write access to this repo; running it here keeps
+# the execution inside our own Actions. Given this repo publishes an npm package
+# that talks to customer ServiceNow instances, that seemed the better trade.
+#
+# IT IS NOT FREE OF TRADE-OFFS. It needs RENOVATE_TOKEN — a PAT with
+# `public_repo`, or a token minted from an app you own. The default GITHUB_TOKEN
+# will NOT do: GitHub deliberately does not trigger workflows on pull requests
+# created with it, so Renovate's PRs would arrive with no CI at all and we would
+# be merging dependency bumps blind. So the choice is a third-party app, or a
+# long-lived credential in repo secrets. Neither is free; this one at least
+# keeps the code execution ours.
+#
+# Cost: the repo is public, so standard runners are unmetered. A run over two
+# packages and about a dozen dependencies takes a couple of minutes.
+
+on:
+  schedule:
+    # Daily at 04:00 UTC. The cadence for ordinary updates is set in
+    # renovate.json (grouped, weekly); running daily only means a security
+    # advisory — which bypasses that schedule — is picked up within a day
+    # instead of within a week.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: "Renovate log level"
+        type: choice
+        options: [info, debug]
+        default: info
+      dry_run:
+        description: "Report what it would do, change nothing"
+        type: boolean
+        default: false
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    # A fork running this on its own schedule would do nothing useful and would
+    # fail noisily on the missing secret.
+    if: github.repository == 'serac-labs/serac'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Refuse to run without a token
+        # Fail loudly and early rather than letting Renovate start, find no
+        # credentials and log something ambiguous. A dependency bot that
+        # silently does nothing is how advisories sit for months.
+        run: |
+          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+            echo "::error::RENOVATE_TOKEN is not set. Create a PAT with public_repo scope and add it as a repository secret."
+            exit 1
+          fi
+
+      - name: Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
+        env:
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run && 'full' || '' }}
+          # Read the config from the repo rather than restating it here, so the
+          # hosted App and this workflow can never drift apart.
+          RENOVATE_REPOSITORIES: serac-labs/serac
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REQUIRE_CONFIG: "required"
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "description": [
+    "Replaces Dependabot, which cannot land a PR in this repo at all: it updates",
+    "package.json but not bun.lock, so `bun install --frozen-lockfile` fails before",
+    "a single test runs. Both of its security PRs (axios, hono) were stuck that way",
+    "until they were applied by hand in #282. Renovate runs the package manager",
+    "itself, so the lockfile moves with the manifest.",
+    "",
+    "There are TWO lockfiles and that is deliberate: the root bun.lock for the",
+    "workspace, and packages/servicenow-mcp/bun.lock which the publish workflow's",
+    "standalone gate uses to prove the package still builds lifted out of the",
+    "monorepo. Both must move together or that gate fails \u2014 which is exactly what",
+    "happened when only the root one was refreshed."
+  ],
+  "timezone": "Europe/Amsterdam",
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "prConcurrentLimit": 5,
+  "labels": [
+    "dependencies"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 6am on the first day of the month"
+    ]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "dependencies",
+      "security"
+    ],
+    "schedule": null,
+    "prCreation": "immediate",
+    "minimumReleaseAge": null
+  },
+  "packageRules": [
+    {
+      "description": "Group the low-risk updates into one PR a week. This repo is two packages and about a dozen dependencies; a PR per patch bump is more review than the risk deserves.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "non-major dependencies"
+    },
+    {
+      "description": "Majors stay separate and are never automatic. axios and hono are how this server reaches customer ServiceNow instances, and @modelcontextprotocol/sdk is the wire protocol \u2014 a major there is a behaviour change, not a bump.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Let a release settle before adopting it, except for advisories, which vulnerabilityAlerts above exempts.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "minimumReleaseAge": "3 days"
+    }
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency dashboard"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,13 @@
         "patch"
       ],
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "GitHub Actions are reported on the dashboard, never opened as PRs. Renovate would need the `workflow` scope to push a change under .github/workflows, and a long-lived token that can rewrite CI is a meaningful escalation \u2014 whoever holds it could redirect a build to exfiltrate secrets. Action bumps are rare enough to do by hand; the dashboard makes sure we still hear about them.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "dependencyDashboardApproval": true
     }
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
**Dependabot cannot land a PR in this repo.** It updates `package.json` but not `bun.lock`, so `bun install --frozen-lockfile` fails before a single test runs. Both of its security PRs — axios and hono, genuine advisories — sat stuck that way until #282 applied them by hand. Every future Dependabot PR here would fail identically.

Renovate runs the package manager itself, so the lockfile moves with the manifest.

## Self-hosted, not the App

Running it as a workflow in this repo rather than installing the hosted GitHub App. The App would mean granting a third party write access to a repo that publishes an npm package talking to customer ServiceNow instances; this keeps the execution ours.

**That is a trade, not a free win**, and the workflow comment says so:

It needs `RENOVATE_TOKEN` — a PAT with `public_repo` scope. The default `GITHUB_TOKEN` will **not** do: GitHub deliberately does not trigger workflows on PRs created with it, so Renovate's PRs would arrive with **no CI at all** and we would be merging dependency bumps blind. So the real choice is *a third-party app* or *a long-lived credential in repo secrets*. Neither is free. This one at least keeps the code execution inside our own Actions, and the token is scoped to public repos.

If you would rather have the App after all, deleting the workflow is the whole change — `renovate.json` is identical either way.

## Config

| | |
|---|---|
| minor + patch | grouped into one PR a week, after 3 days settling |
| major | held behind dashboard approval |
| advisories | bypass all of it, open immediately |
| lockfile maintenance | monthly |

Majors are gated deliberately: `axios` and `hono` are how this server reaches customer ServiceNow instances, and `@modelcontextprotocol/sdk` is the wire protocol. A major there is a behaviour change, not a bump.

The workflow runs **daily** even though updates are grouped weekly — that only means an advisory is picked up within a day instead of a week.

## The two lockfiles

Both must move together, and this already bit once. The root `bun.lock` for the workspace, **and** `packages/servicenow-mcp/bun.lock`, which the publish workflow's standalone gate uses to prove the package still builds lifted out of the monorepo. Refreshing only the root one is what left #282 red until I regenerated the second outside the workspace.

## Cost

Not a factor: the repo is **public**, so standard runners are unmetered. A run over two packages and a dozen dependencies takes a couple of minutes.

## Two things only you can do

1. **Create the PAT** (`public_repo` scope) and add it as repository secret `RENOVATE_TOKEN`. The job fails loudly if it is missing rather than starting and quietly finding no credentials — that silence is how two real advisories sat for weeks.
2. **Turn off Dependabot security updates** in repo settings, but **leave the alerts on**. The alerts are the detection and worth keeping; only the PRs cannot work here.

## Worth noting

Open advisories went **112 → 53 → 1** across yesterday: the strip removed most of the surface, #282 cleared the rest. What remains is `form-data` (high, CVE-2026-12143) in the MCP, transitive — Renovate should pick it up on its first run.

Validated with Renovate's own config validator (which rejected my first attempt for an invalid key), and the action is pinned by SHA like everything else here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)