### PR TITLE
test(mcp): eval suite for tool_search retrieval

### DIFF
--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.queries.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.queries.ts
@@ -1,0 +1,164 @@
+/**
+ * Retrieval fixture for `ToolSearch.search` — see `tool-search-eval.test.ts`.
+ *
+ * Each entry is a request phrased the way a person (or the model relaying for
+ * them) would actually type it, paired with the tool(s) from `tools.json` that
+ * should come back. Queries deliberately do NOT echo tool ids: a query built
+ * out of the tool's own name measures the index's ability to find a string it
+ * already contains, which is not the thing that decides whether a session
+ * reaches the right tool.
+ *
+ * `expected` lists more than one tool only where the catalog genuinely has
+ * near-duplicates for the same intent (snow_create_acl vs
+ * snow_create_access_control, three separate attachment uploaders, …). Any of
+ * them is a correct answer, so a hit on any of them counts. It is not a place
+ * to widen the target until the number looks better.
+ *
+ * Every name here is asserted to exist in `tools.json` before scoring, so a
+ * renamed or deleted tool fails the suite instead of silently counting as a
+ * retrieval miss.
+ */
+
+export const EVAL_QUERIES = [
+  // Records, tasks, SLAs
+  { query: "find all P1 incidents opened last week", expected: ["snow_query_table", "snow_record_manage"] },
+  { query: "close the incident and fill in the resolution notes", expected: ["snow_record_manage"] },
+  { query: "add a work note to a ticket", expected: ["snow_add_comment"] },
+  { query: "pull up a record when all I have is its sys_id", expected: ["snow_get_by_sysid"] },
+  { query: "set the assignment group on 200 old tickets at once", expected: ["snow_bulk_update"] },
+  { query: "give this task to whoever has the lightest workload", expected: ["snow_assign_task"] },
+  { query: "are we about to breach the response target on this ticket", expected: ["snow_get_sla_status", "snow_sla_manage"] },
+  { query: "define a four hour response target for priority 1", expected: ["snow_create_sla_definition", "snow_create_sla"] },
+
+  // Change and approvals
+  { query: "raise a normal change for the firewall upgrade", expected: ["snow_change_manage"] },
+  { query: "how risky is this change", expected: ["snow_change_query"] },
+  { query: "show the approvals still waiting on me", expected: ["snow_get_pending_approvals"] },
+  { query: "sign this off and add a comment", expected: ["snow_approve_reject"] },
+  { query: "ask the line manager to authorise this record", expected: ["snow_request_approval"] },
+
+  // Platform configuration
+  { query: "add a field to the change request form", expected: ["snow_add_form_field", "snow_create_field"] },
+  { query: "new column on the incident table for the vendor ticket number", expected: ["snow_create_field"] },
+  { query: "make assignment group mandatory when priority is 1", expected: ["snow_create_ui_policy", "snow_create_ui_policy_action"] },
+  { query: "run some server side logic before every insert on sc_task", expected: ["snow_create_business_rule"] },
+  { query: "I want a reusable function I can call from several scripts", expected: ["snow_create_script_include"] },
+  { query: "put a button on the incident form that closes the record", expected: ["snow_create_ui_action"] },
+  { query: "hide a field on the form when the category changes", expected: ["snow_create_client_script"] },
+  { query: "make a new table that extends task", expected: ["snow_create_table"] },
+  { query: "turn off that business rule without deleting it", expected: ["snow_disable_business_rule"] },
+  { query: "what columns does cmdb_ci_server have", expected: ["snow_discover_table_fields", "snow_table_schema_discovery"] },
+  { query: "keep the field read only even for imports and API writes", expected: ["snow_create_data_policy", "snow_create_data_policy_rule"] },
+  { query: "save a set of prefilled values people can reuse on new records", expected: ["snow_create_template", "snow_apply_template"] },
+
+  // Scripting and execution
+  { query: "run this javascript against the instance and show me the output", expected: ["snow_execute_script"] },
+  { query: "my script uses arrow functions and the instance throws a syntax error", expected: ["snow_convert_es6_to_es5", "snow_convert_to_es5"] },
+  { query: "look for anti patterns in our scripts", expected: ["snow_detect_code_patterns"] },
+
+  // Search, dependencies, impact
+  { query: "find every script that calls GlideAjax", expected: ["snow_code_search"] },
+  { query: "what breaks if I change this script include", expected: ["snow_blast_radius_dependents"] },
+  { query: "which artifacts still read the u_vendor_ticket column", expected: ["snow_blast_radius_field_references"] },
+  { query: "list everything that runs on the sc_req_item table", expected: ["snow_blast_radius_table_configs"] },
+  { query: "was this widget already picked up in an update set", expected: ["snow_blast_radius_update_sets"] },
+  // Genuinely ambiguous: the honest answers are "see what is configured on the
+  // table", "look at the form's own config", or "read the logs".
+  { query: "why did this business rule not fire", expected: ["snow_analyze_form", "snow_blast_radius_table_configs", "snow_get_logs"] },
+  { query: "find the widget we built for the employee portal", expected: ["snow_search_artifacts"] },
+
+  // Flow Designer and legacy workflow
+  { query: "build something that emails the manager when a request is submitted", expected: ["snow_manage_flow"] },
+  { query: "it says it ran but nothing happened", expected: ["snow_get_flow_execution_logs"] },
+  { query: "custom Flow Designer action that calls our own API", expected: ["snow_create_flow_action"] },
+
+  // Notifications
+  { query: "email the assigned user about the outage", expected: ["snow_send_email", "snow_send_notification"] },
+  { query: "automatically mail the on call team whenever a P1 comes in", expected: ["snow_create_notification", "snow_email_notification_manage"] },
+  { query: "did that mail actually go out yesterday", expected: ["snow_get_email_logs"] },
+  { query: "tell everyone in the company the datacenter is down", expected: ["snow_emergency_broadcast"] },
+  { query: "alert people on their phones", expected: ["snow_send_push_notification", "snow_send_push"] },
+
+  // Service catalog
+  { query: "publish a new laptop request people can order", expected: ["snow_create_catalog_item"] },
+  { query: "add a dropdown question to the laptop request", expected: ["snow_create_catalog_variable", "snow_create_variable"] },
+  { query: "order that for a user without going through the portal", expected: ["snow_order_catalog_item"] },
+  { query: "what can employees request for onboarding", expected: ["snow_search_catalog", "snow_catalog_item_search"] },
+  { query: "hide a question on the order form unless another answer is yes", expected: ["snow_create_catalog_ui_policy"] },
+
+  // Security, users, roles
+  { query: "why can this user not see the record", expected: ["snow_test_acl", "snow_impersonate_user"] },
+  { query: "give the itil role write access to our custom table", expected: ["snow_create_access_control", "snow_create_acl"] },
+  { query: "what roles does this user have", expected: ["snow_get_user_roles"] },
+  { query: "put someone in the network support group", expected: ["snow_manage_group_membership", "snow_role_group_manage"] },
+  { query: "create an account for a new contractor", expected: ["snow_user_manage"] },
+  { query: "I need elevated rights to change an ACL", expected: ["snow_elevate_role"] },
+
+  // Update sets, scope, deployment
+  { query: "which update set are my changes going into", expected: ["snow_update_set_query", "snow_update_set_manage"] },
+  { query: "copy this widget from dev to test", expected: ["snow_clone_instance_artifact"] },
+  { query: "check the artifact for ES5 and dependency problems before it goes live", expected: ["snow_validate_deployment"] },
+  { query: "the release broke something, put it back", expected: ["snow_rollback_deployment"] },
+  { query: "which application scope am I working in", expected: ["snow_get_current_scope"] },
+
+  // Monitoring and logs
+  { query: "show me the errors from the last hour", expected: ["snow_get_logs"] },
+  { query: "our calls out to the vendor keep timing out", expected: ["snow_get_outbound_http_logs"] },
+  { query: "the instance is slow, which queries are the worst", expected: ["snow_get_slow_queries"] },
+  { query: "did the nightly cleanup run last night", expected: ["snow_get_scheduled_job_logs", "snow_job_status"] },
+  { query: "what changed on the instance between 2 and 3 this morning", expected: ["snow_inspect_mutations", "snow_audit_trail_analysis"] },
+
+  // CMDB and discovery
+  { query: "find the configuration item for the payroll database", expected: ["snow_search_cmdb", "snow_cmdb_search"] },
+  { query: "what services go down if this server fails", expected: ["snow_get_ci_impact", "snow_impact_analysis"] },
+  { query: "record that this application runs on that server", expected: ["snow_create_ci_relationship"] },
+  { query: "scan this subnet and bring the hardware into the CMDB", expected: ["snow_run_discovery"] },
+
+  // HR, CSM, field service, agile, PPM
+  { query: "open an HR case for an address change", expected: ["snow_create_hr_case"] },
+  { query: "someone leaves on friday, start the leaver process", expected: ["snow_employee_offboarding"] },
+  { query: "log a complaint from a customer account", expected: ["snow_create_customer_case"] },
+  { query: "send a technician out to fix the printer on site", expected: ["snow_fsm_work_order_manage", "snow_fsm_dispatch_manage"] },
+  { query: "how many story points does the team deliver per sprint", expected: ["snow_agile_velocity_report"] },
+  { query: "move this story into the next sprint", expected: ["snow_agile_story_manage", "snow_agile_backlog_groom"] },
+  { query: "set up a project with a start date and a project manager", expected: ["snow_create_project"] },
+
+  // Reporting and analytics
+  { query: "pie chart of incidents by category", expected: ["snow_create_report"] },
+  { query: "mail that report to the managers every monday morning", expected: ["snow_schedule_report_delivery", "snow_report_manage"] },
+  { query: "count open incidents grouped by assignment group", expected: ["snow_aggregate_metrics"] },
+
+  // Integration
+  { query: "call an external API from ServiceNow", expected: ["snow_create_rest_message", "snow_rest_message_manage"] },
+  { query: "install the jira spoke", expected: ["snow_install_spoke"] },
+  { query: "store an API key somewhere safe for the integration", expected: ["snow_create_credential_alias"] },
+  { query: "can the MID server reach the vendor endpoint", expected: ["snow_test_mid_connectivity"] },
+  { query: "load a csv of users into the platform", expected: ["snow_create_import_set", "snow_create_transform_map"] },
+
+  // Testing
+  { query: "automated test that fills in a form and submits it", expected: ["snow_create_atf_test", "snow_create_atf_test_step"] },
+  { query: "run the regression suite and show me what failed", expected: ["snow_execute_atf_test", "snow_get_atf_results"] },
+
+  // Portal, lists, workspaces
+  { query: "build a page where employees can see their own requests", expected: ["snow_create_sp_page"] },
+  { query: "write an angularjs widget for the portal", expected: ["snow_create_sp_widget"] },
+  { query: "restyle the portal with our brand colours", expected: ["snow_sp_theme_manage"] },
+  { query: "show one more column in the default list", expected: ["snow_add_list_column", "snow_create_list_view", "snow_create_list_layout"] },
+  { query: "spin up an agent workspace for the service desk", expected: ["snow_create_complete_workspace", "snow_create_configurable_agent_workspace", "snow_create_workspace"] },
+
+  // Attachments and local utilities
+  { query: "attach this file to the ticket", expected: ["snow_file_upload", "snow_upload_attachment", "snow_attach_file"] },
+  { query: "get the screenshot off that ticket", expected: ["snow_file_download"] },
+  { query: "generate a sys_id for a test record", expected: ["snow_generate_guid"] },
+  { query: "what is inside this bearer token", expected: ["snow_jwt_decode"] },
+  { query: "build the encoded query for records opened in the last seven days", expected: ["snow_date_filter", "snow_query_filter"] },
+  { query: "export the table to csv", expected: ["snow_data_export"] },
+  { query: "change a system property value", expected: ["snow_property_manage", "snow_property_manager"] },
+
+  // Virtual agent, knowledge, scheduling
+  { query: "chatbot conversation for password reset", expected: ["snow_create_va_topic"] },
+  { query: "publish an article about how to set up the vpn", expected: ["snow_knowledge_article_manage"] },
+  { query: "run a script every night at 2am", expected: ["snow_schedule_job", "snow_scheduled_job_manage"] },
+  { query: "block out the christmas holidays in the business hours", expected: ["snow_add_schedule_entry", "snow_create_schedule"] },
+  { query: "who is on call this weekend", expected: ["snow_oncall_manage"] },
+]

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.queries.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.queries.ts
@@ -2,8 +2,8 @@
  * Retrieval fixture for `ToolSearch.search` — see `tool-search-eval.test.ts`.
  *
  * Each entry is a request phrased the way a person (or the model relaying for
- * them) would actually type it, paired with the tool(s) from `tools.json` that
- * should come back. Queries deliberately do NOT echo tool ids: a query built
+ * them) would actually type it, paired with the tool(s) that should come back.
+ * Queries deliberately do NOT echo tool ids: a query built
  * out of the tool's own name measures the index's ability to find a string it
  * already contains, which is not the thing that decides whether a session
  * reaches the right tool.
@@ -14,9 +14,9 @@
  * them is a correct answer, so a hit on any of them counts. It is not a place
  * to widen the target until the number looks better.
  *
- * Every name here is asserted to exist in `tools.json` before scoring, so a
- * renamed or deleted tool fails the suite instead of silently counting as a
- * retrieval miss.
+ * Every name here is asserted to be in the index the server builds before
+ * scoring, so a renamed, deleted or unregistered tool fails the suite instead
+ * of silently counting as a retrieval miss.
  */
 
 export const EVAL_QUERIES = [
@@ -114,11 +114,15 @@ export const EVAL_QUERIES = [
   { query: "record that this application runs on that server", expected: ["snow_create_ci_relationship"] },
   { query: "scan this subnet and bring the hardware into the CMDB", expected: ["snow_run_discovery"] },
 
-  // HR, CSM, field service, agile, PPM
+  // HR, CSM, agile, PPM
+  //
+  // No field-service request here: the three snow_fsm_* tools are published in
+  // tools.json but the server never registers them (issue #307), so a query
+  // aimed at them would score as a ranking miss for a tool no ranking can
+  // return.
   { query: "open an HR case for an address change", expected: ["snow_create_hr_case"] },
   { query: "someone leaves on friday, start the leaver process", expected: ["snow_employee_offboarding"] },
   { query: "log a complaint from a customer account", expected: ["snow_create_customer_case"] },
-  { query: "send a technician out to fix the printer on site", expected: ["snow_fsm_work_order_manage", "snow_fsm_dispatch_manage"] },
   { query: "how many story points does the team deliver per sprint", expected: ["snow_agile_velocity_report"] },
   { query: "move this story into the next sprint", expected: ["snow_agile_story_manage", "snow_agile_backlog_groom"] },
   { query: "set up a project with a start date and a project manager", expected: ["snow_create_project"] },

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.test.ts
@@ -2,7 +2,7 @@
  * Retrieval eval for `ToolSearch.search`.
  *
  * Every tool but the two meta tools is deferred, so `tool_search` is the only
- * path a model has to the other 435. A tool the ranking never surfaces might
+ * path a model has to the other 429. A tool the ranking never surfaces might
  * as well not be installed — and the ranking is a hand-tuned pile of substring
  * bonuses that until now nothing measured.
  *
@@ -10,71 +10,74 @@
  * real gate rather than an approximation: it scores the shipped ranker against
  * a fixed set of realistically-phrased requests and fails when recall drops.
  *
- * The index is built from `tools.json` the way the transports build theirs —
- * same `extractKeywords`, same 200-char description truncation — so the score
- * is the score a session gets. Two deliberate deviations, neither of which can
- * move the numbers:
+ * The index comes from `toolRegistry` through `buildToolIndex` — the same call
+ * both transports make at bootstrap — so this scores the catalog a session
+ * actually searches. That is 429 tools, not the 437 in `tools.json`: the `fsm`
+ * and `predictive-intelligence-MIGRATED` domains are missing from
+ * `STATIC_TOOL_MODULES` and `snow_create_catalog_variable` is not re-exported,
+ * so nine published tools never enter anyone's index (issue #307), and
+ * `snow_comprehensive_search` is the reverse case. Scoring `tools.json`
+ * instead moves every metric and counts unreachable tools as findable, which
+ * is the opposite of what this measures.
  *
- *   - `category` comes from the manifest group; the transports use the
- *     registry domain (the tool's directory). They differ for the ~20 tools
- *     that declare their own `subcategory`, but category only scores when the
- *     *entire* query is a substring of it, which no multi-word request is.
- *   - `search()` is called with the full catalog as its limit instead of the
- *     default 20, so MRR is not truncated at 1/20. The @k slices are identical
- *     either way.
+ * One deliberate deviation from a session: `search()` is called with the whole
+ * catalog as its limit instead of the default 20, so MRR is not truncated at
+ * 1/20. The @k slices are identical either way.
  *
- * CURRENT SCORE (437 tools, 102 queries): recall@1 0.255, recall@5 0.480,
- * recall@20 0.667, MRR 0.370. Two thirds of realistic requests do reach the
+ * CURRENT SCORE (429 tools, 101 queries): recall@1 0.267, recall@5 0.505,
+ * recall@20 0.663, MRR 0.385. Two thirds of realistic requests do reach the
  * right tool eventually, but a quarter of them put `snow_sp_theme_manage`
  * first — its keywords contain "theme"/"theming", and the word-level rules
  * match substrings for any query word longer than two characters, so every
- * request containing the word "the" scores it +31. See issue #295; fixing the
- * ranking is deliberately not part of this suite.
+ * request containing the word "the" scores it +31. Issue #298 has the
+ * diagnosis; fixing the ranking is deliberately not part of this suite.
  */
 
 import { describe, test, expect, afterAll } from "@jest/globals"
-import * as path from "path"
-import { ToolSearch, extractKeywords } from "../tool-search"
+import { ToolSearch, buildToolIndex } from "../tool-search"
+import { toolRegistry } from "../tool-registry"
 import { EVAL_QUERIES } from "./tool-search-eval.queries"
 
 /**
- * Floors, not targets. They sit ~2 queries under the measured score so that
- * adding a tool that steals one rank does not fail an unrelated PR, while any
- * real degradation does.
+ * Floors, not targets.
  *
- * These may be raised when the ranking improves. Lowering one to make a change
- * pass is the failure mode this file exists to prevent: it means the change
- * made retrieval worse, and the number is the argument against it.
+ * `search()` sorts by score alone and the sort is stable, so tools on equal
+ * scores come back in index order — which means part of the measurement is
+ * array position, not ranking. Scoring the same 429 tools in 24 different
+ * orders (production, reversed, by id, 20 shuffles) spans recall@1
+ * 0.248-0.297, recall@5 0.465-0.515, recall@20 0.653-0.693, MRR 0.368-0.397.
+ * These floors sit under the bottom of that band, so adding a tool that lands
+ * in a tied cluster cannot fail an unrelated PR. The gap to the measured score
+ * is tie noise, not slack.
+ *
+ * Raise them when the ranking improves. Lowering one to make a change pass is
+ * the failure mode this file exists to prevent: it means the change made
+ * retrieval worse, and the number is the argument against it.
  */
 const MIN_RECALL_AT_1 = 0.24
-const MIN_RECALL_AT_5 = 0.46
-const MIN_RECALL_AT_20 = 0.65
+const MIN_RECALL_AT_5 = 0.45
+const MIN_RECALL_AT_20 = 0.63
 const MIN_MRR = 0.35
 
-const manifest: { count: number; groups: { name: string; tools: { name: string; description: string }[] }[] } =
-  await Bun.file(path.resolve(__dirname, "../../../..", "tools.json")).json()
+await toolRegistry.initialize()
 
-const index = manifest.groups.flatMap((group) =>
-  group.tools.map((tool) => ({
-    id: tool.name,
-    description: tool.description.substring(0, 200),
-    category: group.name,
-    keywords: extractKeywords(tool.name, tool.description),
-    deferred: true,
-  })),
+const index = buildToolIndex(
+  toolRegistry.getToolDefinitions(),
+  (name) => toolRegistry.getTool(name)?.domain || "unknown",
+  true,
 )
 
 afterAll(() => ToolSearch.clearIndex())
 
 describe("tool_search retrieval", () => {
-  test("the fixture points at tools that exist", () => {
+  test("every query has an answer the server can actually return", () => {
     const catalog = new Set(index.map((entry) => entry.id))
-    const unknown = EVAL_QUERIES.flatMap((entry) => entry.expected.filter((name) => !catalog.has(name)))
+    const unanswerable = EVAL_QUERIES.filter((entry) => !entry.expected.some((name) => catalog.has(name)))
 
-    // A renamed or deleted tool must fail loudly here rather than quietly
-    // degrade the score below as if retrieval had regressed.
-    expect(unknown).toEqual([])
-    expect(index.length).toBe(manifest.count)
+    // A target that is not in the index is not a retrieval miss — no ranking
+    // change could ever surface it — so it must fail loudly here instead of
+    // sitting in the score as if the ranker were at fault.
+    expect(unanswerable.map((entry) => entry.query)).toEqual([])
   })
 
   test("recall against realistic queries stays above the measured floor", () => {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/tool-search-eval.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Retrieval eval for `ToolSearch.search`.
+ *
+ * Every tool but the two meta tools is deferred, so `tool_search` is the only
+ * path a model has to the other 435. A tool the ranking never surfaces might
+ * as well not be installed — and the ranking is a hand-tuned pile of substring
+ * bonuses that until now nothing measured.
+ *
+ * The scoring is pure and deterministic (no LLM, no network), so this is a
+ * real gate rather than an approximation: it scores the shipped ranker against
+ * a fixed set of realistically-phrased requests and fails when recall drops.
+ *
+ * The index is built from `tools.json` the way the transports build theirs —
+ * same `extractKeywords`, same 200-char description truncation — so the score
+ * is the score a session gets. Two deliberate deviations, neither of which can
+ * move the numbers:
+ *
+ *   - `category` comes from the manifest group; the transports use the
+ *     registry domain (the tool's directory). They differ for the ~20 tools
+ *     that declare their own `subcategory`, but category only scores when the
+ *     *entire* query is a substring of it, which no multi-word request is.
+ *   - `search()` is called with the full catalog as its limit instead of the
+ *     default 20, so MRR is not truncated at 1/20. The @k slices are identical
+ *     either way.
+ *
+ * CURRENT SCORE (437 tools, 102 queries): recall@1 0.255, recall@5 0.480,
+ * recall@20 0.667, MRR 0.370. Two thirds of realistic requests do reach the
+ * right tool eventually, but a quarter of them put `snow_sp_theme_manage`
+ * first — its keywords contain "theme"/"theming", and the word-level rules
+ * match substrings for any query word longer than two characters, so every
+ * request containing the word "the" scores it +31. See issue #295; fixing the
+ * ranking is deliberately not part of this suite.
+ */
+
+import { describe, test, expect, afterAll } from "@jest/globals"
+import * as path from "path"
+import { ToolSearch, extractKeywords } from "../tool-search"
+import { EVAL_QUERIES } from "./tool-search-eval.queries"
+
+/**
+ * Floors, not targets. They sit ~2 queries under the measured score so that
+ * adding a tool that steals one rank does not fail an unrelated PR, while any
+ * real degradation does.
+ *
+ * These may be raised when the ranking improves. Lowering one to make a change
+ * pass is the failure mode this file exists to prevent: it means the change
+ * made retrieval worse, and the number is the argument against it.
+ */
+const MIN_RECALL_AT_1 = 0.24
+const MIN_RECALL_AT_5 = 0.46
+const MIN_RECALL_AT_20 = 0.65
+const MIN_MRR = 0.35
+
+const manifest: { count: number; groups: { name: string; tools: { name: string; description: string }[] }[] } =
+  await Bun.file(path.resolve(__dirname, "../../../..", "tools.json")).json()
+
+const index = manifest.groups.flatMap((group) =>
+  group.tools.map((tool) => ({
+    id: tool.name,
+    description: tool.description.substring(0, 200),
+    category: group.name,
+    keywords: extractKeywords(tool.name, tool.description),
+    deferred: true,
+  })),
+)
+
+afterAll(() => ToolSearch.clearIndex())
+
+describe("tool_search retrieval", () => {
+  test("the fixture points at tools that exist", () => {
+    const catalog = new Set(index.map((entry) => entry.id))
+    const unknown = EVAL_QUERIES.flatMap((entry) => entry.expected.filter((name) => !catalog.has(name)))
+
+    // A renamed or deleted tool must fail loudly here rather than quietly
+    // degrade the score below as if retrieval had regressed.
+    expect(unknown).toEqual([])
+    expect(index.length).toBe(manifest.count)
+  })
+
+  test("recall against realistic queries stays above the measured floor", () => {
+    ToolSearch.clearIndex()
+    ToolSearch.registerTools(index)
+
+    const results = EVAL_QUERIES.map((entry) => {
+      const ranked = ToolSearch.search(entry.query, index.length).map((tool) => tool.id)
+      return {
+        query: entry.query,
+        expected: entry.expected,
+        // 0-based position of the first acceptable tool, -1 when the ranking
+        // never returns one at all.
+        rank: ranked.findIndex((id) => entry.expected.includes(id)),
+        top: ranked.slice(0, 3),
+      }
+    })
+
+    const recallAt = (k: number) => results.filter((r) => r.rank >= 0 && r.rank < k).length / results.length
+    const mrr = results.reduce((sum, r) => sum + (r.rank >= 0 ? 1 / (r.rank + 1) : 0), 0) / results.length
+
+    // Printed before the assertions so a failing run still shows every number
+    // and the queries behind it, not just the first metric that tripped.
+    console.log(
+      `\ntool_search retrieval — ${results.length} queries over ${index.length} tools\n` +
+        `  recall@1  ${recallAt(1).toFixed(3)}  (floor ${MIN_RECALL_AT_1})\n` +
+        `  recall@5  ${recallAt(5).toFixed(3)}  (floor ${MIN_RECALL_AT_5})\n` +
+        `  recall@20 ${recallAt(20).toFixed(3)}  (floor ${MIN_RECALL_AT_20})\n` +
+        `  MRR       ${mrr.toFixed(3)}  (floor ${MIN_MRR})`,
+    )
+
+    // Never-found (-1) sorts as worse than any real rank, so the head of this
+    // list is the head of the problem.
+    const sortable = (rank: number) => (rank < 0 ? Number.MAX_SAFE_INTEGER : rank)
+    const worst = results.filter((r) => r.rank < 0 || r.rank >= 20).sort((a, b) => sortable(b.rank) - sortable(a.rank))
+    console.log(
+      `  ${worst.length} queries never reach their tool in the top 20; the first few:\n` +
+        worst
+          .slice(0, 10)
+          .map((r) => `    "${r.query}" → want ${r.expected.join(" | ")}, got ${r.top.join(", ")}`)
+          .join("\n"),
+    )
+
+    expect(recallAt(1)).toBeGreaterThanOrEqual(MIN_RECALL_AT_1)
+    expect(recallAt(5)).toBeGreaterThanOrEqual(MIN_RECALL_AT_5)
+    expect(recallAt(20)).toBeGreaterThanOrEqual(MIN_RECALL_AT_20)
+    expect(mrr).toBeGreaterThanOrEqual(MIN_MRR)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
@@ -43,15 +43,53 @@ import { STDIO_TENANT } from "./tenant-scope.js"
 export { STDIO_TENANT, resolveTenantScope, tenantScopedKey } from "./tenant-scope.js"
 
 /**
+ * Tool index entry - lightweight representation for search
+ */
+export interface ToolIndexEntry {
+  id: string
+  description: string
+  category: string
+  keywords: string[]
+  deferred: boolean
+}
+
+/**
+ * Build the index the transports register at bootstrap.
+ *
+ * `stdio.ts` and `http-entry.ts` each carried their own copy of this mapping,
+ * and the retrieval eval needs the same one. Either copy drifting — a
+ * different truncation length, a field the ranker reads that only one of them
+ * fills — silently changes what a session can find, and nothing fails.
+ *
+ * `deferred` is the one thing the callers genuinely disagree on: stdio defers
+ * the whole catalog so `tool_search` is the only way in, HTTP marks it
+ * available because the portal budgets tools itself. It does not affect
+ * ranking. Note that keywords come from the untruncated description even
+ * though the indexed description is cut at 200 chars.
+ */
+export function buildToolIndex(
+  tools: { name: string; description: string }[],
+  categoryOf: (name: string) => string,
+  deferred: boolean,
+): ToolIndexEntry[] {
+  return tools.map((tool) => ({
+    id: tool.name,
+    description: tool.description.substring(0, 200),
+    category: categoryOf(tool.name),
+    keywords: extractKeywords(tool.name, tool.description),
+    deferred,
+  }))
+}
+
+/**
  * Derive the search keywords for a tool from its name and description.
  *
- * Lived as a private copy in both `transports/stdio.ts` and
- * `transports/http-entry.ts` — the http-entry copy carried a comment saying it
- * mirrored the stdio one, which is the sort of pairing that drifts. It sits
- * here now because it is what fills the `keywords` field below, and because
- * the retrieval eval has to score the same keywords the transports index.
+ * Lived as a private copy in both transports — the http-entry copy carried a
+ * comment saying it mirrored the stdio one, which is the sort of pairing that
+ * drifts. `src/enterprise-proxy/tool-cache.ts` has a genuinely different one
+ * for non-`snow_` tools; that is not this.
  */
-export function extractKeywords(name: string, description: string): string[] {
+function extractKeywords(name: string, description: string): string[] {
   const keywords = new Set<string>()
 
   // snow_query_incidents -> query, incidents
@@ -70,17 +108,6 @@ export function extractKeywords(name: string, description: string): string[] {
   for (const word of descWords.slice(0, 10)) keywords.add(word)
 
   return Array.from(keywords)
-}
-
-/**
- * Tool index entry - lightweight representation for search
- */
-export interface ToolIndexEntry {
-  id: string
-  description: string
-  category: string
-  keywords: string[]
-  deferred: boolean
 }
 
 /**

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/tool-search.ts
@@ -43,6 +43,36 @@ import { STDIO_TENANT } from "./tenant-scope.js"
 export { STDIO_TENANT, resolveTenantScope, tenantScopedKey } from "./tenant-scope.js"
 
 /**
+ * Derive the search keywords for a tool from its name and description.
+ *
+ * Lived as a private copy in both `transports/stdio.ts` and
+ * `transports/http-entry.ts` — the http-entry copy carried a comment saying it
+ * mirrored the stdio one, which is the sort of pairing that drifts. It sits
+ * here now because it is what fills the `keywords` field below, and because
+ * the retrieval eval has to score the same keywords the transports index.
+ */
+export function extractKeywords(name: string, description: string): string[] {
+  const keywords = new Set<string>()
+
+  // snow_query_incidents -> query, incidents
+  for (const part of name.replace(/^snow_/, "").split("_")) {
+    if (part.length > 2) keywords.add(part.toLowerCase())
+  }
+
+  // Only the first 10 significant description words are indexed, so a tool
+  // whose distinguishing noun appears late in a long description is not
+  // reachable by keyword — see the eval's reported misses.
+  const descWords = description
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 3 && !["this", "that", "with", "from", "will", "have", "been", "tool"].includes(w))
+  for (const word of descWords.slice(0, 10)) keywords.add(word)
+
+  return Array.from(keywords)
+}
+
+/**
  * Tool index entry - lightweight representation for search
  */
 export interface ToolIndexEntry {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/http-entry.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/http-entry.ts
@@ -19,7 +19,7 @@
  */
 
 import { toolRegistry } from "../shared/tool-registry.js"
-import { ToolSearch, extractKeywords } from "../shared/tool-search.js"
+import { ToolSearch, buildToolIndex } from "../shared/tool-search.js"
 import { createHttpApp } from "./http.js"
 import { createHttpResolver } from "./http-resolver.js"
 import { mcpDebug, mcpWarn } from "../../shared/mcp-debug.js"
@@ -59,22 +59,15 @@ async function main(): Promise<void> {
   // index + SNOW_LAZY_TOOLS defaulting to on, and filters everything except
   // the two meta tools (tool_search / tool_execute) — which makes the LLM
   // think ServiceNow is read-only.
-  const allTools = toolRegistry.getToolDefinitions()
-  const toolIndexEntries = allTools.map((tool) => {
-    const registeredTool = toolRegistry.getTool(tool.name)
-    return {
-      id: tool.name,
-      description: tool.description.substring(0, 200),
-      category: registeredTool?.domain || "unknown",
-      keywords: extractKeywords(tool.name, tool.description),
-      // HTTP callers (portal chat) do their own token budgeting + tool
-      // enablement on the client side. Marking everything non-deferred
-      // here means `listTools` returns the full catalog so the portal's
-      // tool_search overlay can match against write/deploy tools, not
-      // just the two meta tools.
-      deferred: false,
-    }
-  })
+  // HTTP callers (portal chat) do their own token budgeting + tool enablement
+  // on the client side. Marking everything non-deferred here means `listTools`
+  // returns the full catalog so the portal's tool_search overlay can match
+  // against write/deploy tools, not just the two meta tools.
+  const toolIndexEntries = buildToolIndex(
+    toolRegistry.getToolDefinitions(),
+    (name) => toolRegistry.getTool(name)?.domain || "unknown",
+    false,
+  )
   ToolSearch.registerTools(toolIndexEntries)
   mcpDebug(`[mcp-http] tool search index populated with ${toolIndexEntries.length} tools`)
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/http-entry.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/http-entry.ts
@@ -19,29 +19,10 @@
  */
 
 import { toolRegistry } from "../shared/tool-registry.js"
-import { ToolSearch } from "../shared/tool-search.js"
+import { ToolSearch, extractKeywords } from "../shared/tool-search.js"
 import { createHttpApp } from "./http.js"
 import { createHttpResolver } from "./http-resolver.js"
 import { mcpDebug, mcpWarn } from "../../shared/mcp-debug.js"
-
-/**
- * Derive search keywords from a tool's name + description. Mirrors the
- * stdio transport's helper so both transports produce the same index.
- */
-const extractKeywords = (name: string, description: string): string[] => {
-  const keywords = new Set<string>()
-  const nameParts = name.replace(/^snow_/, "").split("_")
-  for (const part of nameParts) {
-    if (part.length > 2) keywords.add(part.toLowerCase())
-  }
-  const descWords = description
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .filter((w) => w.length > 3 && !["this", "that", "with", "from", "will", "have", "been", "tool"].includes(w))
-  for (const w of descWords.slice(0, 10)) keywords.add(w)
-  return Array.from(keywords)
-}
 
 async function main(): Promise<void> {
   const resolverUrl = process.env.MCP_RESOLVER_URL

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
@@ -17,7 +17,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { MCPPromptManager } from "../../shared/mcp-prompt-manager.js"
 import { toolRegistry } from "../shared/tool-registry.js"
 import { authManager } from "../shared/auth.js"
-import { ToolSearch, extractKeywords } from "../shared/tool-search.js"
+import { ToolSearch, buildToolIndex } from "../shared/tool-search.js"
 import { mcpDebug, mcpWarn } from "../../shared/mcp-debug.js"
 import { extractJWTPayload } from "../shared/permission-validator.js"
 import { createServer } from "../shared/server-factory.js"
@@ -200,17 +200,12 @@ const bootstrap = async (
 
     // Populate ToolSearch index for session-based tool enabling
     mcpDebug("[Server] Building tool search index...")
-    const allTools = toolRegistry.getToolDefinitions()
-    const toolIndexEntries = allTools.map((tool) => {
-      const registeredTool = toolRegistry.getTool(tool.name)
-      return {
-        id: tool.name,
-        description: tool.description.substring(0, 200),
-        category: registeredTool?.domain || "unknown",
-        keywords: extractKeywords(tool.name, tool.description),
-        deferred: true, // All tools are deferred in lazy mode
-      }
-    })
+    // Everything is deferred in lazy mode: tool_search is the only way in.
+    const toolIndexEntries = buildToolIndex(
+      toolRegistry.getToolDefinitions(),
+      (name) => toolRegistry.getTool(name)?.domain || "unknown",
+      true,
+    )
     ToolSearch.registerTools(toolIndexEntries)
     mcpDebug(`[Server] Tool search index populated with ${toolIndexEntries.length} tools`)
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/transports/stdio.ts
@@ -17,7 +17,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { MCPPromptManager } from "../../shared/mcp-prompt-manager.js"
 import { toolRegistry } from "../shared/tool-registry.js"
 import { authManager } from "../shared/auth.js"
-import { ToolSearch } from "../shared/tool-search.js"
+import { ToolSearch, extractKeywords } from "../shared/tool-search.js"
 import { mcpDebug, mcpWarn } from "../../shared/mcp-debug.js"
 import { extractJWTPayload } from "../shared/permission-validator.js"
 import { createServer } from "../shared/server-factory.js"
@@ -263,31 +263,4 @@ const bootstrap = async (
     mcpDebug("[Server] Initialization failed:", error.message)
     throw error
   }
-}
-
-/**
- * Extract keywords from tool name and description for search indexing.
- */
-const extractKeywords = (name: string, description: string): string[] => {
-  const keywords = new Set<string>()
-
-  // Extract from tool name (e.g., snow_query_incidents -> query, incidents)
-  const nameParts = name.replace(/^snow_/, "").split("_")
-  nameParts.forEach((part) => {
-    if (part.length > 2) {
-      keywords.add(part.toLowerCase())
-    }
-  })
-
-  // Extract significant words from description
-  const descWords = description
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .filter((w) => w.length > 3 && !["this", "that", "with", "from", "will", "have", "been", "tool"].includes(w))
-
-  // Take top 10 most relevant words from description
-  descWords.slice(0, 10).forEach((w) => keywords.add(w))
-
-  return Array.from(keywords)
 }


### PR DESCRIPTION
### Issue for this PR

Closes #295

### Type of change

- [ ] Bug fix
- [ ] New tool or skill
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tool_search` is the only way a model reaches the 429 deferred tools, and nothing checked whether it returns
the right one. This scores 101 realistically-phrased requests against the shipped ranker and the index the
transports build, fails below fixed floors, and prints the numbers on every run.

The score is bad, which is the reason to have it: recall@1 0.267, recall@5 0.505, recall@20 0.663, MRR 0.385.
A third of realistic requests never surface an acceptable tool in the top 20 at all. `snow_sp_theme_manage` is
the top hit for 24 of the 101 queries, because query words are matched with `includes()` at length > 2, so
"the" hits its id, its description and both its keywords. I left the ranking alone; that is #298.

Two things I ran into on the way. Nine tools in `tools.json` are never registered by the server, so I filed
#307 and score against the registry instead. And the index-building code was copied in both transports, so it
moved into `shared/tool-search.ts`; behaviour is the same.

The floors are under the tie band, not just under the measured score: equal scores keep index order, so the
same 429 tools in 24 different orders span recall@20 0.653-0.693.

### How did you verify it works?

`bun typecheck` clean, `bun run lint` 1761 warnings / 0 errors (same as main), `bun test` 254 pass in the MCP
package and 60 in skills. The eval runs in ~130ms. I also raised a floor and broke a fixture entry on purpose
to confirm both assertions really fail rather than pass vacuously. Nothing here touches a ServiceNow instance,
so there was nothing to call.

Caveat worth a maintainer's eye: which tool answers which request is my judgment. 36 of the 101 entries accept
more than one tool, where the catalog ships near-duplicates for one intent. Disagree with a mapping and the
numbers move.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json` (no tool changed; `generate:tools-json:check` says up to date)
- [x] If I added or changed a skill, I re-ran the skills `generate` (no skill changed)
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
