### PR TITLE
docs: refresh repo positioning after the un-fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ also what CI installs.
 ```bash
 bun install
 bun typecheck          # tsgo across both packages
-bun run test           # both suites: 168 MCP tests, 60 skills tests
+bun run test           # both suites
 bun run lint           # oxlint
 ```
 

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -4,14 +4,8 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for ServiceNo
 stdio or streamable HTTP, plus blast-radius impact analysis. Part of [Serac](https://serac.build).
 
 ```bash
-npm install -g @serac-labs/servicenow-mcp@next
+npm install -g @serac-labs/servicenow-mcp
 ```
-
-> **Why `@next`:** the `latest` tag still points at 0.1.0, whose main entrypoint cannot be imported
-> under Node — it does a named import of `machineIdSync` from `node-machine-id`, a CJS module Node's
-> lexer cannot read named exports from, which takes out 4 of 11 subpaths and both bins. 0.2.0 on
-> `next` is the fixed build. Promote it (`npm dist-tag add @serac-labs/servicenow-mcp@0.2.0 latest`,
-> see the header of `.github/workflows/publish-mcp.yml`), then drop the `@next` and this note.
 
 ## Use it as an MCP server
 

--- a/packages/servicenow-mcp/src/enterprise-proxy/README.md
+++ b/packages/servicenow-mcp/src/enterprise-proxy/README.md
@@ -39,16 +39,22 @@ The Enterprise MCP Proxy bridges **any MCP client** (stdio MCP protocol) with th
 
 ## Configuration
 
-Two environment variables:
+The variables the proxy reads:
 
 ```bash
-SNOW_LICENSE_KEY=<enterprise license key, or a device-auth JWT>
+SNOW_LICENSE_KEY=<enterprise license key, or a device-auth JWT>   # SNOW_ENTERPRISE_LICENSE_KEY is an alias
 SNOW_ENTERPRISE_URL=https://enterprise.serac.build   # the default when unset
+SNOW_PORTAL_URL=https://portal.serac.build           # the default; only used to trade a raw SNOW-ENT-* key for a JWT
 ```
 
-`SNOW_LICENSE_KEY` is optional when `~/.snow-code/enterprise.json` holds a token. The proxy re-reads that
-file on every call and prefers it, because an MCP client config is written once and goes stale while the
-token file does not.
+If you point `SNOW_ENTERPRISE_URL` at a staging or self-hosted server, set `SNOW_PORTAL_URL` to match —
+a raw license key is exchanged for a JWT against the portal, not against the enterprise server, so leaving
+it unset authenticates against production and fails as "License key invalid or expired".
+
+`SNOW_LICENSE_KEY` is optional when `~/.serac/enterprise.json` holds a token — or the legacy pre-rebrand
+`~/.snow-code/enterprise.json`, which is still read as a fallback. The proxy re-reads them on every call and
+prefers the token file over the env var, because an MCP client config is written once and goes stale while
+the token file does not.
 
 Point any MCP client at the binary:
 
@@ -74,8 +80,9 @@ locally. `credentials.ts` is the old local-environment path: deprecated, and imp
 
 ## Files
 
-- **index.ts** - MCP Server entry point (stdio transport)
-- **server.ts** - Server setup and configuration
+- **index.ts** - MCP Server entry point (stdio transport); this is what the bin runs
+- **server.ts** - an alternate stdio entrypoint, dead: no exports, no importers, not the bin. Its token check
+  knows only the legacy `~/.snow-code` path, so do not read it as the source of truth for token resolution
 - **proxy.ts** - HTTPS client for enterprise server communication
 - **credentials.ts** - Environment variable credential gathering (deprecated, unused)
 - **types.ts** - TypeScript type definitions

--- a/packages/servicenow-mcp/src/enterprise-proxy/README.md
+++ b/packages/servicenow-mcp/src/enterprise-proxy/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Enterprise MCP Proxy bridges **SnowCode CLI** (stdio MCP protocol) with the **Serac Enterprise License Server** (HTTPS REST API), enabling enterprise features like Jira, Azure DevOps, and Confluence integrations.
+The Enterprise MCP Proxy bridges **any MCP client** (stdio MCP protocol) with the **Serac Enterprise License Server** (HTTPS REST API), enabling enterprise features like Jira, Azure DevOps, and Confluence integrations. It ships in this package as the `servicenow-mcp-enterprise-proxy` binary.
 
 ### 🚀 Enterprise Tool Ecosystem
 
@@ -32,82 +32,52 @@ The Enterprise MCP Proxy bridges **SnowCode CLI** (stdio MCP protocol) with the 
 
 ```
 ┌─────────────┐  stdio MCP   ┌──────────────┐  HTTPS REST   ┌─────────────────┐
-│  SnowCode   │─────────────▶│  MCP Proxy   │──────────────▶│ License Server  │
-│  CLI        │◀─────────────│  (LOKAAL)    │◀──────────────│  (CLOUD - GCP)  │
+│ MCP client  │─────────────▶│  MCP Proxy   │──────────────▶│ License Server  │
+│ (local)     │◀─────────────│  (local)     │◀──────────────│  (cloud)        │
 └─────────────┘              └──────────────┘               └─────────────────┘
 ```
 
 ## Configuration
 
-The proxy is automatically configured when running `snow-flow auth login` with an enterprise license key.
-
-### Environment Variables
+Two environment variables:
 
 ```bash
-# ============================================
-# Required - Enterprise License
-# ============================================
-SNOW_LICENSE_KEY=SNOW-ENT-CUST-ABC123
-SNOW_ENTERPRISE_URL=https://license-server.run.app
-
-# ============================================
-# Optional: Local Credentials
-# (Otherwise uses server-side encrypted credentials)
-# ============================================
-
-# Jira Integration (22 tools)
-JIRA_HOST=https://company.atlassian.net
-JIRA_EMAIL=user@company.com
-JIRA_API_TOKEN=ATATT3xFfGF0...
-# Get token: https://id.atlassian.com/manage-profile/security/api-tokens
-
-# Azure DevOps Integration (26 tools)
-AZURE_DEVOPS_ORG=mycompany
-AZURE_DEVOPS_PAT=xxxxxxxxxxxxxxxxxxxxx
-# Get PAT: https://dev.azure.com/{org}/_usersSettings/tokens
-# Required scopes: Work Items (Read, Write), Build (Read, Execute), Code (Read, Write)
-
-# Confluence Integration (24 tools)
-CONFLUENCE_HOST=https://company.atlassian.net
-CONFLUENCE_EMAIL=user@company.com
-CONFLUENCE_API_TOKEN=ATATT3xFfGF0...
-# Same token as Jira (Atlassian Cloud uses same API tokens)
+SNOW_LICENSE_KEY=<enterprise license key, or a device-auth JWT>
+SNOW_ENTERPRISE_URL=https://enterprise.serac.build   # the default when unset
 ```
 
-**Credential Priority:**
+`SNOW_LICENSE_KEY` is optional when `~/.snow-code/enterprise.json` holds a token. The proxy re-reads that
+file on every call and prefers it, because an MCP client config is written once and goes stale while the
+token file does not.
 
-1. **Local environment variables** (shown above) - Sent encrypted to server
-2. **Server-side encrypted storage** - Managed by enterprise admin
-3. **Error** - If neither available, tool will fail with clear message
-
-### SnowCode Configuration
-
-Automatically added to `~/.config/snow-code/snow-code.json`:
+Point any MCP client at the binary:
 
 ```json
 {
   "mcpServers": {
     "serac-enterprise": {
-      "command": "node",
-      "args": ["node_modules/snow-flow/dist/mcp/enterprise-proxy/index.js"],
+      "command": "servicenow-mcp-enterprise-proxy",
       "env": {
-        "SNOW_LICENSE_KEY": "SNOW-ENT-CUST-ABC123",
-        "SNOW_ENTERPRISE_URL": "https://license-server.run.app",
-        "JIRA_HOST": "...",
-        "JIRA_EMAIL": "...",
-        "JIRA_API_TOKEN": "..."
+        "SNOW_LICENSE_KEY": "...",
+        "SNOW_ENTERPRISE_URL": "https://enterprise.serac.build"
       }
     }
   }
 }
 ```
 
+### Integration credentials
+
+Jira, Azure DevOps and Confluence credentials are **not** read from this process. The enterprise server
+fetches them from the Portal API with the license JWT and decrypts them there, so nothing needs them
+locally. `credentials.ts` is the old local-environment path: deprecated, and imported by nothing.
+
 ## Files
 
 - **index.ts** - MCP Server entry point (stdio transport)
 - **server.ts** - Server setup and configuration
 - **proxy.ts** - HTTPS client for enterprise server communication
-- **credentials.ts** - Environment variable credential gathering
+- **credentials.ts** - Environment variable credential gathering (deprecated, unused)
 - **types.ts** - TypeScript type definitions
 
 ## Available Enterprise Tools
@@ -302,29 +272,19 @@ await confluence_improve_content({
 
 ## Usage
 
-### Automatic (Recommended)
+The MCP client spawns the proxy over stdio; there is nothing to start separately. To drive it by hand
+for debugging:
 
 ```bash
-# During snow-flow auth login
-$ snow-flow auth login
+export SNOW_LICENSE_KEY=...
+export SNOW_ENTERPRISE_URL=https://enterprise.serac.build
 
-? Do you have a Serac Enterprise license? Yes
-? Enterprise License Key: SNOW-ENT-CUST-ABC123
-
-✓ Enterprise MCP Proxy configured
-✓ snow-code.json updated
+bun src/enterprise-proxy/index.ts   # from a checkout
+servicenow-mcp-enterprise-proxy     # from an install
 ```
 
-### Manual Testing
-
-```bash
-# Set environment variables
-export SNOW_LICENSE_KEY=SNOW-ENT-CUST-ABC123
-export SNOW_ENTERPRISE_URL=https://license-server.run.app
-
-# Run proxy directly (for debugging)
-node dist/mcp/enterprise-proxy/index.js
-```
+Set `SNOW_MCP_DEBUG=true` for the proxy's own logging, and `SNOW_ENTERPRISE_LAZY_TOOLS=false` to list the
+whole enterprise catalog up front instead of behind the two meta-tools.
 
 ## Security
 
@@ -336,17 +296,9 @@ node dist/mcp/enterprise-proxy/index.js
 
 ### Credentials
 
-**Option 1: Local (in environment)**
-
-- Credentials read from environment variables
-- Sent to server in HTTPS request body (encrypted in transit)
-- Simple setup, no server-side configuration needed
-
-**Option 2: Server-side (encrypted)**
-
-- Credentials stored encrypted in enterprise server database
-- Not sent in requests, server uses own credentials
-- Requires SSO configuration, most secure option
+- Integration credentials are stored encrypted in the enterprise server's database and decrypted there
+- They are never sent in a request from this proxy, so a compromised client machine yields the license
+  token but not the Jira, Azure DevOps or Confluence credentials behind it
 
 ### Machine Fingerprinting
 
@@ -367,20 +319,11 @@ The proxy handles common errors gracefully:
 
 ## Development
 
-### Building
+From `packages/servicenow-mcp`:
 
 ```bash
-npm run build
-```
-
-### Testing
-
-```bash
-# Unit tests
-npm test
-
-# Integration test with mock server
-npm run test:integration
+bun run build   # tsc, for the npm tarball
+bun test        # the package suite; the proxy has no tests of its own
 ```
 
 ## License


### PR DESCRIPTION
### Issue for this PR

Closes #296

### Type of change

- [ ] Bug fix
- [ ] New tool or skill
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The repo still sold the CLI. The GitHub description pitched an "AI build agent" with bring-your-own LLM
keys, the topics said cli/opencode/update-set, and two READMEs still explained how to install things that
are gone.

The description and topics I applied live with `gh repo edit`, since a merge cannot do that. Old values are
at the bottom so it stays revertable.

The diff is the two READMEs. servicenow-mcp's install line said `@next`, with a note explaining that
`latest` was stuck on a broken 0.1.0. That was fixed on 15 Aug (latest 0.2.1, next 0.2.0), so following the
README installed the *older* build. The enterprise-proxy README told you to run `snow-flow auth login` and
pointed into `node_modules/snow-flow`; I rewrote its setup from what `proxy.ts` actually reads. That also
drops the documented local-credentials path — `credentials.ts` is `@deprecated` and nothing imports it, and
the enterprise server fetches credentials from the Portal API itself. `types.ts` still carries a
`credentials?` field on the wire shape, so the protocol permits it; this proxy just never fills it.

Also dropped the test counts from the root README — the MCP one said 168 against a 252-test suite.

Left alone on purpose: the enterprise tool inventory (it comes from the license server, I cannot check it),
the root `install` script, and the "What used to be here" section.

### How did you verify it works?

`bun typecheck` clean, `bun run lint` 1761 warnings / 0 errors, 252 MCP tests and 60 skills tests pass — all
identical to before the change. Docs only, so no regeneration; `generate:tools-json:check` reports up to
date, 437 tools.

For the rewritten config section I read `proxy.ts` instead of trusting the old doc. Token order is
`~/.serac/enterprise.json`, then the legacy `~/.snow-code/enterprise.json`, then `SNOW_LICENSE_KEY`. Note
that `server.ts` disagrees — it checks only `~/.snow-code` — but it is dead: no exports, no importers, and
the bin is `index.ts`. I flagged that in the file list rather than change code in a docs PR; it probably
wants its own issue, along with deleting `credentials.ts`.

What I did not do: run the proxy against a live enterprise server, so the config section comes from reading
the code, not from a working connection. I published nothing; the dist-tag facts are from `npm view`.

<details>
<summary>Repo metadata before the <code>gh repo edit</code>, for rollback</summary>

```
description: Serac — open-source AI build agent for ServiceNow. 400+ MCP tools, bring-your-own LLM keys (Claude/GPT/Gemini/Ollama). Read a story, ship the update set.
topics removed: ai-agent, bring-your-own-key, cli, opencode, update-set
topics added:   mcp-server, agent-skills
homepage:       unchanged (https://serac.build)
```

</details>

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json` (n/a — no tools changed)
- [x] If I added or changed a skill, I re-ran the skills `generate` (n/a — no skills changed)
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
