### PR TITLE
feat: add server.json for the MCP registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -9,12 +9,13 @@ name: Publish to MCP Registry
 #   1. npm binds a Trusted Publisher to owner + repo + workflow FILENAME, so
 #      publish-mcp.yml cannot be renamed and every edit to it risks the one
 #      credential path that has no fallback. Nothing here needs to touch it.
-#   2. Ordering forces the split anyway. The registry validates the npm package
-#      before it will accept the server: it fetches
+#   2. Ordering. The registry validates the npm package before it will accept
+#      the server: it fetches
 #      registry.npmjs.org/@serac-labs/servicenow-mcp/<version> and demands an
 #      `mcpName` there equal to the server name. The version must therefore
-#      already be live on npm when this runs, which a step appended to the npm
-#      publish cannot guarantee — it would race npm's own propagation.
+#      already be live on npm when this runs. An appended step could poll for
+#      that — publish-mcp.yml already polls npm for its own provenance
+#      read-back — so this is a cost of appending, not an impossibility.
 #   3. A workflow_run chain off publish-mcp.yml would fire on its dry runs and
 #      on forks too, and would publish under whoever happened to dispatch the
 #      npm release. Two dispatches in order — npm first, registry second — keep
@@ -78,7 +79,9 @@ jobs:
       # Runs on both paths. server.json repeats the version, the package name
       # and the server name from packages/servicenow-mcp/package.json, and all
       # of it is hand-maintained — see the script's header for what each
-      # mismatch costs.
+      # mismatch costs. It also checks that the `npx` command this listing
+      # implies can still resolve a bin, which a bin rename would silently
+      # break.
       - name: Gate — server.json agrees with the package manifest
         run: bun run --cwd packages/servicenow-mcp check:registry-manifest
 
@@ -92,13 +95,31 @@ jobs:
           echo "version=$(node -p "require('./packages/servicenow-mcp/package.json').version")" >> "$GITHUB_OUTPUT"
           echo "name=$(node -p "require('./packages/servicenow-mcp/package.json').mcpName")" >> "$GITHUB_OUTPUT"
 
+      - name: Install cosign
+        # Pinning the action pins the cosign binary too: the installer checks
+        # the release it downloads against a hash baked into the action itself.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install mcp-publisher
-        # Deliberately `latest` rather than pinned: the registry rejects tokens
-        # minted by an out-of-date CLI with "invalid audience", so a pin here
+        # The CLI stays on `latest` rather than a pin: the registry rejects
+        # tokens minted by an out-of-date CLI with "invalid audience", so a pin
         # would break the release the next time the audience contract moves.
+        # What makes a moving target acceptable is the signature check below —
+        # this job holds `id-token: write` for io.github.serac-labs/*, so an
+        # unverified binary here is the one thing in this file that could
+        # publish as us. `gh attestation verify` does not work on these assets:
+        # they carry sigstore signature bundles, not SLSA provenance.
         run: |
           set -euo pipefail
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ASSET="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+          BASE="https://github.com/modelcontextprotocol/registry/releases/latest/download"
+          curl -fsSL -o "$ASSET" "$BASE/$ASSET"
+          curl -fsSL -o "$ASSET.sigstore.json" "$BASE/$ASSET.sigstore.json"
+          cosign verify-blob "$ASSET" \
+            --bundle "$ASSET.sigstore.json" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github\.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v'
+          tar xzf "$ASSET" mcp-publisher
           ./mcp-publisher --help > /dev/null
 
       - name: Validate server.json against the registry's own schema
@@ -149,12 +170,25 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           NAME: ${{ steps.version.outputs.name }}
         # The publish call reporting success is not the same as the listing
-        # existing — read it back the way a user's client would.
+        # existing — read it back the way a user's client would. Polled, like
+        # publish-mcp.yml's provenance read-back: this has never run, so how
+        # quickly the registry serves a just-published version is unknown, and
+        # a single 404 here would fail a release that actually landed. Re-runs
+        # do not help once the publish has succeeded (the registry rejects a
+        # version it already holds), so the retry has to be in-line.
         run: |
           set -euo pipefail
           ENCODED=${NAME/\//%2F}
-          curl -fsS "https://registry.modelcontextprotocol.io/v0/servers/$ENCODED/versions/$VERSION" > /dev/null
-          echo "$NAME@$VERSION is live at registry.modelcontextprotocol.io"
+          for attempt in 1 2 3; do
+            if curl -fsS "https://registry.modelcontextprotocol.io/v0/servers/$ENCODED/versions/$VERSION" > /dev/null; then
+              echo "$NAME@$VERSION is live at registry.modelcontextprotocol.io"
+              exit 0
+            fi
+            echo "not readable yet (attempt $attempt) — waiting 10s"
+            sleep 10
+          done
+          echo "::error::$NAME@$VERSION is not readable at registry.modelcontextprotocol.io, but the publish reported success. Re-running this job will fail on the duplicate version — check the listing by hand."
+          exit 1
 
       - name: Summary (nothing published)
         if: github.event_name != 'workflow_dispatch' || inputs.dry_run == true || github.repository != 'serac-labs/serac'

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,164 @@
+name: Publish to MCP Registry
+
+# Lists @serac-labs/servicenow-mcp in the official MCP registry
+# (registry.modelcontextprotocol.io) by uploading the repo-root server.json.
+# The registry stores metadata only — the artifact stays on npm, published by
+# publish-mcp.yml.
+#
+# WHY THIS IS A SECOND FILE AND NOT A STEP IN publish-mcp.yml
+#   1. npm binds a Trusted Publisher to owner + repo + workflow FILENAME, so
+#      publish-mcp.yml cannot be renamed and every edit to it risks the one
+#      credential path that has no fallback. Nothing here needs to touch it.
+#   2. Ordering forces the split anyway. The registry validates the npm package
+#      before it will accept the server: it fetches
+#      registry.npmjs.org/@serac-labs/servicenow-mcp/<version> and demands an
+#      `mcpName` there equal to the server name. The version must therefore
+#      already be live on npm when this runs, which a step appended to the npm
+#      publish cannot guarantee — it would race npm's own propagation.
+#   3. A workflow_run chain off publish-mcp.yml would fire on its dry runs and
+#      on forks too, and would publish under whoever happened to dispatch the
+#      npm release. Two dispatches in order — npm first, registry second — keep
+#      each release attributable and independently re-runnable.
+#
+#   The cost of the split is honest: releasing is now two dispatches instead of
+#   one, and a maintainer can forget the second. The pre-flight below makes the
+#   forgotten-first-half case loud; nothing detects the forgotten second half
+#   except the registry listing being a version behind, which is a stale
+#   listing rather than a broken install.
+#
+# TRIGGER: workflow_dispatch to publish. pull_request runs the drift gate only,
+# on the PRs that can introduce drift, so a server.json that disagrees with the
+# package manifest is caught on the PR instead of at release time.
+#
+# AUTH: GitHub OIDC, no secret. The registry grants io.github.<repository
+# owner>/* straight from the OIDC claim, which is why the server is named
+# io.github.serac-labs/servicenow-mcp. The alternative — a PAT in a secret —
+# would be a long-lived credential able to overwrite EVERY server under
+# io.github.serac-labs/*, reachable by anyone who can cause a job to run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Gate and validate, but stop before publishing to the registry"
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - "server.json"
+      - "packages/servicenow-mcp/package.json"
+      - "packages/servicenow-mcp/script/check-registry-manifest.ts"
+      - ".github/workflows/publish-mcp-registry.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Same reasoning as publish-mcp.yml: a publish is not idempotent (the
+  # registry rejects a version it already holds), so a live release must never
+  # be cancelled from under itself. PR verification is disposable.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: gate and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC token for `mcp-publisher login github-oidc`
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      # Runs on both paths. server.json repeats the version, the package name
+      # and the server name from packages/servicenow-mcp/package.json, and all
+      # of it is hand-maintained — see the script's header for what each
+      # mismatch costs.
+      - name: Gate — server.json agrees with the package manifest
+        run: bun run --cwd packages/servicenow-mcp check:registry-manifest
+
+      - name: Read version from packages/servicenow-mcp/package.json
+        id: version
+        # The same single version source publish-mcp.yml uses. The gate above
+        # has already proven server.json carries this exact value, so reading
+        # it from the package manifest here is not a third opinion.
+        run: |
+          set -euo pipefail
+          echo "version=$(node -p "require('./packages/servicenow-mcp/package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "name=$(node -p "require('./packages/servicenow-mcp/package.json').mcpName")" >> "$GITHUB_OUTPUT"
+
+      - name: Install mcp-publisher
+        # Deliberately `latest` rather than pinned: the registry rejects tokens
+        # minted by an out-of-date CLI with "invalid audience", so a pin here
+        # would break the release the next time the audience contract moves.
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --help > /dev/null
+
+      - name: Validate server.json against the registry's own schema
+        # Exhaustive server-side validation, no authentication involved. It
+        # reports every issue at once with JSON paths, and catches what the
+        # local gate cannot — field lengths, enum values, transport shapes.
+        run: ./mcp-publisher validate server.json
+
+      # Only on the publish path: between releases the npm version in the
+      # manifest is legitimately not on npm yet, and failing PRs for that would
+      # be noise.
+      - name: Pre-flight — the version is on npm and carries mcpName
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NAME: ${{ steps.version.outputs.name }}
+        # Exactly the check the registry runs before it accepts the server, run
+        # first so the failure names the cause. Without it, dispatching this
+        # before the npm release fails inside the registry with a bare
+        # "Registry validation failed for package".
+        run: |
+          set -euo pipefail
+          META=$(curl -fsS "https://registry.npmjs.org/@serac-labs/servicenow-mcp/$VERSION" 2>/dev/null || true)
+          if [ -z "$META" ]; then
+            echo "::error::@serac-labs/servicenow-mcp@$VERSION is not on npm. Dispatch publish-mcp.yml first — the registry validates the package before it will accept the server."
+            exit 1
+          fi
+          PUBLISHED_MCP_NAME=$(printf '%s' "$META" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).mcpName ?? ''")
+          if [ "$PUBLISHED_MCP_NAME" != "$NAME" ]; then
+            echo "::error::the published @serac-labs/servicenow-mcp@$VERSION declares mcpName '$PUBLISHED_MCP_NAME', not '$NAME'. Ownership verification will fail, and an npm version is immutable — this version can never be registered. Ship the corrected manifest in the next npm release and register that one."
+            exit 1
+          fi
+          echo "@serac-labs/servicenow-mcp@$VERSION is on npm and declares mcpName $NAME"
+
+      - name: Authenticate to the MCP Registry (OIDC)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run != true && github.repository == 'serac-labs/serac'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json to the MCP Registry
+        # No continue-on-error, for the reason spelled out in publish-mcp.yml:
+        # a publish that cannot happen must turn the run red.
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run != true && github.repository == 'serac-labs/serac'
+        run: ./mcp-publisher publish server.json
+
+      - name: Verify the registry serves the version
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run != true && github.repository == 'serac-labs/serac'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NAME: ${{ steps.version.outputs.name }}
+        # The publish call reporting success is not the same as the listing
+        # existing — read it back the way a user's client would.
+        run: |
+          set -euo pipefail
+          ENCODED=${NAME/\//%2F}
+          curl -fsS "https://registry.modelcontextprotocol.io/v0/servers/$ENCODED/versions/$VERSION" > /dev/null
+          echo "$NAME@$VERSION is live at registry.modelcontextprotocol.io"
+
+      - name: Summary (nothing published)
+        if: github.event_name != 'workflow_dispatch' || inputs.dry_run == true || github.repository != 'serac-labs/serac'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NAME: ${{ steps.version.outputs.name }}
+        run: echo "$NAME@$VERSION gated and validated. Not published (pull request, dry run, or fork)."

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -36,6 +36,11 @@ name: Publish to MCP Registry
 # io.github.serac-labs/servicenow-mcp. The alternative — a PAT in a secret —
 # would be a long-lived credential able to overwrite EVERY server under
 # io.github.serac-labs/*, reachable by anyone who can cause a job to run.
+#
+# A build.serac/* namespace is the other option, and it is not free: the
+# registry would want the domain proved with a DNS TXT record, and the server
+# re-registered under the new name. io.github.<owner>/* needs no setup at all,
+# which is why it is where this starts.
 
 on:
   workflow_dispatch:
@@ -109,6 +114,13 @@ jobs:
         # unverified binary here is the one thing in this file that could
         # publish as us. `gh attestation verify` does not work on these assets:
         # they carry sigstore signature bundles, not SLSA provenance.
+        #
+        # Do not reach for npm to get this locally. The CLI ships only as a Go
+        # binary from modelcontextprotocol/registry releases and via Homebrew;
+        # `@modelcontextprotocol/publisher` does not exist, and the bare name
+        # `mcp-publisher` on npm belongs to an unrelated browser-automation
+        # package from a different maintainer — so `npm i -g mcp-publisher`
+        # installs the wrong tool without erroring.
         run: |
           set -euo pipefail
           ASSET="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ trusted publishing and signed provenance. Every PR that touches the package runs
 packaging gates without publishing, including one that copies the package out of the workspace entirely and
 proves it installs, builds and tests with no monorepo around it.
 
+The [MCP registry](https://registry.modelcontextprotocol.io) listing is a second, separate dispatch:
+`.github/workflows/publish-mcp-registry.yml` uploads the repo-root `server.json` once the npm version is
+live. `server.json` repeats that version and the package name, so a gate on every PR touching either file
+fails when the two disagree — `bun run --cwd packages/servicenow-mcp check:registry-manifest`.
+
 `@serac-labs/skills` is not on npm today. It is consumed from a checkout.
 
 ## What used to be here

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -35,6 +35,7 @@
     "./cli/enterprise-docs-generator": "./src/cli/enterprise-docs-generator.ts"
   },
   "bin": {
+    "servicenow-mcp": "./src/servicenow-mcp-unified/index.ts",
     "servicenow-mcp-stdio": "./src/servicenow-mcp-unified/index.ts",
     "servicenow-mcp-enterprise-proxy": "./src/enterprise-proxy/index.ts"
   },

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@serac-labs/servicenow-mcp",
   "version": "0.2.1",
+  "mcpName": "io.github.serac-labs/servicenow-mcp",
   "description": "Unified ServiceNow MCP server (437 snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
   "repository": {
@@ -44,6 +45,7 @@
     "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "generate:tools-json": "bun script/generate-tools-json.ts",
     "generate:tools-json:check": "bun script/generate-tools-json.ts --check",
+    "check:registry-manifest": "bun script/check-registry-manifest.ts",
     "probe:sn-roles": "bun script/probe-sn-roles/index.ts"
   },
   "dependencies": {

--- a/packages/servicenow-mcp/script/__tests__/check-registry-manifest.test.ts
+++ b/packages/servicenow-mcp/script/__tests__/check-registry-manifest.test.ts
@@ -41,6 +41,12 @@ const PACKAGE = {
   name: "@serac-labs/servicenow-mcp",
   version: "0.2.1",
   mcpName: "io.github.serac-labs/servicenow-mcp",
+  repository: { type: "git", url: "git+https://github.com/serac-labs/serac.git" },
+  bin: {
+    "servicenow-mcp": "./src/servicenow-mcp-unified/index.ts",
+    "servicenow-mcp-stdio": "./src/servicenow-mcp-unified/index.ts",
+    "servicenow-mcp-enterprise-proxy": "./src/enterprise-proxy/index.ts",
+  },
 }
 
 const fixture = async (server: unknown, pkg: unknown) => {
@@ -95,6 +101,53 @@ describe("server.json / package.json drift", () => {
 
     expect(problems).toHaveLength(1)
     expect(problems[0]).toContain("io.github.serac-labs/")
+  })
+
+  // The failure this repo actually shipped into: the package had only
+  // servicenow-mcp-stdio and servicenow-mcp-enterprise-proxy, so `npx -y
+  // @serac-labs/servicenow-mcp@0.2.1` — the command a registry entry with no
+  // runtimeArguments means — died with "could not determine executable to run"
+  // while every other check here stayed green.
+  test("bins npx cannot choose between are reported", async () => {
+    const problems = await registryManifestProblems(
+      await fixture(SERVER, {
+        ...PACKAGE,
+        bin: {
+          "servicenow-mcp-stdio": "./src/servicenow-mcp-unified/index.ts",
+          "servicenow-mcp-enterprise-proxy": "./src/enterprise-proxy/index.ts",
+        },
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain(`npx -y @serac-labs/servicenow-mcp@0.2.1`)
+  })
+
+  // npm's other resolution path: several names for one file is unambiguous, so
+  // the checker must not demand a bin named after the package in that case.
+  test("bins that all point at one file resolve without a name match", async () => {
+    const aliases = { stdio: "./src/index.ts", "servicenow-mcp-stdio": "./src/index.ts" }
+
+    expect(await registryManifestProblems(await fixture(SERVER, { ...PACKAGE, bin: aliases }))).toEqual([])
+  })
+
+  // A client told to run something other than the bare package is not subject
+  // to npm's guess, so the bin shape stops being this checker's business.
+  test("an entry with runtimeArguments is not held to npx bin resolution", async () => {
+    const explicit = {
+      ...SERVER,
+      packages: [
+        {
+          ...SERVER.packages[0],
+          runtimeHint: "npx",
+          runtimeArguments: [{ type: "positional", valueHint: "bin", value: "servicenow-mcp-stdio" }],
+        },
+      ],
+    }
+
+    expect(
+      await registryManifestProblems(await fixture(explicit, { ...PACKAGE, bin: { a: "./a.ts", b: "./b.ts" } })),
+    ).toEqual([])
   })
 
   test("a missing server.json fails rather than reporting a clean run", async () => {

--- a/packages/servicenow-mcp/script/__tests__/check-registry-manifest.test.ts
+++ b/packages/servicenow-mcp/script/__tests__/check-registry-manifest.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Drives the real `registryManifestProblems` against real files on disk, one
+ * fixture repo per failure mode.
+ *
+ * It deliberately does NOT assert against the checkout's own `server.json`:
+ * `publish-mcp.yml` copies this package out of the workspace and runs `bun
+ * test` there with no repo root above it, so a test reading `../../..` would
+ * fail that release gate for a file that is legitimately absent. The real
+ * files are checked by `bun run --cwd packages/servicenow-mcp
+ * check:registry-manifest`, which `publish-mcp-registry.yml` runs on every PR.
+ * What is proven here is that the checker actually reports the drift it is
+ * there to catch — including that a deleted `server.json` is a failure and not
+ * a clean run.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import { mkdir, mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { registryManifestProblems } from "../check-registry-manifest.js"
+
+// A repo where the two manifests agree. Every test below breaks exactly one
+// thing about it, so the reported problem can only come from that break.
+const SERVER = {
+  $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  name: "io.github.serac-labs/servicenow-mcp",
+  description: "400+ ServiceNow tools",
+  version: "0.2.1",
+  repository: { url: "https://github.com/serac-labs/serac", source: "github" },
+  packages: [
+    {
+      registryType: "npm",
+      identifier: "@serac-labs/servicenow-mcp",
+      version: "0.2.1",
+      transport: { type: "stdio" },
+    },
+  ],
+}
+
+const PACKAGE = {
+  name: "@serac-labs/servicenow-mcp",
+  version: "0.2.1",
+  mcpName: "io.github.serac-labs/servicenow-mcp",
+}
+
+const fixture = async (server: unknown, pkg: unknown) => {
+  const root = await mkdtemp(join(tmpdir(), "registry-manifest-"))
+  await mkdir(join(root, "packages", "servicenow-mcp"), { recursive: true })
+  await Bun.write(join(root, "server.json"), JSON.stringify(server, null, 2))
+  await Bun.write(join(root, "packages", "servicenow-mcp", "package.json"), JSON.stringify(pkg, null, 2))
+  return root
+}
+
+describe("server.json / package.json drift", () => {
+  test("agreeing manifests report nothing", async () => {
+    expect(await registryManifestProblems(await fixture(SERVER, PACKAGE))).toEqual([])
+  })
+
+  test("a version bump server.json did not follow is reported, in both places it is written down", async () => {
+    const problems = await registryManifestProblems(await fixture(SERVER, { ...PACKAGE, version: "0.3.0" }))
+
+    expect(problems).toHaveLength(2)
+    expect(problems[0]).toContain(`server.json says "0.2.1", package.json says "0.3.0"`)
+    expect(problems[1]).toContain(`pinned to "0.2.1", package.json says "0.3.0"`)
+  })
+
+  test("a package entry left on the old version is reported even when the server version was bumped", async () => {
+    const stale = { ...SERVER, version: "0.3.0", packages: [{ ...SERVER.packages[0], version: "0.2.1" }] }
+    const problems = await registryManifestProblems(await fixture(stale, { ...PACKAGE, version: "0.3.0" }))
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain(`pinned to "0.2.1"`)
+  })
+
+  // The registry reads mcpName off the npm manifest to prove the publisher owns
+  // the package, so this pair disagreeing is a rejected publish, not a warning.
+  test("an mcpName that no longer matches the server name is reported", async () => {
+    const problems = await registryManifestProblems(
+      await fixture(SERVER, { ...PACKAGE, mcpName: "io.github.serac-labs/serac" }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain("mcpName")
+  })
+
+  // `mcp-publisher validate` accepts this — the schema only requires one slash
+  // — so nothing before the publish attempt would catch it.
+  test("a server name outside the repository owner's namespace is reported", async () => {
+    const problems = await registryManifestProblems(
+      await fixture(
+        { ...SERVER, name: "build.serac/servicenow-mcp" },
+        { ...PACKAGE, mcpName: "build.serac/servicenow-mcp" },
+      ),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain("io.github.serac-labs/")
+  })
+
+  test("a missing server.json fails rather than reporting a clean run", async () => {
+    const problems = await registryManifestProblems(join(tmpdir(), "registry-manifest-does-not-exist"))
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain("server.json is missing")
+  })
+})

--- a/packages/servicenow-mcp/script/check-registry-manifest.ts
+++ b/packages/servicenow-mcp/script/check-registry-manifest.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Gate the repo-root `server.json` — the manifest the official MCP registry
+ * stores — against this package's `package.json`.
+ *
+ * Four values are written down in both files, and every one of them is
+ * hand-maintained:
+ *
+ *   - the VERSION. `publish-mcp.yml` takes the version it publishes from this
+ *     package's manifest and from nothing else, deliberately: a second version
+ *     string that can disagree is the coupling that once made this package
+ *     inherit opencode's version number. `server.json` is exactly such a
+ *     second string, so it is checked rather than trusted.
+ *   - `mcpName`. The registry fetches
+ *     registry.npmjs.org/<identifier>/<version> and refuses the publish unless
+ *     the manifest it finds there carries an `mcpName` equal to the server
+ *     name — that is how it proves the publisher owns the npm package. A
+ *     mismatch is not a warning, it is a rejected release.
+ *   - the npm package NAME, repeated as `packages[].identifier`.
+ *   - the NAMESPACE. GitHub OIDC grants `io.github.<repository owner>/*` and
+ *     nothing else, so a server name outside the owner in `repository.url`
+ *     cannot be published from this repo's Actions at all. `mcp-publisher
+ *     validate` does NOT catch this — a bare `serac-labs/servicenow-mcp`
+ *     satisfies the schema pattern and fails only at publish time.
+ *
+ * Run:
+ *   bun run --cwd packages/servicenow-mcp check:registry-manifest
+ *
+ * `.github/workflows/publish-mcp-registry.yml` runs it on every PR and again
+ * before it uploads anything, so drift is caught here rather than published.
+ */
+
+import { join } from "node:path"
+
+export const registryManifestProblems = async (repoRoot: string): Promise<string[]> => {
+  const serverPath = join(repoRoot, "server.json")
+  const packagePath = join(repoRoot, "packages", "servicenow-mcp", "package.json")
+
+  const server: ServerManifest | undefined = await Bun.file(serverPath)
+    .json()
+    .catch(() => undefined)
+  if (!server) return [`${serverPath} is missing or is not valid JSON`]
+
+  const pkg: PackageManifest | undefined = await Bun.file(packagePath)
+    .json()
+    .catch(() => undefined)
+  if (!pkg) return [`${packagePath} is missing or is not valid JSON`]
+
+  // The owner segment of the repository URL is what the OIDC token's
+  // `repository_owner` claim will say, which is what the registry turns into a
+  // namespace grant.
+  const owner = server.repository?.url?.split("github.com/")[1]?.split("/")[0]
+  const npm = server.packages?.filter((entry) => entry.registryType === "npm") ?? []
+
+  return [
+    server.version === pkg.version
+      ? undefined
+      : `version: server.json says "${server.version}", package.json says "${pkg.version}". The package manifest is the only version source — bring server.json to it.`,
+    pkg.mcpName === server.name
+      ? undefined
+      : `ownership: package.json mcpName "${pkg.mcpName}" is not server.json name "${server.name}". The registry reads mcpName off the published npm manifest and rejects the publish when they differ.`,
+    owner && server.name?.startsWith(`io.github.${owner}/`)
+      ? undefined
+      : `namespace: server.json name "${server.name}" is not under "io.github.${owner}/", the owner in repository.url "${server.repository?.url}". GitHub OIDC grants that namespace and no other.`,
+    npm.length > 0
+      ? undefined
+      : `packages: server.json declares no npm package, so the registry listing would have no install path.`,
+    ...npm.flatMap((entry) => [
+      entry.identifier === pkg.name
+        ? undefined
+        : `packages: identifier "${entry.identifier}" is not the published package name "${pkg.name}".`,
+      entry.version === pkg.version
+        ? undefined
+        : `packages: "${entry.identifier}" is pinned to "${entry.version}", package.json says "${pkg.version}". The registry validates that exact version on npm.`,
+    ]),
+  ].filter((problem): problem is string => problem !== undefined)
+}
+
+type ServerManifest = {
+  name?: string
+  version?: string
+  repository?: { url?: string }
+  packages?: { registryType?: string; identifier?: string; version?: string }[]
+}
+
+type PackageManifest = { name?: string; version?: string; mcpName?: string }
+
+if (import.meta.main) {
+  // script/ -> packages/servicenow-mcp/ -> packages/ -> repo root.
+  const problems = await registryManifestProblems(join(import.meta.dir, "..", "..", ".."))
+
+  if (problems.length === 0) {
+    console.log("server.json agrees with packages/servicenow-mcp/package.json")
+    process.exit(0)
+  }
+
+  console.error(`server.json disagrees with packages/servicenow-mcp/package.json:`)
+  console.error(problems.map((problem) => `  - ${problem}`).join("\n"))
+  process.exit(1)
+}

--- a/packages/servicenow-mcp/script/check-registry-manifest.ts
+++ b/packages/servicenow-mcp/script/check-registry-manifest.ts
@@ -18,10 +18,17 @@
  *     mismatch is not a warning, it is a rejected release.
  *   - the npm package NAME, repeated as `packages[].identifier`.
  *   - the NAMESPACE. GitHub OIDC grants `io.github.<repository owner>/*` and
- *     nothing else, so a server name outside the owner in `repository.url`
+ *     nothing else, so a server name outside this package's repository owner
  *     cannot be published from this repo's Actions at all. `mcp-publisher
  *     validate` does NOT catch this — a bare `serac-labs/servicenow-mcp`
  *     satisfies the schema pattern and fails only at publish time.
+ *
+ * And one thing that is not written down twice but is just as easy to break:
+ * an npm entry with no `runtimeArguments` says "run `npx -y <identifier>@<v>`",
+ * and npx can only resolve that when `bin` names the unscoped package or every
+ * bin points at one file. Two differently-named bins and npx refuses with
+ * "could not determine executable to run" — a listing that publishes, reads
+ * back green, and cannot start. Renaming a bin is enough to cause it.
  *
  * Run:
  *   bun run --cwd packages/servicenow-mcp check:registry-manifest
@@ -46,11 +53,20 @@ export const registryManifestProblems = async (repoRoot: string): Promise<string
     .catch(() => undefined)
   if (!pkg) return [`${packagePath} is missing or is not valid JSON`]
 
-  // The owner segment of the repository URL is what the OIDC token's
-  // `repository_owner` claim will say, which is what the registry turns into a
-  // namespace grant.
-  const owner = server.repository?.url?.split("github.com/")[1]?.split("/")[0]
+  // Read the owner from the PACKAGE manifest, not from server.json's own
+  // repository.url: npm's trusted publisher binds the published package to
+  // this repository, so this URL cannot quietly name someone else, whereas a
+  // server.json that renamed itself and its own repository.url together would
+  // agree with itself all the way to the publish attempt.
+  const owner = pkg.repository?.url?.split("github.com/")[1]?.split("/")[0]
   const npm = server.packages?.filter((entry) => entry.registryType === "npm") ?? []
+
+  // npm's rule, from libnpmexec/lib/get-bin-from-manifest.js: it runs the one
+  // bin when every bin points at the same file, otherwise the bin named after
+  // the unscoped package, otherwise it refuses to guess.
+  const bin = pkg.bin ?? {}
+  const unscoped = pkg.name?.split("/").at(-1) ?? ""
+  const npxResolves = new Set(Object.values(bin)).size === 1 || bin[unscoped] !== undefined
 
   return [
     server.version === pkg.version
@@ -61,7 +77,7 @@ export const registryManifestProblems = async (repoRoot: string): Promise<string
       : `ownership: package.json mcpName "${pkg.mcpName}" is not server.json name "${server.name}". The registry reads mcpName off the published npm manifest and rejects the publish when they differ.`,
     owner && server.name?.startsWith(`io.github.${owner}/`)
       ? undefined
-      : `namespace: server.json name "${server.name}" is not under "io.github.${owner}/", the owner in repository.url "${server.repository?.url}". GitHub OIDC grants that namespace and no other.`,
+      : `namespace: server.json name "${server.name}" is not under "io.github.${owner}/", the owner in package.json repository.url "${pkg.repository?.url}". GitHub OIDC grants that namespace and no other.`,
     npm.length > 0
       ? undefined
       : `packages: server.json declares no npm package, so the registry listing would have no install path.`,
@@ -72,6 +88,9 @@ export const registryManifestProblems = async (repoRoot: string): Promise<string
       entry.version === pkg.version
         ? undefined
         : `packages: "${entry.identifier}" is pinned to "${entry.version}", package.json says "${pkg.version}". The registry validates that exact version on npm.`,
+      entry.runtimeArguments || npxResolves
+        ? undefined
+        : `packages: "npx -y ${entry.identifier}@${entry.version}" — the command an npm entry without runtimeArguments asks a client to run — cannot pick a binary out of bins ${Object.keys(bin).join(", ")}. npm needs one named "${unscoped}", or every bin on one file.`,
     ]),
   ].filter((problem): problem is string => problem !== undefined)
 }
@@ -79,11 +98,16 @@ export const registryManifestProblems = async (repoRoot: string): Promise<string
 type ServerManifest = {
   name?: string
   version?: string
-  repository?: { url?: string }
-  packages?: { registryType?: string; identifier?: string; version?: string }[]
+  packages?: { registryType?: string; identifier?: string; version?: string; runtimeArguments?: unknown[] }[]
 }
 
-type PackageManifest = { name?: string; version?: string; mcpName?: string }
+type PackageManifest = {
+  name?: string
+  version?: string
+  mcpName?: string
+  repository?: { url?: string }
+  bin?: Record<string, string>
+}
 
 if (import.meta.main) {
   // script/ -> packages/servicenow-mcp/ -> packages/ -> repo root.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.serac-labs/servicenow-mcp",
+  "title": "Serac ServiceNow",
+  "description": "400+ ServiceNow tools over stdio or streamable HTTP, plus blast-radius impact analysis",
+  "version": "0.2.1",
+  "websiteUrl": "https://docs.serac.build",
+  "repository": {
+    "url": "https://github.com/serac-labs/serac",
+    "source": "github",
+    "id": "1020628118",
+    "subfolder": "packages/servicenow-mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@serac-labs/servicenow-mcp",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SNOW_INSTANCE",
+          "description": "ServiceNow instance, e.g. dev12345.service-now.com. SERVICENOW_INSTANCE_URL is also read.",
+          "format": "string",
+          "isRequired": true,
+          "placeholder": "dev12345.service-now.com"
+        },
+        {
+          "name": "SNOW_CLIENT_ID",
+          "description": "Client ID of an OAuth entry under System OAuth > Application Registry on the instance.",
+          "format": "string",
+          "isRequired": true
+        },
+        {
+          "name": "SNOW_CLIENT_SECRET",
+          "description": "Client secret of that same OAuth application registry entry.",
+          "format": "string",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "SNOW_LAZY_TOOLS",
+          "description": "false registers all tools up front. Default defers them behind tool_search/tool_execute.",
+          "format": "boolean",
+          "default": "true"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Issue for this PR

Closes #292

### Type of change

- [x] Bug fix
- [ ] New tool or skill
- [ ] Refactor / code improvement
- [ ] Documentation

(Mostly packaging metadata, which isn't one of the four — but it does carry a real bug fix, below.)

### What does this PR do?

Nothing of ours is listed at registry.modelcontextprotocol.io, so people searching it for ServiceNow never
find this server. This adds the repo-root `server.json` (schema `2025-12-11`), the `mcpName` in the package
manifest that the registry reads off npm to prove we own `@serac-labs/servicenow-mcp`, and a separate
workflow that uploads it. I did not touch `publish-mcp.yml` — npm binds its trusted publisher to that exact
filename, and the registry wants the npm version already live before it accepts the server. So a release is
now two dispatches: npm first, registry second.

`server.json` repeats the version and the package name, so `check:registry-manifest` fails when they drift,
and CI runs it on every PR touching either file.

Verifying that gate is how I found the listing would not have worked at all: `npx -y
@serac-labs/servicenow-mcp` cannot choose between `servicenow-mcp-stdio` and
`servicenow-mcp-enterprise-proxy`, which is the command a client derives from an npm entry. I added a
`servicenow-mcp` bin alias for the stdio entrypoint and taught the same check to catch a bin rename doing
this again.

One sequencing fact: 0.2.1 is already on npm without `mcpName`, and npm versions are immutable, so the
listing can only go live from the next release — bump, dispatch `publish-mcp.yml`, then dispatch
`publish-mcp-registry.yml`. The registry workflow's pre-flight says so out loud if you get the order wrong.

### How did you verify it works?

`mcp-publisher validate server.json` says valid; a deliberately 101-char description gets a 422 back, so it
is really checking. For the bin fix I packed the tarball from this branch, installed it, and ran `npm exec
@serac-labs/servicenow-mcp` — an MCP `initialize` handshake came back. With the alias removed, the same
command dies with `could not determine executable to run`.

`bun typecheck`, `bun run lint` (0 errors, the usual 1761 warnings), 261 MCP tests, 60 skills tests. I also
replicated `publish-mcp.yml`'s standalone package gate locally, since the new test lives in a package that
gate copies out of the workspace.

On this PR the new workflow ran green up to the publish: drift gate, `Verified OK` on the mcp-publisher
download, `server.json is valid`, nothing published. What is still untested is the OIDC login, the publish
itself and the read-back, since I dispatched nothing. Worth a first dispatch with `dry_run` on.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [ ] If I added or changed a tool, I re-ran `generate:tools-json` — no tools changed
- [ ] If I added or changed a skill, I re-ran the skills `generate` — no skills changed
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
