### PR TITLE
feat(mcp): publish sn-roles.manifest.json as a documented artifact

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -311,6 +311,14 @@ jobs:
               ),
               ...Object.entries(pkg.bin ?? {}).map(([key, value]) => [`bin["${key}"]`, value]),
               ["files", "dist/index.js"],
+              // The roles manifest is data, not an entrypoint: exports["./sn-roles"]
+              // reads it from the package root at runtime, and it deliberately has
+              // no JSON subpath of its own (importing one under node needs an
+              // import attribute the smoke gate below cannot pass). So nothing in
+              // exports would notice it dropping out of `files` — which is the
+              // state every published tarball was in until it was added there:
+              // present in the repo, absent from the package.
+              ["files", "sn-roles.manifest.json"],
             ]
 
             const inTarball = (file) => {

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -229,10 +229,10 @@ jobs:
           tar -cf - --exclude=node_modules --exclude=dist . | tar -xf - -C "$STANDALONE"
           cd "$STANDALONE"
           test ! -e ../package.json || { echo "::error::standalone dir has a parent manifest; the test is meaningless"; exit 1; }
-          # Resolve fresh rather than from a committed lockfile. The package
-          # ships only dist/ and src/agent-fragments (see `files`), so no
-          # lockfile ever reaches a consumer — they resolve the ranges in
-          # package.json themselves, which is exactly what this now reproduces.
+          # Resolve fresh rather than from a committed lockfile. Nothing in
+          # `files` is a lockfile, so none ever reaches a consumer — they
+          # resolve the ranges in package.json themselves, which is exactly what
+          # this now reproduces.
           # A committed standalone lockfile pinned nothing a user gets and cost
           # us the dependency automation: with two bun projects overlapping,
           # Renovate updated neither lockfile on a workspace-member bump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,9 @@ Keep helpers close to the code they support, below the main export. Extract only
 - After adding or changing a tool, run `bun run --cwd packages/servicenow-mcp generate:tools-json`.
   `tools.json` is fetched from `main` by the public docs site, so a stale manifest means the tool exists but
   nobody can see it.
+- A new tool also has no entry in `sn-roles.manifest.json`, and that one cannot be regenerated in CI — it
+  reads a live instance's ACLs. Add the tool's name to `AWAITING_PROBE` in
+  `src/__tests__/sn-roles.test.ts`; the next `probe:sn-roles` run covers it and takes it back off.
 - Every executor takes a `ServiceNowContext`. In the HTTP transport one process serves many customers, so
   anything cached must be keyed by `tenantId` — a request that cannot be placed in a tenant is refused, not
   pooled. See `src/servicenow-mcp-unified/shared/tenant-scope.ts`.

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -93,7 +93,8 @@ supply its own shared store.
 `sn-roles.manifest.json` answers "which ServiceNow role do I need to run this tool?" It is empirical, not
 documentation-derived: `script/probe-sn-roles` extracts every `(table, operation)` pair each tool performs,
 then resolves it against a live instance's `sys_security_acl` — the rows ServiceNow's own auth engine reads
-at request time. It ships inside the npm tarball, and the `/sn-roles` subpath types it:
+at request time. `files` ships it inside the npm tarball as of the next release — 0.2.1 and earlier did not
+contain it at all — and the `/sn-roles` subpath types it:
 
 ```ts
 import { loadSnRolesManifest } from "@serac-labs/servicenow-mcp/sn-roles"
@@ -130,16 +131,23 @@ Each tool is one of two shapes. Resolved:
 
 - **`anyOf`** — single roles that ALONE suffice for the whole tool: the intersection of every primitive's
   role list, plus `admin`, which bypasses ACLs outright. Just `["admin"]` means no single non-admin role
-  covers it.
-- **`minimumBundle`** — the smallest set of roles a user needs _together_ (greedy set-cover). `[]` means the
-  tool needs no authenticated role at all; `["admin"]` means some primitive is admin-only. `admin` stays an
-  implicit alternative either way.
+  covers it. `public` shows up here too; it is ServiceNow's "no authentication required" marker, not a role
+  anyone can be granted, so do not render it as one.
+- **`minimumBundle`** — the smallest set of roles a user needs _together_ (greedy set-cover), computed with
+  the `public` primitives dropped — which is why a tool whose every primitive is `public` comes out as `[]`,
+  needing no authenticated role at all. `["admin"]` means some primitive had nothing non-admin left in its
+  role list, and that happens two ways: a genuinely admin-only ACL, or an ACL carrying no roles at all,
+  which any authenticated caller passes. They are indistinguishable in the rollup, so check that
+  primitive's own `roles` before telling someone they need admin. `admin` stays an implicit alternative
+  either way.
 - **`primitives`** — one entry per table call the tool makes, so a table read three times appears three
-  times. `roles` is OR-combined across every matching ACL. `source` is how the ACL was found: `direct` on
-  the table, `inherited` from a `sys_db_object.super_class` ancestor (then `inheritedFrom` names it), or
-  `wildcard` from the `*` ACL. `scriptAcls` counts matching ACLs that carry a condition or advanced script —
-  above zero, the role list is necessary but may not be sufficient, because those scripts run per record and
-  the probe cannot evaluate them.
+  times. `roles` is OR-combined across every matching ACL, and an empty `roles` means the ACL rows exist but
+  name no role — any authenticated caller passes. `source` is how the ACL was found: `direct` on the table,
+  `inherited` from a `sys_db_object.super_class` ancestor (then `inheritedFrom` names it), `wildcard` from
+  the `*` ACL, or `none` — nothing matched at any level, and `roles` is then ServiceNow's implicit
+  admin-only deny, assumed rather than measured. `scriptAcls` counts matching ACLs that carry a condition or
+  advanced script — above zero, the role list is necessary but may not be sufficient, because those scripts
+  run per record and the probe cannot evaluate them.
 
 Untestable:
 
@@ -151,10 +159,11 @@ Untestable:
 }
 ```
 
-**`untestable` means "not measurable by this method", not "needs no role"** — 128 of the 428 entries are in
-this state. The extractor only sees literal `/api/now/table/<table>` endpoints passed to `client.get/post/…`,
-so tools that go through Scripted REST or another API, tools that only compute locally, and tools that build
-their table name at runtime all land here with no roles at all.
+**`untestable` means "not measurable by this method", not "needs no role"** — `stats.untestable` is how many
+entries are in this state, and it is a large share of them. The extractor only sees literal
+`/api/now/table/<table>` endpoints passed to `client.get/post/…`, so tools that go through Scripted REST or
+another API, tools that only compute locally, and tools that build their table name at runtime all land here
+with no roles at all.
 
 `stats` mirrors the run: `tools` and `untestable` are entry counts; `primitivesTotal` is the number of
 distinct `(table, operation)` pairs and `primitivesResolved` how many of them the instance answered for
@@ -169,9 +178,9 @@ and sometimes between patches, so the manifest is exact for the release it names
 elsewhere. Nothing refreshes it automatically — `probe:sn-roles` needs OAuth credentials for a live
 instance, so it is a human running it after a family upgrade and diffing the result.
 
-Tools added since the last run therefore have no entry. Today that is 9 of 437 (the `snow_fluent_*` family
-and `snow_blast_radius_sys_properties`); `src/__tests__/sn-roles.test.ts` names them and fails if that set
-changes in either direction, so the gap stays visible instead of silently growing.
+Tools added since the last run therefore have no entry — there are some today. `src/__tests__/sn-roles.test.ts`
+names the current set and fails if it changes in either direction, so the gap stays visible instead of
+silently growing.
 
 ## Published manifests — read before moving them
 

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -65,6 +65,7 @@ Each tool is exported as a `*_def` / `*_exec` pair: the MCP tool definition and 
 | `/stdio`            | The stdio transport                                           |
 | `/http`             | The streamable-HTTP transport, as a Hono app                  |
 | `/blast-radius`     | Impact-analysis tools, usable without the MCP layer           |
+| `/sn-roles`         | The ServiceNow roles each tool needs — see below              |
 | `/types`            | `ServiceNowContext`, `MCPToolDefinition`, …                   |
 | `/auth`             | OAuth + basic auth, token cache, authenticated Axios client   |
 | `/error-handler`    | Result envelopes and error classification                     |
@@ -87,11 +88,97 @@ the credentials, which is safe but colder.
 None of this state is shared between processes, so an HTTP deployment should run **single-replica** or
 supply its own shared store.
 
+## The roles manifest
+
+`sn-roles.manifest.json` answers "which ServiceNow role do I need to run this tool?" It is empirical, not
+documentation-derived: `script/probe-sn-roles` extracts every `(table, operation)` pair each tool performs,
+then resolves it against a live instance's `sys_security_acl` — the rows ServiceNow's own auth engine reads
+at request time. It ships inside the npm tarball, and the `/sn-roles` subpath types it:
+
+```ts
+import { loadSnRolesManifest } from "@serac-labs/servicenow-mcp/sn-roles"
+
+const manifest = loadSnRolesManifest()
+manifest.tools["snow_trigger_scheduled_job"].snRoles
+// { anyOf: ["admin", "system_scheduler_admin"], minimumBundle: ["system_scheduler_admin"] }
+```
+
+`loadSnRolesManifest()` re-reads and re-parses ~420 kB per call, so hold the result. `snRolesManifestPath`
+is the absolute path to the same file, for consumers that would rather stream or serve it than parse it.
+
+### Schema
+
+| Top-level     | What it is                                                                                               |
+| ------------- | -------------------------------------------------------------------------------------------------------- |
+| `version`     | Schema version, currently `1`. Bumped when the shape changes, not when the data is re-probed.            |
+| `validatedOn` | The release string the probed instance reported, e.g. `glide-australia-02-11-2026__patch1-…`.            |
+| `testedAt`    | When the probe ran, ISO-8601.                                                                            |
+| `stats`       | Rollups over the whole run, below.                                                                       |
+| `tools`       | Keyed by tool name. A tool that is absent has not been probed, which is not the same as needing no role. |
+
+Each tool is one of two shapes. Resolved:
+
+```json
+"snow_job_status": {
+  "snRoles": { "anyOf": ["admin"], "minimumBundle": ["assessment_admin", "snc_internal"] },
+  "primitives": [
+    { "table": "sys_trigger", "operation": "read", "roles": ["…"], "source": "direct", "scriptAcls": 0 },
+    { "table": "sys_execution_tracker", "operation": "read", "roles": ["snc_internal"], "source": "direct", "scriptAcls": 1 }
+  ]
+}
+```
+
+- **`anyOf`** — single roles that ALONE suffice for the whole tool: the intersection of every primitive's
+  role list, plus `admin`, which bypasses ACLs outright. Just `["admin"]` means no single non-admin role
+  covers it.
+- **`minimumBundle`** — the smallest set of roles a user needs _together_ (greedy set-cover). `[]` means the
+  tool needs no authenticated role at all; `["admin"]` means some primitive is admin-only. `admin` stays an
+  implicit alternative either way.
+- **`primitives`** — one entry per table call the tool makes, so a table read three times appears three
+  times. `roles` is OR-combined across every matching ACL. `source` is how the ACL was found: `direct` on
+  the table, `inherited` from a `sys_db_object.super_class` ancestor (then `inheritedFrom` names it), or
+  `wildcard` from the `*` ACL. `scriptAcls` counts matching ACLs that carry a condition or advanced script —
+  above zero, the role list is necessary but may not be sufficient, because those scripts run per record and
+  the probe cannot evaluate them.
+
+Untestable:
+
+```json
+"snow_date_filter": {
+  "snRoles": null,
+  "untestable": true,
+  "reason": "no /api/now/table/<table> calls detected in static analysis"
+}
+```
+
+**`untestable` means "not measurable by this method", not "needs no role"** — 128 of the 428 entries are in
+this state. The extractor only sees literal `/api/now/table/<table>` endpoints passed to `client.get/post/…`,
+so tools that go through Scripted REST or another API, tools that only compute locally, and tools that build
+their table name at runtime all land here with no roles at all.
+
+`stats` mirrors the run: `tools` and `untestable` are entry counts; `primitivesTotal` is the number of
+distinct `(table, operation)` pairs and `primitivesResolved` how many of them the instance answered for
+(fewer means a partial run); `sourceDistribution` counts primitive _occurrences_, so it sums higher than
+`primitivesTotal`; and `topRoles[].tools` is misnamed — it counts distinct primitives whose ACLs accept the
+role, not tools.
+
+### Staleness
+
+`validatedOn`, not `testedAt`, is the field that matters: roles and ACLs move between ServiceNow families
+and sometimes between patches, so the manifest is exact for the release it names and a strong hint
+elsewhere. Nothing refreshes it automatically — `probe:sn-roles` needs OAuth credentials for a live
+instance, so it is a human running it after a family upgrade and diffing the result.
+
+Tools added since the last run therefore have no entry. Today that is 9 of 437 (the `snow_fluent_*` family
+and `snow_blast_radius_sys_properties`); `src/__tests__/sn-roles.test.ts` names them and fails if that set
+changes in either direction, so the gap stays visible instead of silently growing.
+
 ## Published manifests — read before moving them
 
-Two generated JSON files live at the root of this package. They are **not** part
-of the npm tarball; they are published _by being committed_, because live
-services fetch them straight from `main` over `raw.githubusercontent.com`:
+Two generated JSON files live at the root of this package. Both are published _by
+being committed_, because live services fetch them straight from `main` over
+`raw.githubusercontent.com`. `sn-roles.manifest.json` is _also_ in the npm
+tarball, behind the `/sn-roles` subpath above; `tools.json` is not:
 
 | File                     | Fetched at runtime by                                                         | If the URL 404s                                                                                                                                                                     |
 | ------------------------ | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -16,7 +16,8 @@
   "private": false,
   "files": [
     "dist",
-    "src/agent-fragments"
+    "src/agent-fragments",
+    "sn-roles.manifest.json"
   ],
   "exports": {
     ".": "./src/index.ts",
@@ -26,6 +27,7 @@
     "./stdio": "./src/servicenow-mcp-unified/transports/stdio.ts",
     "./enterprise-proxy": "./src/enterprise-proxy/index.ts",
     "./blast-radius": "./src/servicenow-mcp-unified/tools/blast-radius/index.ts",
+    "./sn-roles": "./src/sn-roles.ts",
     "./types": "./src/servicenow-mcp-unified/shared/types.ts",
     "./auth": "./src/servicenow-mcp-unified/shared/auth.ts",
     "./error-handler": "./src/servicenow-mcp-unified/shared/error-handler.ts",

--- a/packages/servicenow-mcp/script/__tests__/published-manifests.test.ts
+++ b/packages/servicenow-mcp/script/__tests__/published-manifests.test.ts
@@ -2,10 +2,11 @@
  * Presence and shape guard for the two manifests that are published BY BEING
  * COMMITTED.
  *
- * `tools.json` and `sn-roles.manifest.json` are not in the npm tarball — the
- * package's `files` field ships only `dist` and `src/agent-fragments`. They
- * reach production a completely different way: live services fetch them from
- * `main` over raw.githubusercontent.com. See README.md, "Published manifests".
+ * `tools.json` and `sn-roles.manifest.json` reach production a way no build gate
+ * sees: live services fetch them from `main` over raw.githubusercontent.com. See
+ * README.md, "Published manifests". (`sn-roles.manifest.json` is in the npm
+ * tarball as well — `files` ships it for the `/sn-roles` subpath — but that is a
+ * second audience, not the one below.)
  *
  * That makes them the one part of this package where deleting a file is a
  * production incident rather than a failing build, and where the failure is

--- a/packages/servicenow-mcp/script/probe-sn-roles/README.md
+++ b/packages/servicenow-mcp/script/probe-sn-roles/README.md
@@ -67,60 +67,13 @@ in any matching ACL grants access, subject to that ACL's condition/script.
 
 ## Output shape
 
-```json
-{
-  "version": 1,
-  "validatedOn": "glide-australia-02-11-2026__patch1-...",
-  "testedAt": "2026-05-14T...",
-  "stats": {
-    "tools": 428,
-    "untestable": 128,
-    "primitivesTotal": 462,
-    "primitivesResolved": 462,
-    "sourceDistribution": { "direct": 380, "inherited": 60, "wildcard": 22 },
-    "topRoles": [ { "role": "admin", "tools": 462 }, ... ]
-  },
-  "tools": {
-    "snow_change_manage": {
-      "snRoles": {
-        "anyOf": ["admin"],
-        "minimumBundle": ["itil", "snc_internal"]
-      },
-      "primitives": [
-        { "table": "change_request", "operation": "create", "roles": ["itil", "sn_change_write"], "source": "direct", "scriptAcls": 0 },
-        { "table": "sysapproval_approver", "operation": "create", "roles": ["snc_internal"], "source": "direct", "scriptAcls": 1 }
-      ]
-    },
-    "snow_check_health": {
-      "snRoles": {
-        "anyOf": ["admin", "public", "snc_internal"],
-        "minimumBundle": []
-      },
-      "primitives": [...]
-    },
-    "snow_date_filter": {
-      "snRoles": null,
-      "untestable": true,
-      "reason": "no /api/now/table/<table> calls detected in static analysis"
-    }
-  }
-}
-```
-
-Two rollup fields per tool:
-
-- **`anyOf`** — single roles that ALONE suffice for the entire tool (intersection
-  of primitive role sets, plus `admin` since admin bypasses ACLs). When this is
-  just `["admin"]`, no non-admin role works on its own.
-- **`minimumBundle`** — smallest set of roles the user needs **together** to
-  unlock every primitive. Computed via greedy set-cover.
-  - `[]` (empty) = entire tool is publicly accessible (no auth required)
-  - `["foo"]` = single role suffices
-  - `["foo", "bar"]` = user needs BOTH roles
-  - `["admin"]` = some primitive is admin-only, no non-admin bundle works
-
-`admin` is always an implicit alternative regardless of `minimumBundle` value —
-it bypasses ACLs entirely in SN's auth engine.
+Documented once, in the package README's "The roles manifest" section
+(`../../README.md`), which is the copy that ships to npm consumers behind the
+`/sn-roles` subpath, and typed in `src/sn-roles.ts`. The copy that used to be
+here had already drifted: it showed a `sourceDistribution` of
+`{direct: 380, inherited: 60, wildcard: 22}` against a manifest that says
+`{direct: 870, wildcard: 189, inherited: 42}`, and repeated the wrong rule for
+`minimumBundle: ["admin"]`.
 
 ## Re-running across SN releases
 

--- a/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
@@ -14,8 +14,8 @@
  *  3. It has to describe the same tools as `tools.json`.
  *
  * (3) is the one that has already gone wrong in this repo, on the other
- * manifest: `tools.json` sat at 429 tools while the tree had 437, missing all
- * eight `snow_fluent_*` tools for two months, because nothing compared them.
+ * manifest: `tools.json` sat at 429 tools while the tree had 437, because
+ * nothing compared them (issue #294).
  * The roles manifest is a step further out of reach — it cannot be regenerated
  * in CI at all (it reads `sys_security_acl` on a live instance), so it goes
  * stale by default. This makes the gap explicit and countable instead.
@@ -70,20 +70,24 @@ describe("the manifest is published, not just committed", () => {
     // `sn-roles.ts` reads `../sn-roles.manifest.json`, which lands on the
     // package root from `src/` here and from `dist/` in the tarball only
     // because tsconfig.build.json sets rootDir to src. Move the module a
-    // directory deeper and both layouts break; this pins the src half, and the
-    // tarball gate in .github/workflows/publish-mcp.yml pins the dist half.
+    // directory deeper and both layouts break. This pins the src half only:
+    // nothing in CI calls loadSnRolesManifest() against a built tarball, since
+    // the publish workflow's smoke gate imports the subpath and this module
+    // does no I/O at import time. The dist half was checked by hand — untar the
+    // pack and import dist/sn-roles.js under node.
     expect(snRolesManifestPath).toBe(resolve(PACKAGE_ROOT, "sn-roles.manifest.json"))
   })
 })
 
 describe("the declared types still describe the data", () => {
   test("every entry matches SnRolesResolvedTool or SnRolesUntestableTool", () => {
-    // The unions as `sn-roles.ts` declares them. `methodOp` in the probe can
-    // emit "unknown" for an HTTP verb it does not map, and a future ServiceNow
-    // release can add a resolution source, so neither union is guaranteed by
-    // its producer — this is what keeps loadSnRolesManifest()'s return type honest.
+    // The unions as `sn-roles.ts` declares them. Neither is guaranteed by its
+    // producer: `methodOp` in the probe emits "unknown" for an HTTP verb it does
+    // not map, which SnRolesOperation deliberately does not cover, and "none" is
+    // a source the probe can write but this data has no instance of. That is
+    // what keeps loadSnRolesManifest()'s return type honest across probe runs.
     const operations: SnRolesOperation[] = ["read", "create", "write", "delete"]
-    const sources: SnRolesSource[] = ["direct", "inherited", "wildcard"]
+    const sources: SnRolesSource[] = ["direct", "inherited", "wildcard", "none"]
 
     const violations = Object.entries(manifest.tools).flatMap(([name, tool]) => {
       // `in` rather than a truthiness or null check: this package compiles
@@ -119,15 +123,24 @@ describe("the declared types still describe the data", () => {
 
 describe("tools.json and the roles manifest agree on which tools exist", () => {
   test("every published tool has a roles entry, except those awaiting the next probe", () => {
-    expect(published.filter((name) => !Object.hasOwn(manifest.tools, name) && !AWAITING_PROBE.includes(name))).toEqual(
-      [],
-    )
+    // Failures name the fix rather than printing a bare array diff: this fires
+    // on whoever adds the next tool, in a test that has nothing to do with
+    // their change, and AGENTS.md is the only other place that says so.
+    expect(
+      published
+        .filter((name) => !Object.hasOwn(manifest.tools, name) && !AWAITING_PROBE.includes(name))
+        .map((name) => `${name}: no roles entry — add it to AWAITING_PROBE in this file until the next probe run`),
+    ).toEqual([])
   })
 
   test("AWAITING_PROBE holds nothing already covered, and nothing that is no longer a tool", () => {
-    expect(AWAITING_PROBE.filter((name) => Object.hasOwn(manifest.tools, name) || !published.includes(name))).toEqual(
-      [],
-    )
+    expect(
+      AWAITING_PROBE.filter((name) => Object.hasOwn(manifest.tools, name) || !published.includes(name)).map((name) =>
+        Object.hasOwn(manifest.tools, name)
+          ? `${name}: the manifest covers it now — drop it from AWAITING_PROBE`
+          : `${name}: no longer a tool — drop it from AWAITING_PROBE`,
+      ),
+    ).toEqual([])
   })
 
   test("the manifest names no tool that no longer exists", () => {

--- a/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The roles manifest as a published artifact.
+ *
+ * Three things have to stay true for `sn-roles.manifest.json` to be worth
+ * anything to a consumer, and none of them are checked anywhere else:
+ *
+ *  1. It has to reach npm. It did not: `files` shipped only `dist` and
+ *     `src/agent-fragments`, so no tarball published before #294 contained a
+ *     byte of it.
+ *  2. The types in `sn-roles.ts` have to keep describing it. They are
+ *     hand-written over an unchecked `JSON.parse`, and the data is regenerated
+ *     by a manual probe run against whatever ServiceNow release is current — a
+ *     `loadSnRolesManifest()` whose return type lies is worse than no type.
+ *  3. It has to describe the same tools as `tools.json`.
+ *
+ * (3) is the one that has already gone wrong in this repo, on the other
+ * manifest: `tools.json` sat at 429 tools while the tree had 437, missing all
+ * eight `snow_fluent_*` tools for two months, because nothing compared them.
+ * The roles manifest is a step further out of reach — it cannot be regenerated
+ * in CI at all (it reads `sys_security_acl` on a live instance), so it goes
+ * stale by default. This makes the gap explicit and countable instead.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { loadSnRolesManifest, snRolesManifestPath, type SnRolesOperation, type SnRolesSource } from "../sn-roles"
+
+const PACKAGE_ROOT = resolve(__dirname, "..", "..")
+
+/**
+ * Tools that exist but have no roles entry yet, because they landed after the
+ * last probe run (`testedAt` in the manifest) and re-probing needs OAuth
+ * credentials for a live instance — a human with an instance, not CI.
+ *
+ * Adding a tool means adding it here; re-running `probe:sn-roles` means
+ * emptying whatever it covered back out. Both directions fail below, so this
+ * list cannot quietly drift out of date the way an unchecked manifest can.
+ */
+const AWAITING_PROBE = [
+  "snow_blast_radius_sys_properties",
+  "snow_fluent_build",
+  "snow_fluent_dependencies",
+  "snow_fluent_download",
+  "snow_fluent_explain",
+  "snow_fluent_init",
+  "snow_fluent_install",
+  "snow_fluent_status",
+  "snow_fluent_transform",
+]
+
+const manifest = loadSnRolesManifest()
+const probed = Object.keys(manifest.tools)
+
+const toolsJson: { groups: { tools: { name: string }[] }[] } = JSON.parse(
+  readFileSync(resolve(PACKAGE_ROOT, "tools.json"), "utf8"),
+)
+const published = toolsJson.groups.flatMap((group) => group.tools.map((tool) => tool.name))
+
+describe("the manifest is published, not just committed", () => {
+  test("package.json ships it in the tarball", () => {
+    // Without this the file reaches only the services that fetch it from main
+    // over raw.githubusercontent.com, and `npm install` users — the audience
+    // for exports["./sn-roles"] — get a module that throws ENOENT on first call.
+    const pkg: { files: string[] } = JSON.parse(readFileSync(resolve(PACKAGE_ROOT, "package.json"), "utf8"))
+    expect(pkg.files).toContain("sn-roles.manifest.json")
+  })
+
+  test("the entry point resolves the package-root copy", () => {
+    // `sn-roles.ts` reads `../sn-roles.manifest.json`, which lands on the
+    // package root from `src/` here and from `dist/` in the tarball only
+    // because tsconfig.build.json sets rootDir to src. Move the module a
+    // directory deeper and both layouts break; this pins the src half, and the
+    // tarball gate in .github/workflows/publish-mcp.yml pins the dist half.
+    expect(snRolesManifestPath).toBe(resolve(PACKAGE_ROOT, "sn-roles.manifest.json"))
+  })
+})
+
+describe("the declared types still describe the data", () => {
+  test("every entry matches SnRolesResolvedTool or SnRolesUntestableTool", () => {
+    // The unions as `sn-roles.ts` declares them. `methodOp` in the probe can
+    // emit "unknown" for an HTTP verb it does not map, and a future ServiceNow
+    // release can add a resolution source, so neither union is guaranteed by
+    // its producer — this is what keeps loadSnRolesManifest()'s return type honest.
+    const operations: SnRolesOperation[] = ["read", "create", "write", "delete"]
+    const sources: SnRolesSource[] = ["direct", "inherited", "wildcard"]
+
+    const violations = Object.entries(manifest.tools).flatMap(([name, tool]) => {
+      // `in` rather than a truthiness or null check: this package compiles
+      // without strictNullChecks, where neither of those narrows the union.
+      if ("untestable" in tool) {
+        if (tool.snRoles === null && typeof tool.reason === "string" && !("primitives" in tool)) return []
+        return [`${name}: untestable entry is not shaped like SnRolesUntestableTool`]
+      }
+      // `anyOf` always contains admin: admin bypasses ACLs outright, so a
+      // resolved tool without it means the probe's rollup, not ServiceNow,
+      // changed underneath these types.
+      const rollup = tool.snRoles.anyOf.includes("admin")
+        ? []
+        : [`${name}: anyOf ${JSON.stringify(tool.snRoles.anyOf)} does not include admin`]
+      return [
+        ...rollup,
+        ...tool.primitives.flatMap((primitive) => {
+          if (!operations.includes(primitive.operation)) return [`${name}: operation "${primitive.operation}"`]
+          if (!sources.includes(primitive.source)) return [`${name}: source "${primitive.source}"`]
+          // inheritedFrom is the ancestor table an inherited ACL came from, so
+          // it is meaningless on a direct or wildcard match and required on an
+          // inherited one.
+          if ((primitive.inheritedFrom !== undefined) !== (primitive.source === "inherited"))
+            return [`${name}: inheritedFrom does not agree with source "${primitive.source}"`]
+          return []
+        }),
+      ]
+    })
+
+    expect(violations).toEqual([])
+  })
+})
+
+describe("tools.json and the roles manifest agree on which tools exist", () => {
+  test("every published tool has a roles entry, except those awaiting the next probe", () => {
+    expect(published.filter((name) => !Object.hasOwn(manifest.tools, name) && !AWAITING_PROBE.includes(name))).toEqual(
+      [],
+    )
+  })
+
+  test("AWAITING_PROBE holds nothing already covered, and nothing that is no longer a tool", () => {
+    expect(AWAITING_PROBE.filter((name) => Object.hasOwn(manifest.tools, name) || !published.includes(name))).toEqual(
+      [],
+    )
+  })
+
+  test("the manifest names no tool that no longer exists", () => {
+    // The other direction is a harder failure: a consumer joining the two
+    // manifests renders a role requirement for a tool nobody can call.
+    expect(probed.filter((name) => !published.includes(name))).toEqual([])
+  })
+
+  test("stats.untestable counts what the manifest actually flags", () => {
+    // Both numbers are read straight off the artifact by the portal, so a
+    // half-written manifest that still parses has to fail somewhere.
+    expect(manifest.stats.untestable).toBe(probed.filter((name) => "untestable" in manifest.tools[name]).length)
+  })
+})

--- a/packages/servicenow-mcp/src/sn-roles.ts
+++ b/packages/servicenow-mcp/src/sn-roles.ts
@@ -22,17 +22,26 @@ import { fileURLToPath } from "node:url"
 export type SnRolesOperation = "read" | "create" | "write" | "delete"
 
 /**
- * How the ACL that answered for a primitive was found:
- * `direct` on the table itself, `inherited` from a `sys_db_object.super_class`
- * ancestor, or `wildcard` from the `*` ACL.
+ * How the ACL that answered for a primitive was found: `direct` on the table
+ * itself, `inherited` from a `sys_db_object.super_class` ancestor, `wildcard`
+ * from the `*` ACL, or `none` — nothing matched at any level, and the probe
+ * falls back to ServiceNow's implicit deny, so `roles` is `["admin"]` by
+ * assumption rather than by measurement. The probed instance had a `*` ACL for
+ * every operation, so no entry is `none` today.
  */
-export type SnRolesSource = "direct" | "inherited" | "wildcard"
+export type SnRolesSource = "direct" | "inherited" | "wildcard" | "none"
 
 /** One (table, operation) pair a tool performs, with the roles the instance's ACLs accept for it. */
 export interface SnRolesPrimitive {
   table: string
   operation: SnRolesOperation
-  /** Roles OR-combined across every matching ACL: holding any one of them satisfies this primitive. */
+  /**
+   * Roles OR-combined across every matching ACL: holding any one of them
+   * satisfies this primitive. Empty means the ACL rows exist but name no role,
+   * which any authenticated caller passes — not the same as needing admin.
+   * `public` is ServiceNow's "no authentication required" marker, not a
+   * grantable role.
+   */
   roles: string[]
   source: SnRolesSource
   /** Only present when `source` is `inherited`: the ancestor table the ACL came from. */
@@ -50,14 +59,17 @@ export interface SnRolesRequirement {
   /**
    * Single roles that ALONE suffice for the whole tool — the intersection of every
    * primitive's role list, plus `admin`, which bypasses ACLs entirely. `["admin"]`
-   * on its own means no single non-admin role covers the tool.
+   * on its own means no single non-admin role covers the tool. May contain
+   * `public`, which is not a grantable role.
    */
   anyOf: string[]
   /**
    * Smallest set of roles a user needs TOGETHER to cover every primitive (greedy
-   * set-cover). `[]` means the tool needs no authenticated role at all; `["admin"]`
-   * means some primitive is admin-only. `admin` remains an implicit alternative
-   * whatever this says.
+   * set-cover over the primitives that are not `public`). `[]` means the tool needs
+   * no authenticated role at all. `["admin"]` means some primitive had nothing
+   * non-admin left in its role list — either a genuinely admin-only ACL or an ACL
+   * with no roles on it, and the rollup cannot tell you which, so read that
+   * primitive's `roles`. `admin` remains an implicit alternative whatever this says.
    */
   minimumBundle: string[]
 }

--- a/packages/servicenow-mcp/src/sn-roles.ts
+++ b/packages/servicenow-mcp/src/sn-roles.ts
@@ -1,0 +1,142 @@
+/**
+ * Typed access to `sn-roles.manifest.json` — which ServiceNow roles each `snow_*`
+ * tool actually requires.
+ *
+ * The manifest is empirical, not documentation-derived: `script/probe-sn-roles`
+ * resolves every (table, operation) pair a tool touches against a live
+ * instance's `sys_security_acl`, which is the same data ServiceNow's own auth
+ * engine consults at request time. That is also why it cannot be regenerated in
+ * CI, and why `validatedOn` / `testedAt` are part of the payload — they are the
+ * only staleness signal a consumer gets. See README.md, "The roles manifest".
+ *
+ * This module sits at the top of `src/` rather than under `shared/` because the
+ * manifest sits at the package root — live services fetch it from `main` at a
+ * literal raw.githubusercontent.com URL, so it cannot move. `../` from here
+ * resolves to that root both from `src/` and from the published `dist/`.
+ */
+
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+/** The four operations the probe maps HTTP verbs onto: GET, POST, PATCH/PUT, DELETE. */
+export type SnRolesOperation = "read" | "create" | "write" | "delete"
+
+/**
+ * How the ACL that answered for a primitive was found:
+ * `direct` on the table itself, `inherited` from a `sys_db_object.super_class`
+ * ancestor, or `wildcard` from the `*` ACL.
+ */
+export type SnRolesSource = "direct" | "inherited" | "wildcard"
+
+/** One (table, operation) pair a tool performs, with the roles the instance's ACLs accept for it. */
+export interface SnRolesPrimitive {
+  table: string
+  operation: SnRolesOperation
+  /** Roles OR-combined across every matching ACL: holding any one of them satisfies this primitive. */
+  roles: string[]
+  source: SnRolesSource
+  /** Only present when `source` is `inherited`: the ancestor table the ACL came from. */
+  inheritedFrom?: string
+  /**
+   * How many of the matching ACLs carry a condition or advanced script. Those
+   * run per record and the probe cannot evaluate them, so `scriptAcls > 0` means
+   * the role list is necessary but may not be sufficient at runtime.
+   */
+  scriptAcls: number
+}
+
+/** The two role rollups, both computed from the tool's `primitives`. */
+export interface SnRolesRequirement {
+  /**
+   * Single roles that ALONE suffice for the whole tool — the intersection of every
+   * primitive's role list, plus `admin`, which bypasses ACLs entirely. `["admin"]`
+   * on its own means no single non-admin role covers the tool.
+   */
+  anyOf: string[]
+  /**
+   * Smallest set of roles a user needs TOGETHER to cover every primitive (greedy
+   * set-cover). `[]` means the tool needs no authenticated role at all; `["admin"]`
+   * means some primitive is admin-only. `admin` remains an implicit alternative
+   * whatever this says.
+   */
+  minimumBundle: string[]
+}
+
+/** A tool whose ServiceNow table calls were found and resolved against the instance's ACLs. */
+export interface SnRolesResolvedTool {
+  snRoles: SnRolesRequirement
+  primitives: SnRolesPrimitive[]
+}
+
+/**
+ * A tool the probe could not place: static analysis found no
+ * `/api/now/table/<table>` call in its source, so there is no ACL to resolve.
+ * That covers tools that only call scripted/other REST APIs, tools that are pure
+ * local computation, and tools whose table is assembled at runtime — so
+ * "untestable" means "not measurable by this method", NOT "needs no role".
+ */
+export interface SnRolesUntestableTool {
+  snRoles: null
+  untestable: true
+  reason: string
+}
+
+/**
+ * Narrow with `"untestable" in tool`, which works whether or not the consumer
+ * compiles with `strictNullChecks` — `tool.snRoles === null` only narrows with
+ * it on, and this package itself compiles with it off.
+ */
+export type SnRolesTool = SnRolesResolvedTool | SnRolesUntestableTool
+
+export interface SnRolesStats {
+  /** Tools in `tools`, including the untestable ones. */
+  tools: number
+  untestable: number
+  /** Distinct (table, operation) pairs across all tools. */
+  primitivesTotal: number
+  /** How many of those the probe got an ACL answer for. Below `primitivesTotal` means a partial run. */
+  primitivesResolved: number
+  /**
+   * Counted per primitive OCCURRENCE, so it sums to more than `primitivesTotal`:
+   * a table read by twenty tools is counted twenty times.
+   */
+  sourceDistribution: Record<string, number>
+  /**
+   * Most frequently required roles. `tools` is a misnomer inherited from the
+   * probe: it counts distinct PRIMITIVES whose ACLs accept the role, not tools.
+   */
+  topRoles: { role: string; tools: number }[]
+}
+
+export interface SnRolesManifest {
+  /** Schema version of this file. Bumped when the shape changes, not when the data is re-probed. */
+  version: number
+  /**
+   * The ServiceNow release the data was read from, as the instance reports it
+   * (`glide-<family>-<build dates>.zip`). Roles move between releases, so this —
+   * not `testedAt` — is what tells a reader whether the data still applies to
+   * their instance.
+   */
+  validatedOn: string
+  /** When the probe ran, ISO-8601. */
+  testedAt: string
+  stats: SnRolesStats
+  /** Keyed by tool name (`snow_*`). A tool absent here has not been probed yet. */
+  tools: Record<string, SnRolesTool>
+}
+
+/**
+ * Absolute path to the manifest inside the installed package, for consumers that
+ * want to stream, hash or serve the file rather than parse it.
+ */
+export const snRolesManifestPath = fileURLToPath(new URL("../sn-roles.manifest.json", import.meta.url))
+
+/**
+ * Read and parse the manifest that shipped with this package.
+ *
+ * Re-reads and re-parses ~420 kB on every call — hold the result rather than
+ * calling it per tool. Throws if the manifest is not in the installed package;
+ * `files` in package.json ships it, and the tarball gate in
+ * `.github/workflows/publish-mcp.yml` is what keeps that true.
+ */
+export const loadSnRolesManifest = (): SnRolesManifest => JSON.parse(readFileSync(snRolesManifestPath, "utf8"))


### PR DESCRIPTION
### Issue for this PR

Closes #294

### Type of change

- [ ] Bug fix
- [ ] New tool or skill
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`sn-roles.manifest.json` maps 428 tools to the ServiceNow roles they actually need, measured against a real
instance's ACLs. It was treated as a build output: no types, no docs, and `files` listed only `dist` and
`src/agent-fragments`, so it never reached an npm tarball. `npm pack --dry-run` goes from 16 entries to 17
with it added.

So this adds an `./sn-roles` export with `loadSnRolesManifest()` and types for the shape the file really
has, the schema in the package README, and a test that fails when `tools.json` and the manifest disagree
about which tools exist.

They already disagree: 437 tools against 428. The nine missing are the `snow_fluent_*` family and
`snow_blast_radius_sys_properties`, added after the May probe run. I can't close that — `probe:sn-roles`
reads `sys_security_acl` on a live instance and I have no credentials for one. They sit in `AWAITING_PROBE`
and the test fails if that list drifts either way.

Before merging, note that package.json is at 0.2.1 and 0.2.1 is already on npm: someone has to bump it or
the next release dispatch fails its pre-flight. Putting this data behind a search UI on serac.build is
another repo, so not here.

### How did you verify it works?

`bun typecheck`, `bun run lint` (1761 warnings / 0 errors, same as main), 259 tests in servicenow-mcp and 60
in skills. In a scratch copy I built and packed the package, ran the publish workflow's tarball gate against
that pack (31 entrypoints, manifest included), untarred it and called `loadSnRolesManifest()` under node to
confirm `../` still resolves from `dist/`. No real publish, and I did not run the CI gate that npm-installs
the tarball.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json`
- [x] If I added or changed a skill, I re-ran the skills `generate`
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
