### PR TITLE
docs(renovate): the token also needs Dependabot alerts read

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,18 @@ name: Renovate
 # that talks to customer ServiceNow instances, that seemed the better trade.
 #
 # IT IS NOT FREE OF TRADE-OFFS. It needs RENOVATE_TOKEN. Fine-grained, scoped to
-# this repository: Contents read/write, Pull requests read/write, Metadata read.
+# this repository:
+#   Contents           read/write
+#   Pull requests      read/write
+#   Metadata           read        (mandatory, added automatically)
+#   Dependabot alerts  read        <- easy to miss, and the one that matters most
+#
+# Without the alerts permission Renovate logs "Cannot access vulnerability
+# alerts" as a WARNING and carries on: the run goes green, ordinary updates keep
+# flowing, and the vulnerabilityAlerts rule in renovate.json simply never fires.
+# Security PRs — the whole reason for moving off Dependabot — would silently
+# never open. The first dry run here hit exactly that.
+#
 # Classic equivalent: `public_repo` alone — NOT full `repo`, which would also
 # reach private repositories this token has no business in.
 #


### PR DESCRIPTION
The first Renovate dry run logged this and then **finished green**:

```
WARN: Cannot access vulnerability alerts. Please ensure permissions have been granted.
```

That is the dangerous shape. Ordinary updates keep flowing, the run looks healthy, and the `vulnerabilityAlerts` rule in `renovate.json` simply never fires — so security PRs, the entire reason for moving off Dependabot, would silently never open. Exactly the failure mode this whole switch was meant to end.

Spells the four permissions out as a list rather than a sentence, with the easily-missed one marked:

| Permission | Level |
|---|---|
| Contents | read/write |
| Pull requests | read/write |
| Metadata | read (mandatory, automatic) |
| **Dependabot alerts** | **read** ← easy to miss |

`RENOVATE_TOKEN` is already set on the repo but was created without the alerts permission; it needs editing (or reissuing) before Renovate can see the open `form-data` advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)