### PR TITLE
docs: contributor on-ramp for missing skills

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill-proposal.yml
@@ -1,0 +1,43 @@
+name: Skill proposal
+description: Propose a new skill guide, or a domain an existing guide misses
+title: "docs(skills): "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: domain
+    attributes:
+      label: What should the skill teach
+      description: A sentence or two. Which ServiceNow domain, and what an agent gets wrong without it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tools
+    attributes:
+      label: Tools it would cover
+      description: The snow_* tools the guide would drive. See https://docs.serac.build for the full list.
+      placeholder: |
+        snow_oncall_manage
+        snow_create_schedule
+    validations:
+      required: true
+
+  - type: input
+    id: closest
+    attributes:
+      label: Closest existing skill
+      description:
+        Which directory under packages/skills comes nearest, and why it does not cover this. Overlapping guides
+        are worse than a missing one, so this is the field that decides the answer.
+      placeholder: sla-management — mentions business-hours schedules, nothing about rotations
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Optional. Release or plugin dependencies, an instance you can verify against, prior art.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,11 @@ Both are described in [AGENTS.md](./AGENTS.md), along with the code style. The s
 
 Both generators have a `--check` mode, and `bun test` fails if the checked-in artifact drifts from the tree.
 
+A skill is the smallest useful thing to contribute here: one markdown file, no build step. The issues
+labelled [good first issue](https://github.com/serac-labs/serac/labels/good%20first%20issue) are ServiceNow
+domains where the server has tools and nothing teaches an agent to use them, each with the tools listed.
+[`packages/skills/README.md`](./packages/skills/README.md) covers how to write one and what done looks like.
+
 ### Two files that are production
 
 `packages/servicenow-mcp/tools.json` and `packages/servicenow-mcp/sn-roles.manifest.json` are fetched at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Both are described in [AGENTS.md](./AGENTS.md), along with the code style. The s
 
 Both generators have a `--check` mode, and `bun test` fails if the checked-in artifact drifts from the tree.
 
-A skill is the smallest useful thing to contribute here: one markdown file, no build step. The issues
+A skill is the smallest useful thing to contribute here: one markdown file, plus the `generate` above. The issues
 labelled [good first issue](https://github.com/serac-labs/serac/labels/good%20first%20issue) are ServiceNow
 domains where the server has tools and nothing teaches an agent to use them, each with the tools listed.
 [`packages/skills/README.md`](./packages/skills/README.md) covers how to write one and what done looks like.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -48,3 +48,42 @@ compared its output to reality.
 `bun test` also asserts that every tool named in frontmatter actually exists in
 `@serac-labs/servicenow-mcp`, so a skill cannot promise the agent a tool the
 server does not have.
+
+## Writing a new skill
+
+The MCP server covers more ServiceNow than these 57 guides do. The domains where
+it has tools and no skill explains them are filed as issues labelled
+[good first issue][gfi]; each one names the tools involved and the closest
+existing skill. Pick one and say so in a comment before you start. For a domain
+that is not on that list, open an issue first — the label means a maintainer
+already agreed the guide is wanted, which is the whole point of it.
+
+A skill is one directory holding one `SKILL.md`, and it opens with frontmatter:
+
+```yaml
+---
+name: on-call-rotations # must equal the directory name
+description: One line. This is what an agent reads when deciding to load it.
+tools:
+  - snow_oncall_manage
+---
+```
+
+Write for an agent that knows ServiceNow exists but has never worked in this
+corner of it: the order operations have to happen in, the values the platform
+actually accepts, and the mistake that costs an afternoon. Not a paraphrase of
+each tool's input schema — the agent already has that. `es5-compliance` is a
+short one to copy, `update-set-workflow` a slightly longer one.
+
+Done looks like this:
+
+- `bun run --cwd packages/skills generate` has been run and the resulting
+  `src/embedded.ts` is part of the commit.
+- `cd packages/skills && bun test` passes. A mistyped tool name and a stale
+  `embedded.ts` both fail there rather than in front of a user.
+- You ran the tools you wrote about against an instance, and the PR says what
+  you saw. A free developer instance is enough — see [CONTRIBUTING][contrib].
+- The PR links its issue with `Fixes #123`.
+
+[gfi]: https://github.com/serac-labs/serac/labels/good%20first%20issue
+[contrib]: ../../CONTRIBUTING.md

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -58,11 +58,12 @@ existing skill. Pick one and say so in a comment before you start. For a domain
 that is not on that list, open an issue first — the label means a maintainer
 already agreed the guide is wanted, which is the whole point of it.
 
-A skill is one directory holding one `SKILL.md`, and it opens with frontmatter:
+A skill is one directory holding one `SKILL.md`, and it opens with frontmatter
+whose `name` is the directory name:
 
 ```yaml
 ---
-name: on-call-rotations # must equal the directory name
+name: on-call-rotations
 description: One line. This is what an agent reads when deciding to load it.
 tools:
   - snow_oncall_manage

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -41,28 +41,30 @@ const walk = (dir: string, acc: string[] = []): string[] => {
   return acc
 }
 
-/** The `tools:` list out of a SKILL.md's YAML frontmatter. */
+/**
+ * Tool names declared under `tools:`.
+ *
+ * Several skills annotate an entry with the action they mean —
+ * `- snow_update_set_manage (action='create')`. Only the first token is the tool
+ * name, and requiring the whole item to be one token dropped those entries
+ * silently, which exempted ten names in the tree from the check below.
+ */
+const declaredTools = (lines: string[]): string[] => {
+  const start = lines.findIndex((line) => /^tools:\s*$/.test(line))
+  if (start < 0) return []
+  const end = lines.findIndex((line, index) => index > start && /^\S/.test(line))
+  return lines.slice(start + 1, end < 0 ? undefined : end).flatMap((line) => /^\s*-\s*(\S+)/.exec(line)?.[1] ?? [])
+}
+
+/** The `name`, `description` and `tools:` list out of a SKILL.md's YAML frontmatter. */
 const frontmatter = (name: string) => {
   const raw = readFileSync(join(ROOT, name, "SKILL.md"), "utf8")
   const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw)
   if (!match) return undefined
-  const lines = match[1]!.split(/\r?\n/)
-  const tools: string[] = []
-  let inTools = false
-  for (const line of lines) {
-    if (/^tools:\s*$/.test(line)) {
-      inTools = true
-      continue
-    }
-    if (!inTools) continue
-    const item = /^\s*-\s*(\S+)\s*$/.exec(line)
-    if (item) tools.push(item[1]!)
-    else if (/^\S/.test(line)) inTools = false
-  }
   return {
     name: /^name:\s*(\S+)\s*$/m.exec(match[1]!)?.[1],
     description: /^description:\s*(.+)$/m.exec(match[1]!)?.[1],
-    tools,
+    tools: declaredTools(match[1]!.split(/\r?\n/)),
   }
 }
 
@@ -123,6 +125,20 @@ describe("frontmatter tools", () => {
     scan(toolsDir)
     return found
   }
+
+  test("an entry annotated with an action still names its tool", () => {
+    // This is the shape `update-set-workflow` uses, and it is the skill every
+    // "write a guide" issue points a newcomer at, so a parser that skips it
+    // hands the whole check back to the contributor without saying so.
+    const parsed = declaredTools([
+      "tools:",
+      "  - snow_update_set_manage (action='create')",
+      "  - snow_ensure_active_update_set",
+      "license: Apache-2.0",
+      "  - snow_not_a_tool",
+    ])
+    expect(parsed).toEqual(["snow_update_set_manage", "snow_ensure_active_update_set"])
+  })
 
   test("every tool a skill declares exists in @serac-labs/servicenow-mcp", () => {
     if (!existsSync(toolsDir)) {


### PR DESCRIPTION
### Issue for this PR

Closes #297

### Type of change

- [x] Bug fix
- [ ] New tool or skill
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

There was nothing on the board an outsider could pick up. A skill is one markdown file, which is about the
lowest barrier there is, so I read tools.json against the 57 skills and filed the eight domains where the
server has tools and no guide teaches them: #299-#306 (agile, users/groups/roles, the classic workflow
engine, form and list layout, Service Portal, attachments, source control, on-call). This PR is the part
that lives in the repo — a "Writing a new skill" section in the skills README, four lines in CONTRIBUTING
pointing at the label, and a skill-proposal issue template whose "closest existing skill" field is what
keeps guides from overlapping.

The second commit is a bug I only found because I wrote the on-ramp. Those issues tell a contributor that
`bun test` catches a tool name the server does not have. It did not. The frontmatter parser wanted a
`tools:` entry to be one token, so `- snow_update_set_manage (action='create')` matched nothing and was
dropped without a word — ten entries across five skills went unchecked, including all four in
`update-set-workflow`, the skill those issues say to copy. It takes the first token now, so 231 entries are
checked instead of 221.

### How did you verify it works?

`bun typecheck` and `bun run test` pass (252 MCP, 61 skills), `bun run lint` gives 0 errors and the same
1760 warnings as before. I counted the dropped entries with a script first, then confirmed the count after
the fix. I have not rendered `skill-proposal.yml` on GitHub — it is valid YAML in the issue-form shape, but
whoever opens the form first is the real check. Nothing here touches a ServiceNow instance.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json`
- [x] If I added or changed a skill, I re-ran the skills `generate`
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
