### PR TITLE
feat(mcp): diagnose credential setup instead of failing on the first tool call

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -311,6 +311,13 @@ jobs:
               ),
               ...Object.entries(pkg.bin ?? {}).map(([key, value]) => [`bin["${key}"]`, value]),
               ["files", "dist/index.js"],
+              // Not an entrypoint, but the roles check reads it from the
+              // package root at runtime. Dropped from "files" it does not
+              // fail anything — the report silently degrades to "manifest is
+              // not installed" for every npm user while every local test and
+              // CI job stays green. This tarball is the only place that can
+              // see it go missing.
+              ["files", "sn-roles.manifest.json"],
             ]
 
             const inTarball = (file) => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,8 @@ export SNOW_CLIENT_SECRET=…
 
 Developer instances hibernate after a few days of inactivity and then answer with an HTML login page instead
 of JSON, which makes failures look like parse errors. If a tool starts returning nonsense, wake the instance
-first.
+first — `bun packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts --doctor` says whether that is what
+happened, along with which credentials it picked up and from where.
 
 ### Adding a tool or a skill
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Credentials come from an OAuth application registry entry on your instance (`Sys
 Registry`). A developer instance from [developer.servicenow.com](https://developer.servicenow.com) is enough
 to try everything here.
 
+If nothing works — an auth error, or a response that will not parse — ask the server what is wrong before
+changing anything:
+
+```bash
+servicenow-mcp-stdio --doctor
+```
+
+It names which credential source was used, whether the URL is usable, whether the instance is awake (a
+hibernating developer instance answers with an HTML login page, which makes every tool look broken), whether
+the OAuth exchange succeeds, and which roles the account holds. The model can ask for the same report by
+calling `snow_diagnose_setup`.
+
 The catalog is far larger than a context window, so tools are **deferred** by default: `tools/list` returns
 two meta-tools and the model widens its own surface as it works.
 

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -1,6 +1,6 @@
 # @serac-labs/servicenow-mcp
 
-A [Model Context Protocol](https://modelcontextprotocol.io) server for ServiceNow: 437 `snow_*` tools over
+A [Model Context Protocol](https://modelcontextprotocol.io) server for ServiceNow: 400+ `snow_*` tools over
 stdio or streamable HTTP, plus blast-radius impact analysis. Part of [Serac](https://serac.build).
 
 ```bash
@@ -65,6 +65,10 @@ ServiceNow MCP — setup check
                       HTTP 200, text/html;charset=UTF-8
                       -> Sign in at https://developer.servicenow.com, open your instance and press Wake.
   skip  oauth token   Not reached — fix the checks above first.
+  skip  api access    Not reached — fix the checks above first.
+  skip  roles         Not reached — fix the checks above first.
+
+1 problem found. Fix the first FAIL above, then run this again.
 ```
 
 It walks the chain the server itself walks — environment variables, then `auth.json`, then the enterprise

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -42,6 +42,43 @@ tool_execute({tool: "snow_query_incidents", args: {query: "priority=1"}})
 
 Set `SNOW_LAZY_TOOLS=false` to register the whole catalog up front instead.
 
+## When it does not work
+
+Setting up OAuth on an instance you have never used is the part that goes wrong, and it goes wrong
+invisibly: the server starts without credentials, so the first symptom is an error inside an unrelated tool
+call. Ask for a diagnosis instead of guessing:
+
+```bash
+servicenow-mcp-stdio --doctor
+```
+
+```
+ServiceNow MCP — setup check
+
+  warn  credentials   Loaded from /Users/you/.serac/auth.json (modified 2026-01-04).
+                      instance https://dev11111.service-now.com
+                      client id …ab12, client secret set
+                      environment: SNOW_CLIENT_ID, SNOW_CLIENT_SECRET set, but the environment link needs
+                      instance + client id + client secret together, so it was skipped
+  ok    instance url  https://dev11111.service-now.com
+  FAIL  instance      The instance is hibernating.
+                      HTTP 200, text/html;charset=UTF-8
+                      -> Sign in at https://developer.servicenow.com, open your instance and press Wake.
+  skip  oauth token   Not reached — fix the checks above first.
+```
+
+It walks the chain the server itself walks — environment variables, then `auth.json`, then the enterprise
+portal — and reports which link supplied what, so a forgotten `auth.json` cannot quietly outrank the
+variables you just set. Then it checks the URL, the instance (hibernating instances answer with an HTML
+login page, which makes every tool look like it has a parse bug), the OAuth token exchange (a rejected
+client id is reported separately from a rejected grant, quoting what ServiceNow returned), the API call, and
+finally how much of the catalog the authenticated account's roles actually cover, from
+`sn-roles.manifest.json`.
+
+It exits non-zero when something is wrong, prints nothing to stdout on the server path, and never prints a
+secret. `snow_diagnose_setup` returns the same report to the model — useful when the MCP client hides the
+server's stderr, which most of them do. That tool is stdio-only: the report describes the local process.
+
 ## Use it as a library
 
 ESM only. The package exports named subpaths rather than one barrel, so importing blast-radius does not

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@serac-labs/servicenow-mcp",
   "version": "0.2.1",
-  "description": "Unified ServiceNow MCP server (437 snow_* tools), blast-radius analysis, stdio + HTTP transports.",
+  "description": "Unified ServiceNow MCP server (400+ snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -16,7 +16,8 @@
   "private": false,
   "files": [
     "dist",
-    "src/agent-fragments"
+    "src/agent-fragments",
+    "sn-roles.manifest.json"
   ],
   "exports": {
     ".": "./src/index.ts",

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
@@ -8,17 +8,22 @@
  * Usage:
  *   node dist/mcp/servicenow-mcp-unified/index.js
  *
+ * Flags:
+ *   --doctor - diagnose the credential setup and exit, without starting the server
+ *
  * Environment Variables:
- *   SERVICENOW_INSTANCE_URL - ServiceNow instance URL
- *   SERVICENOW_CLIENT_ID - OAuth client ID
- *   SERVICENOW_CLIENT_SECRET - OAuth client secret
+ *   SNOW_INSTANCE_URL / SERVICENOW_INSTANCE_URL - ServiceNow instance URL
+ *   SNOW_CLIENT_ID / SERVICENOW_CLIENT_ID - OAuth client ID
+ *   SNOW_CLIENT_SECRET / SERVICENOW_CLIENT_SECRET - OAuth client secret
  *   SERVICENOW_REFRESH_TOKEN - OAuth refresh token (optional, will be cached)
+ *   The full list, per credential field, is ENV_VARS in shared/context-loader.ts.
  */
 
 import { startStdio } from "./transports/stdio.js"
 import * as dotenv from "dotenv"
 import * as path from "path"
 import { mcpDebug } from "../shared/mcp-debug.js"
+import { ENV_VARS } from "./shared/context-loader.js"
 // Anonymous, content-free usage telemetry. This import lives in the stdio
 // entry point and nowhere else: the HTTP transport must never emit, because
 // it is the platform's multi-tenant server and its "sessions" are our own
@@ -33,16 +38,13 @@ async function main() {
   try {
     // 🆕 Preserve MCP client env vars before loading .env
     // MCP clients (like Claude Code) set env vars from mcp.json which should take priority
-    const mcpEnvVars = {
-      SNOW_LAZY_TOOLS: process.env.SNOW_LAZY_TOOLS,
-      SNOW_TOOL_DOMAINS: process.env.SNOW_TOOL_DOMAINS,
-      SNOW_INSTANCE: process.env.SNOW_INSTANCE,
-      SERVICENOW_INSTANCE_URL: process.env.SERVICENOW_INSTANCE_URL,
-      SNOW_CLIENT_ID: process.env.SNOW_CLIENT_ID,
-      SERVICENOW_CLIENT_ID: process.env.SERVICENOW_CLIENT_ID,
-      SNOW_CLIENT_SECRET: process.env.SNOW_CLIENT_SECRET,
-      SERVICENOW_CLIENT_SECRET: process.env.SERVICENOW_CLIENT_SECRET,
-    }
+    //
+    // Built from ENV_VARS rather than listed by hand: this list used to name
+    // eight variables and the loader read a different set, so a documented
+    // variable could be missing from both without anything noticing.
+    const mcpEnvVars = Object.fromEntries(
+      [...Object.values(ENV_VARS).flat(), "SNOW_LAZY_TOOLS", "SNOW_TOOL_DOMAINS"].map((name) => [name, process.env[name]]),
+    )
 
     // Load environment variables from .env file
     // Note: dotenv should NOT override existing vars, but we preserve them anyway for safety
@@ -78,6 +80,19 @@ async function main() {
         }
         process.env[key] = value
       }
+    }
+
+    // --doctor: diagnose the credential setup and exit. It runs here, after
+    // .env is loaded and the MCP overrides are restored, so it reports the
+    // credentials the server would actually have used — and before the
+    // transport, so no JSON-RPC session is ever opened. That is what makes it
+    // safe to print the report on stdout: this process will not speak the
+    // protocol. Never write anything but JSON to stdout on the server path.
+    if (process.argv.slice(2).includes("--doctor")) {
+      const { runSetupDoctor, renderReport } = await import("./shared/setup-doctor.js")
+      const report = await runSetupDoctor()
+      console.log(renderReport(report))
+      process.exit(report.ok ? 0 : 1)
     }
 
     // Log active configuration mode

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/index.ts
@@ -43,7 +43,7 @@ async function main() {
     // eight variables and the loader read a different set, so a documented
     // variable could be missing from both without anything noticing.
     const mcpEnvVars = Object.fromEntries(
-      [...Object.values(ENV_VARS).flat(), "SNOW_LAZY_TOOLS", "SNOW_TOOL_DOMAINS"].map((name) => [name, process.env[name]]),
+      [...Object.values(ENV_VARS).flat(), "SNOW_LAZY_TOOLS", "SNOW_TOOL_DOMAINS"].map((v) => [v, process.env[v]]),
     )
 
     // Load environment variables from .env file

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/context-loader.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/context-loader.test.ts
@@ -70,7 +70,10 @@ describe("environment credentials", () => {
     process.env.SNOW_INSTANCE_URL = "https://second.service-now.com"
     process.env.SERVICENOW_INSTANCE_URL = "https://first.service-now.com"
 
-    expect(envCredential("instanceUrl")).toEqual({ name: "SERVICENOW_INSTANCE_URL", value: "https://first.service-now.com" })
+    expect(envCredential("instanceUrl")).toEqual({
+      name: "SERVICENOW_INSTANCE_URL",
+      value: "https://first.service-now.com",
+    })
   })
 
   test("a whitespace-only variable counts as unset", () => {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/context-loader.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/context-loader.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Credential loading from the environment.
+ *
+ * The regression that motivated this file: `SNOW_INSTANCE_URL` is the variable
+ * the README quick start, the package README, CONTRIBUTING and SECURITY all
+ * tell people to set, and `loadContext()` read every name except that one. The
+ * result was silent — the server starts fine without credentials — so the first
+ * symptom was an auth error inside an unrelated tool call, hours later.
+ *
+ * Nothing is mocked: the real loader is called against a real (temporarily
+ * emptied) process environment.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals"
+
+import { ENV_VARS, envCredential, authJsonPaths, loadContext } from "../context-loader.js"
+
+const NAMES = Object.values(ENV_VARS).flat()
+
+const saved = new Map<string, string | undefined>()
+
+beforeEach(() => {
+  NAMES.forEach((name) => {
+    saved.set(name, process.env[name])
+    delete process.env[name]
+  })
+})
+
+afterEach(() => {
+  saved.forEach((value, name) => {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  })
+  saved.clear()
+})
+
+describe("environment credentials", () => {
+  test("the env block from the README quick start configures the server", () => {
+    // Copied from the "mcpServers" example in README.md. If this ever fails,
+    // the documented setup produces an unauthenticated server again.
+    process.env.SNOW_INSTANCE_URL = "https://dev12345.service-now.com"
+    process.env.SNOW_CLIENT_ID = "3b7f2c1e9a4d4f6b8c0e1a2b3c4d5e6f"
+    process.env.SNOW_CLIENT_SECRET = "not-a-real-secret"
+
+    const context = loadContext()
+
+    expect(context.instanceUrl).toBe("https://dev12345.service-now.com")
+    expect(context.clientId).toBe("3b7f2c1e9a4d4f6b8c0e1a2b3c4d5e6f")
+    expect(context.clientSecret).toBe("not-a-real-secret")
+  })
+
+  test.each(ENV_VARS.instanceUrl)("%s supplies the instance URL", (name) => {
+    process.env[name] = "https://dev12345.service-now.com"
+    process.env.SNOW_CLIENT_ID = "id"
+    process.env.SNOW_CLIENT_SECRET = "secret"
+
+    expect(loadContext().instanceUrl).toBe("https://dev12345.service-now.com")
+    expect(envCredential("instanceUrl")?.name).toBe(name)
+  })
+
+  test("a bare host gets a scheme, whichever variable it came from", () => {
+    process.env.SERVICENOW_INSTANCE_URL = "dev12345.service-now.com"
+    process.env.SNOW_CLIENT_ID = "id"
+    process.env.SNOW_CLIENT_SECRET = "secret"
+
+    expect(loadContext().instanceUrl).toBe("https://dev12345.service-now.com")
+  })
+
+  test("the first variable that is set wins, and reports its own name", () => {
+    process.env.SNOW_INSTANCE_URL = "https://second.service-now.com"
+    process.env.SERVICENOW_INSTANCE_URL = "https://first.service-now.com"
+
+    expect(envCredential("instanceUrl")).toEqual({ name: "SERVICENOW_INSTANCE_URL", value: "https://first.service-now.com" })
+  })
+
+  test("a whitespace-only variable counts as unset", () => {
+    process.env.SNOW_CLIENT_ID = "   "
+
+    expect(envCredential("clientId")).toBeUndefined()
+  })
+
+  test("half a credential set does not configure anything", () => {
+    // The environment link needs instance + id + secret together. Anything less
+    // falls through to auth.json, which is the moment a stale file takes over.
+    process.env.SNOW_INSTANCE_URL = "https://dev12345.service-now.com"
+    process.env.SNOW_CLIENT_ID = "id"
+
+    expect(loadContext().instanceUrl).not.toBe("https://dev12345.service-now.com")
+  })
+})
+
+describe("auth.json locations", () => {
+  test("the documented Serac path is among the ones the loader reads", () => {
+    const paths = authJsonPaths()
+
+    expect(paths.length).toBeGreaterThan(0)
+    expect(paths.some((path) => path.endsWith(`.serac/auth.json`))).toBe(true)
+    // Every path is absolute — the doctor prints these, and a relative path
+    // would be meaningless to whoever has to go and delete the stale file.
+    expect(paths.every((path) => path.startsWith("/") || /^[A-Za-z]:\\/.test(path))).toBe(true)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
@@ -50,7 +50,11 @@ const HIBERNATING_PAGE = `<!DOCTYPE html>
 const LOGIN_PAGE = `<!DOCTYPE html><html><head><title>Sign In | ServiceNow</title></head>
 <body><form action="/login.do" method="post"><input name="user_name"><input type="password" name="user_password"></form></body></html>`
 
-const observed = (status: number, body: string, contentType = "application/json"): Observed => ({ status, body, contentType })
+const observed = (status: number, body: string, contentType = "application/json"): Observed => ({
+  status,
+  body,
+  contentType,
+})
 
 const UNAUTHENTICATED = `{"error":{"message":"User Not Authenticated","detail":"Required to provide Auth information"},"status":"failure"}`
 const INSUFFICIENT_RIGHTS = `{"error":{"message":"Insufficient rights to query records","detail":"Field(s) present in the query do not have permission to be read"},"status":"failure"}`
@@ -78,7 +82,9 @@ describe("classifying what the instance answered", () => {
   test("HTML is detected by content when the content-type does not say so", () => {
     // Some fronting proxies answer text/plain. Sniffing the body is what keeps
     // the hibernation case from falling through to "unrecognisable response".
-    expect(classifyReachability({ status: 200, body: HIBERNATING_PAGE, contentType: undefined }).code).toBe("instance-hibernating")
+    expect(classifyReachability({ status: 200, body: HIBERNATING_PAGE, contentType: undefined }).code).toBe(
+      "instance-hibernating",
+    )
   })
 
   test("a 401 from the unauthenticated probe means the instance is awake", () => {
@@ -105,7 +111,9 @@ describe("classifying what the instance answered", () => {
   })
 
   test("a grant the OAuth entry does not allow is its own diagnosis", () => {
-    expect(classifyTokenResponse(observed(400, `{"error":"unsupported_grant_type"}`)).code).toBe("oauth-grant-not-allowed")
+    expect(classifyTokenResponse(observed(400, `{"error":"unsupported_grant_type"}`)).code).toBe(
+      "oauth-grant-not-allowed",
+    )
   })
 
   test("a token response is only ok when it carries a token", () => {
@@ -128,17 +136,27 @@ describe("classifying what the instance answered", () => {
   })
 
   test("a 200 identifies the account the OAuth entry is acting as", () => {
-    const check = classifyApiResponse(observed(200, `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}`))
+    const check = classifyApiResponse(
+      observed(200, `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}`),
+    )
 
     expect(check.status).toBe("ok")
     expect(check.title).toContain("integration.user")
   })
 
   test("unreachable is one finding with the reason named", () => {
-    expect(classifyTransportFailure({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND dev12345.service-now.com" }).code).toBe("instance-dns")
-    expect(classifyTransportFailure({ code: "ECONNREFUSED", message: "connect ECONNREFUSED 127.0.0.1:443" }).code).toBe("instance-refused")
-    expect(classifyTransportFailure({ code: "TimeoutError", message: "The operation was aborted due to timeout" }).code).toBe("instance-timeout")
-    expect(classifyTransportFailure({ code: "CERT_HAS_EXPIRED", message: "certificate has expired" }).code).toBe("instance-tls")
+    expect(
+      classifyTransportFailure({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND dev12345.service-now.com" }).code,
+    ).toBe("instance-dns")
+    expect(classifyTransportFailure({ code: "ECONNREFUSED", message: "connect ECONNREFUSED 127.0.0.1:443" }).code).toBe(
+      "instance-refused",
+    )
+    expect(
+      classifyTransportFailure({ code: "TimeoutError", message: "The operation was aborted due to timeout" }).code,
+    ).toBe("instance-timeout")
+    expect(classifyTransportFailure({ code: "CERT_HAS_EXPIRED", message: "certificate has expired" }).code).toBe(
+      "instance-tls",
+    )
   })
 })
 
@@ -167,8 +185,20 @@ describe("instance URL", () => {
     expect(inspectInstanceUrl("https://your-instance.service-now.com").baseUrl).toBeUndefined()
   })
 
+  test("a single-label host with a port is left alone — that is on-prem DNS, not a PDI name", () => {
+    // The ".service-now.com" completion exists for a pasted PDI name. If it
+    // also fired here the doctor would probe, and POST the client secret to,
+    // a host the user never configured — and then report the working config
+    // as a DNS typo.
+    expect(inspectInstanceUrl("https://snprod:8443").baseUrl).toBe("https://snprod:8443")
+    expect(inspectInstanceUrl("http://localhost:1080").baseUrl).toBe("http://localhost:1080")
+    expect(inspectInstanceUrl("https://snprod:8443").check.fix).toEqual([])
+  })
+
   test("a pasted record URL keeps the origin and says the rest was dropped", () => {
-    const inspection = inspectInstanceUrl("https://dev12345.service-now.com/now/nav/ui/classic/params/target/incident.do")
+    const inspection = inspectInstanceUrl(
+      "https://dev12345.service-now.com/now/nav/ui/classic/params/target/incident.do",
+    )
 
     expect(inspection.check.detail.join(" ")).toContain("this looks like a page URL")
     expect(inspection.check.fix[0]).toContain("https://dev12345.service-now.com")
@@ -178,9 +208,11 @@ describe("instance URL", () => {
 describe("role coverage, against the committed sn-roles.manifest.json", () => {
   const manifest = loadRolesManifest()
 
-  test("the manifest ships with the package", () => {
-    // It is read from the package root at runtime, so `files` in package.json
-    // has to keep shipping it. If this fails, npm users lose the roles check.
+  test("the manifest resolves from the package root", () => {
+    // Only proves the relative path is right — this reads the committed file,
+    // so it is blind to `files` in package.json. What the tarball actually
+    // ships is gated in publish-mcp.yml, which is the only place that can see
+    // it.
     expect(manifest).toBeDefined()
   })
 
@@ -272,8 +304,13 @@ const startInstance = async (answer: (path: string) => Answer): Promise<FakeInst
 
 const healthy = (path: string): Answer => {
   if (path.startsWith("/oauth_token.do")) return { status: 200, body: TOKEN_OK }
-  if (path.startsWith("/api/now/table/sys_user_has_role")) return { status: 200, body: `{"result":[{"role.name":"itil"},{"role.name":"snc_internal"}]}` }
-  if (path.startsWith("/api/now/table/sys_user")) return { status: 200, body: `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}` }
+  if (path.startsWith("/api/now/table/sys_user_has_role"))
+    return { status: 200, body: `{"result":[{"role.name":"itil"},{"role.name":"snc_internal"}]}` }
+  if (path.startsWith("/api/now/table/sys_user"))
+    return {
+      status: 200,
+      body: `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}`,
+    }
   return { status: 401, body: UNAUTHENTICATED }
 }
 
@@ -287,7 +324,11 @@ const codes = (report: Awaited<ReturnType<typeof runSetupDoctor>>) => report.che
 
 describe("running the whole diagnosis against an instance", () => {
   test("a hibernating instance stops the walk at reachability instead of blaming OAuth", async () => {
-    const instance = await startInstance(() => ({ status: 200, body: HIBERNATING_PAGE, contentType: "text/html;charset=UTF-8" }))
+    const instance = await startInstance(() => ({
+      status: 200,
+      body: HIBERNATING_PAGE,
+      contentType: "text/html;charset=UTF-8",
+    }))
 
     const report = await runSetupDoctor({ context: credentials(instance.url) })
 
@@ -351,7 +392,9 @@ describe("running the whole diagnosis against an instance", () => {
     // precisely the accounts that hold the most.
     const many = Array.from({ length: 300 }, (_, index) => ({ "role.name": `role_number_${index}` }))
     const instance = await startInstance((path) =>
-      path.startsWith("/api/now/table/sys_user_has_role") ? { status: 200, body: JSON.stringify({ result: many }) } : healthy(path),
+      path.startsWith("/api/now/table/sys_user_has_role")
+        ? { status: 200, body: JSON.stringify({ result: many }) }
+        : healthy(path),
     )
 
     const report = await runSetupDoctor({ context: credentials(instance.url) })
@@ -360,6 +403,27 @@ describe("running the whole diagnosis against an instance", () => {
     expect(roles?.title).toContain("300 roles")
     // Listed, but not all 300 of them dumped into one line.
     expect(roles?.title).toContain("and 288 more")
+    await instance.stop()
+  })
+
+  test("a full page of roles is reported as cut off rather than counted as the whole list", async () => {
+    // The query asks for one page. An account that fills it holds an unknown
+    // number more, so the coverage numbers are a floor — saying "N tools are
+    // out of reach" here would be wrong about the most privileged account on
+    // the instance.
+    const full = Array.from({ length: 500 }, (_, index) => ({ "role.name": `role_number_${index}` }))
+    const instance = await startInstance((path) =>
+      path.startsWith("/api/now/table/sys_user_has_role")
+        ? { status: 200, body: JSON.stringify({ result: full }) }
+        : healthy(path),
+    )
+
+    const roles = (await runSetupDoctor({ context: credentials(instance.url) })).checks.find(
+      (check) => check.step === "roles",
+    )
+
+    expect(roles?.detail[0]).toContain("cut off")
+    expect(roles?.detail[0]).toContain("floor")
     await instance.stop()
   })
 
@@ -398,7 +462,9 @@ describe("servicenow-mcp-stdio --doctor", () => {
     const authJson = join(home, ".serac", "auth.json")
     writeFileSync(
       authJson,
-      JSON.stringify({ servicenow: { instance: instance.url, clientId: "abc", clientSecret: "def", type: "servicenow-oauth" } }),
+      JSON.stringify({
+        servicenow: { instance: instance.url, clientId: "abc", clientSecret: "def", type: "servicenow-oauth" },
+      }),
     )
 
     const entry = new URL("../../index.ts", import.meta.url).pathname

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Setup doctor — behaviour tests.
+ *
+ * Nothing here is mocked. The classifiers are pure functions from an observed
+ * response to a diagnosis, so they are fed the payload shapes ServiceNow really
+ * answers with; the end-to-end runs drive the real `runSetupDoctor()` against a
+ * real HTTP server standing in for an instance, the same way the telemetry
+ * tests stand in for the portal. The role coverage is computed against the
+ * committed `sn-roles.manifest.json`, not a fixture of it.
+ *
+ * On the payloads: the classifiers key off structure (HTML vs JSON) and the
+ * RFC 6749 `error` code, never off ServiceNow's prose, because that prose moves
+ * between releases. The bodies below carry the markers that matter — a
+ * hibernation page saying "hibernating", an OAuth body with `error:
+ * invalid_client` — and the prose is quoted back to the user rather than
+ * matched on.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import * as http from "http"
+import { spawn } from "node:child_process"
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  classifyApiResponse,
+  classifyReachability,
+  classifyTokenResponse,
+  classifyTransportFailure,
+  inspectInstanceUrl,
+  loadRolesManifest,
+  renderReport,
+  runSetupDoctor,
+  summarizeRoleCoverage,
+  type Observed,
+} from "../setup-doctor.js"
+
+// ---------------------------------------------------------------------------
+// Payloads a ServiceNow instance really answers with
+// ---------------------------------------------------------------------------
+
+/** A hibernating developer instance answers every request — REST included — with this page. */
+const HIBERNATING_PAGE = `<!DOCTYPE html>
+<html><head><title>Instance Hibernating page</title></head>
+<body><h2>This instance is hibernating</h2>
+<p>To wake your instance, sign in to developer.servicenow.com and select Wake instance.</p></body></html>`
+
+/** The plain login page: same shape, no mention of hibernation. */
+const LOGIN_PAGE = `<!DOCTYPE html><html><head><title>Sign In | ServiceNow</title></head>
+<body><form action="/login.do" method="post"><input name="user_name"><input type="password" name="user_password"></form></body></html>`
+
+const observed = (status: number, body: string, contentType = "application/json"): Observed => ({ status, body, contentType })
+
+const UNAUTHENTICATED = `{"error":{"message":"User Not Authenticated","detail":"Required to provide Auth information"},"status":"failure"}`
+const INSUFFICIENT_RIGHTS = `{"error":{"message":"Insufficient rights to query records","detail":"Field(s) present in the query do not have permission to be read"},"status":"failure"}`
+const TOKEN_OK = `{"access_token":"9lS8sSJqR1uH","refresh_token":"F4RJc0Ns","scope":"useraccount","token_type":"Bearer","expires_in":1799}`
+
+describe("classifying what the instance answered", () => {
+  test("a hibernating instance is named, not reported as a parse error", () => {
+    const check = classifyReachability(observed(200, HIBERNATING_PAGE, "text/html;charset=UTF-8"))
+
+    expect(check.code).toBe("instance-hibernating")
+    expect(check.status).toBe("fail")
+    expect(check.fix.join(" ")).toContain("developer.servicenow.com")
+    // The whole point: the user is told this is the HTML page, not a bug in a tool.
+    expect(check.fix.join(" ")).toContain("parse error")
+  })
+
+  test("an HTML login page is still called out as HTML, and still leads with hibernation", () => {
+    const check = classifyReachability(observed(200, LOGIN_PAGE, "text/html"))
+
+    expect(check.code).toBe("html-instead-of-json")
+    expect(check.status).toBe("fail")
+    expect(check.fix[0]).toContain("hibernating")
+  })
+
+  test("HTML is detected by content when the content-type does not say so", () => {
+    // Some fronting proxies answer text/plain. Sniffing the body is what keeps
+    // the hibernation case from falling through to "unrecognisable response".
+    expect(classifyReachability({ status: 200, body: HIBERNATING_PAGE, contentType: undefined }).code).toBe("instance-hibernating")
+  })
+
+  test("a 401 from the unauthenticated probe means the instance is awake", () => {
+    const check = classifyReachability(observed(401, UNAUTHENTICATED))
+
+    expect(check.status).toBe("ok")
+    expect(check.code).toBe("instance-awake")
+  })
+
+  test("a bad client id or secret is not confused with a bad grant", () => {
+    const rejected = classifyTokenResponse(
+      observed(401, `{"error":"invalid_client","error_description":"Invalid client_id or client_secret."}`),
+    )
+    const grant = classifyTokenResponse(
+      observed(401, `{"error":"invalid_grant","error_description":"access_denied: no OAuth application user set"}`),
+    )
+
+    expect(rejected.code).toBe("oauth-client-rejected")
+    expect(grant.code).toBe("oauth-grant-rejected")
+    // What ServiceNow actually said survives into the report, verbatim.
+    expect(rejected.detail.join(" ")).toContain("Invalid client_id or client_secret.")
+    expect(grant.detail.join(" ")).toContain("no OAuth application user set")
+    expect(grant.fix.join(" ")).toContain("OAuth application user")
+  })
+
+  test("a grant the OAuth entry does not allow is its own diagnosis", () => {
+    expect(classifyTokenResponse(observed(400, `{"error":"unsupported_grant_type"}`)).code).toBe("oauth-grant-not-allowed")
+  })
+
+  test("a token response is only ok when it carries a token", () => {
+    expect(classifyTokenResponse(observed(200, TOKEN_OK)).status).toBe("ok")
+    expect(classifyTokenResponse(observed(200, `{"result":[]}`)).code).toBe("token-response-unrecognised")
+  })
+
+  test("the token endpoint answering HTML is the hibernation case again, not an OAuth misconfiguration", () => {
+    // Worth pinning: this is the one that sends people to regenerate a client
+    // secret that was never wrong.
+    expect(classifyTokenResponse(observed(200, HIBERNATING_PAGE, "text/html")).code).toBe("instance-hibernating")
+  })
+
+  test("403 on the API is reported as roles, not as broken credentials", () => {
+    const check = classifyApiResponse(observed(403, INSUFFICIENT_RIGHTS))
+
+    expect(check.code).toBe("api-forbidden")
+    expect(check.title).toContain("Authenticated")
+    expect(check.detail.join(" ")).toContain("Insufficient rights to query records")
+  })
+
+  test("a 200 identifies the account the OAuth entry is acting as", () => {
+    const check = classifyApiResponse(observed(200, `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}`))
+
+    expect(check.status).toBe("ok")
+    expect(check.title).toContain("integration.user")
+  })
+
+  test("unreachable is one finding with the reason named", () => {
+    expect(classifyTransportFailure({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND dev12345.service-now.com" }).code).toBe("instance-dns")
+    expect(classifyTransportFailure({ code: "ECONNREFUSED", message: "connect ECONNREFUSED 127.0.0.1:443" }).code).toBe("instance-refused")
+    expect(classifyTransportFailure({ code: "TimeoutError", message: "The operation was aborted due to timeout" }).code).toBe("instance-timeout")
+    expect(classifyTransportFailure({ code: "CERT_HAS_EXPIRED", message: "certificate has expired" }).code).toBe("instance-tls")
+  })
+})
+
+describe("instance URL", () => {
+  test.each([
+    ["dev12345", "https://dev12345.service-now.com", "instance-url-normalized"],
+    ["dev12345.service-now.com", "https://dev12345.service-now.com", "instance-url-normalized"],
+    ["https://dev12345.service-now.com", "https://dev12345.service-now.com", "instance-url-ok"],
+    ["https://dev12345.service-now.com/", "https://dev12345.service-now.com", "instance-url-normalized"],
+    [
+      "https://dev12345.service-now.com/nav_to.do?uri=incident.do%3Fsys_id%3D9d385017c611228701d22104cc95c371",
+      "https://dev12345.service-now.com",
+      "instance-url-normalized",
+    ],
+  ])("%s resolves to %s", (raw, baseUrl, code) => {
+    const inspection = inspectInstanceUrl(raw)
+
+    expect(inspection.baseUrl).toBe(baseUrl)
+    expect(inspection.check.code).toBe(code)
+  })
+
+  test("a missing or placeholder URL fails with nothing to probe", () => {
+    expect(inspectInstanceUrl(undefined).check.code).toBe("instance-url-missing")
+    expect(inspectInstanceUrl("").baseUrl).toBeUndefined()
+    expect(inspectInstanceUrl("https://your-instance.service-now.com").check.code).toBe("instance-url-placeholder")
+    expect(inspectInstanceUrl("https://your-instance.service-now.com").baseUrl).toBeUndefined()
+  })
+
+  test("a pasted record URL keeps the origin and says the rest was dropped", () => {
+    const inspection = inspectInstanceUrl("https://dev12345.service-now.com/now/nav/ui/classic/params/target/incident.do")
+
+    expect(inspection.check.detail.join(" ")).toContain("this looks like a page URL")
+    expect(inspection.check.fix[0]).toContain("https://dev12345.service-now.com")
+  })
+})
+
+describe("role coverage, against the committed sn-roles.manifest.json", () => {
+  const manifest = loadRolesManifest()
+
+  test("the manifest ships with the package", () => {
+    // It is read from the package root at runtime, so `files` in package.json
+    // has to keep shipping it. If this fails, npm users lose the roles check.
+    expect(manifest).toBeDefined()
+  })
+
+  test("holding no roles leaves most of the catalog out of reach", () => {
+    const none = summarizeRoleCoverage(manifest, [])
+
+    expect(none.resolved).toBeGreaterThan(100)
+    expect(none.blocked).toBeGreaterThan(0)
+    expect(none.unlocked + none.blocked).toBe(none.resolved)
+    // Public tools (empty minimumBundle) still count as reachable.
+    expect(none.unlocked).toBeGreaterThan(0)
+    expect(none.openers[0]?.tools).toBeGreaterThan(0)
+  })
+
+  test("admin unlocks everything the probe could resolve", () => {
+    expect(summarizeRoleCoverage(manifest, ["admin"]).blocked).toBe(0)
+  })
+
+  test("more roles never unlock fewer tools", () => {
+    const none = summarizeRoleCoverage(manifest, [])
+    const itil = summarizeRoleCoverage(manifest, ["itil"])
+    const both = summarizeRoleCoverage(manifest, ["itil", "snc_internal"])
+
+    expect(itil.unlocked).toBeGreaterThan(none.unlocked)
+    expect(both.unlocked).toBeGreaterThanOrEqual(itil.unlocked)
+    expect(both.unlocked).toBeLessThan(summarizeRoleCoverage(manifest, ["admin"]).unlocked)
+  })
+
+  test("anyOf is a single role that suffices; minimumBundle is roles needed together", () => {
+    const handBuilt = {
+      tools: {
+        alone: { snRoles: { anyOf: ["admin", "itil"], minimumBundle: ["itil"] } },
+        together: { snRoles: { anyOf: ["admin"], minimumBundle: ["catalog_admin", "catalog_editor"] } },
+        open: { snRoles: { anyOf: ["admin", "public"], minimumBundle: [] } },
+        unresolved: { snRoles: null, untestable: true },
+      },
+    }
+
+    expect(summarizeRoleCoverage(handBuilt, ["itil"]).unlocked).toBe(2) // "alone" + the public one
+    expect(summarizeRoleCoverage(handBuilt, ["catalog_admin"]).blocked).toBe(2) // half a bundle unlocks nothing
+    expect(summarizeRoleCoverage(handBuilt, ["catalog_admin", "catalog_editor"]).blocked).toBe(1)
+    expect(summarizeRoleCoverage(handBuilt, []).unresolved).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End to end, against a real HTTP server standing in for an instance
+// ---------------------------------------------------------------------------
+
+interface Answer {
+  status: number
+  body: string
+  contentType?: string
+}
+
+interface FakeInstance {
+  url: string
+  /** Paths the doctor asked for, in order. */
+  hits: string[]
+  stop: () => Promise<void>
+}
+
+const startInstance = async (answer: (path: string) => Answer): Promise<FakeInstance> => {
+  const hits: string[] = []
+  const sockets = new Set<import("net").Socket>()
+  const server = http.createServer((req, res) => {
+    hits.push(req.url ?? "")
+    const reply = answer(req.url ?? "")
+    res.writeHead(reply.status, { "content-type": reply.contentType ?? "application/json" })
+    res.end(reply.body)
+  })
+  server.on("connection", (socket) => {
+    sockets.add(socket)
+    socket.on("close", () => sockets.delete(socket))
+  })
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready))
+  const address = server.address()
+
+  return {
+    url: `http://127.0.0.1:${typeof address === "object" && address !== null ? address.port : 0}`,
+    hits,
+    stop: () =>
+      new Promise<void>((done) => {
+        sockets.forEach((socket) => socket.destroy())
+        server.close(() => done())
+      }),
+  }
+}
+
+const healthy = (path: string): Answer => {
+  if (path.startsWith("/oauth_token.do")) return { status: 200, body: TOKEN_OK }
+  if (path.startsWith("/api/now/table/sys_user_has_role")) return { status: 200, body: `{"result":[{"role.name":"itil"},{"role.name":"snc_internal"}]}` }
+  if (path.startsWith("/api/now/table/sys_user")) return { status: 200, body: `{"result":[{"user_name":"integration.user","name":"Integration User","active":"true"}]}` }
+  return { status: 401, body: UNAUTHENTICATED }
+}
+
+const credentials = (instanceUrl: string) => ({
+  instanceUrl,
+  clientId: "3b7f2c1e9a4d4f6b8c0e1a2b3c4d5e6f",
+  clientSecret: "not-a-real-secret",
+})
+
+const codes = (report: Awaited<ReturnType<typeof runSetupDoctor>>) => report.checks.map((check) => check.code)
+
+describe("running the whole diagnosis against an instance", () => {
+  test("a hibernating instance stops the walk at reachability instead of blaming OAuth", async () => {
+    const instance = await startInstance(() => ({ status: 200, body: HIBERNATING_PAGE, contentType: "text/html;charset=UTF-8" }))
+
+    const report = await runSetupDoctor({ context: credentials(instance.url) })
+
+    expect(report.ok).toBe(false)
+    expect(codes(report)).toContain("instance-hibernating")
+    // Nothing downstream ran: no token was exchanged, so nobody is told to
+    // regenerate a client secret that was fine all along.
+    expect(instance.hits.some((path) => path.startsWith("/oauth_token.do"))).toBe(false)
+    expect(renderReport(report)).toContain("developer.servicenow.com")
+    await instance.stop()
+  })
+
+  test("a healthy instance reports the account and its role coverage", async () => {
+    const instance = await startInstance(healthy)
+
+    const report = await runSetupDoctor({ context: credentials(instance.url) })
+    const rendered = renderReport(report)
+
+    expect(report.ok).toBe(true)
+    expect(codes(report)).toContain("token-ok")
+    expect(codes(report)).toContain("api-ok")
+    expect(rendered).toContain("integration.user")
+    // Two roles held, and the manifest says what that does and does not cover.
+    expect(rendered).toContain("itil, snc_internal")
+    expect(rendered).toMatch(/\d+ of \d+ tools with a known role requirement/)
+    await instance.stop()
+  })
+
+  test("a rejected client stops before the API call and quotes ServiceNow", async () => {
+    const instance = await startInstance((path) =>
+      path.startsWith("/oauth_token.do")
+        ? { status: 401, body: `{"error":"invalid_client","error_description":"Invalid client_id or client_secret."}` }
+        : { status: 401, body: UNAUTHENTICATED },
+    )
+
+    const report = await runSetupDoctor({ context: credentials(instance.url) })
+
+    expect(codes(report)).toContain("oauth-client-rejected")
+    expect(codes(report)).toContain("api-skipped")
+    expect(instance.hits.filter((path) => path.startsWith("/api/now/table/sys_user")).length).toBe(0)
+    expect(renderReport(report)).toContain("Invalid client_id or client_secret.")
+    await instance.stop()
+  })
+
+  test("an authenticated account with no roles is a warning, not a failure", async () => {
+    const instance = await startInstance((path) =>
+      path.startsWith("/api/now/table/sys_user_has_role") ? { status: 200, body: `{"result":[]}` } : healthy(path),
+    )
+
+    const report = await runSetupDoctor({ context: credentials(instance.url) })
+
+    expect(report.ok).toBe(true)
+    expect(codes(report)).toContain("roles-none")
+    expect(renderReport(report)).toContain("holds no roles")
+    await instance.stop()
+  })
+
+  test("an account with hundreds of roles is read, not truncated into nothing", async () => {
+    // An admin's sys_user_has_role answer is tens of kilobytes. A response body
+    // clipped for quoting parses as nothing, which would report "no roles" for
+    // precisely the accounts that hold the most.
+    const many = Array.from({ length: 300 }, (_, index) => ({ "role.name": `role_number_${index}` }))
+    const instance = await startInstance((path) =>
+      path.startsWith("/api/now/table/sys_user_has_role") ? { status: 200, body: JSON.stringify({ result: many }) } : healthy(path),
+    )
+
+    const report = await runSetupDoctor({ context: credentials(instance.url) })
+    const roles = report.checks.find((check) => check.step === "roles")
+
+    expect(roles?.title).toContain("300 roles")
+    // Listed, but not all 300 of them dumped into one line.
+    expect(roles?.title).toContain("and 288 more")
+    await instance.stop()
+  })
+
+  test("a refused connection is diagnosed as unreachable, with no credentials sent anywhere", async () => {
+    // Port 1 on loopback: nothing listens there, and no DNS is involved.
+    const report = await runSetupDoctor({ context: credentials("http://127.0.0.1:1") })
+
+    expect(report.ok).toBe(false)
+    expect(codes(report)).toContain("instance-refused")
+    expect(codes(report)).toContain("token-skipped")
+  }, 20000)
+
+  test("the report never prints the client secret", async () => {
+    const instance = await startInstance(healthy)
+
+    const rendered = renderReport(await runSetupDoctor({ context: credentials(instance.url) }))
+
+    expect(rendered).not.toContain("not-a-real-secret")
+    expect(rendered).toContain("client secret set")
+    await instance.stop()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The bin flag
+// ---------------------------------------------------------------------------
+
+describe("servicenow-mcp-stdio --doctor", () => {
+  test("reports the auth.json that supplied the credentials, and exits non-zero", async () => {
+    const instance = await startInstance(() => ({ status: 200, body: HIBERNATING_PAGE, contentType: "text/html" }))
+    // A home directory with one stale auth.json in it. os.homedir() under Bun
+    // reads HOME at process start, which is why this is a spawn and not an
+    // in-process test.
+    const home = mkdtempSync(join(tmpdir(), "serac-doctor-"))
+    mkdirSync(join(home, ".serac"))
+    const authJson = join(home, ".serac", "auth.json")
+    writeFileSync(
+      authJson,
+      JSON.stringify({ servicenow: { instance: instance.url, clientId: "abc", clientSecret: "def", type: "servicenow-oauth" } }),
+    )
+
+    const entry = new URL("../../index.ts", import.meta.url).pathname
+    const run = await new Promise<{ code: number | null; stdout: string; stderr: string }>((done) => {
+      const child = spawn(process.execPath, [entry, "--doctor"], {
+        cwd: home,
+        env: { PATH: process.env.PATH ?? "", HOME: home, DO_NOT_TRACK: "1" },
+      })
+      const chunks = { stdout: "", stderr: "" }
+      child.stdout.on("data", (data) => (chunks.stdout += data))
+      child.stderr.on("data", (data) => (chunks.stderr += data))
+      child.on("exit", (code) => done({ code, ...chunks }))
+    })
+
+    expect(run.stdout).toContain(authJson)
+    expect(run.stdout).toContain("hibernating")
+    // Non-zero so a setup script can gate on it.
+    expect(run.code).toBe(1)
+    await instance.stop()
+  }, 60000)
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/transport-parity.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/transport-parity.test.ts
@@ -45,6 +45,10 @@ const EXPECTED_STDIO_ONLY = new Set<string>([
   "snow_fluent_install",
   "snow_fluent_status",
   "snow_fluent_transform",
+  // Not a filesystem case: snow_diagnose_setup reports this process's
+  // environment variables and auth.json files, which on HTTP is the server's
+  // own configuration rather than the caller's.
+  "snow_diagnose_setup",
   // snow_artifact_manage and snow_pull_artifact were stdio-only until they
   // grew per-arg HTTP-safety guards (`httpForbiddenArgs`). They now run on
   // both transports — the unsafe filesystem args are rejected centrally

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
@@ -23,6 +23,15 @@ import { mcpDebug } from "../../shared/mcp-debug.js"
 import { STDIO_TENANT, tenantScopedKey } from "./tenant-scope.js"
 
 /**
+ * Pointer to the diagnostic, appended to the errors a user is most likely to
+ * hit first. These messages used to end at "run: serac auth login" — a CLI this
+ * repository no longer ships — which left the reader with a dead end at exactly
+ * the moment they needed a next step.
+ */
+const DIAGNOSE_HINT =
+  "Run `servicenow-mcp-stdio --doctor` (or call snow_diagnose_setup) to find out which part of the setup is wrong."
+
+/**
  * Extract a human-readable error message from a ServiceNow error response.
  * ServiceNow returns errors in various formats; this normalizes them.
  */
@@ -122,8 +131,8 @@ export class ServiceNowAuthManager {
       throw new Error(
         "Failed to obtain access token. This can happen when:\n" +
         "• Your ServiceNow instance is hibernating — open it in a browser to wake it up\n" +
-        "• Your credentials have expired — run: serac auth login\n" +
-        "• Your OAuth client ID/secret are incorrect"
+        "• Your OAuth client ID/secret are incorrect, or the entry has no OAuth application user\n" +
+        `• Your credentials have expired\n${DIAGNOSE_HINT}`
       )
     }
 
@@ -228,7 +237,7 @@ export class ServiceNowAuthManager {
             const newAccessToken = await this.getAccessToken(context)
 
             if (!newAccessToken) {
-              throw new Error("Failed to obtain access token after 401 refresh. Please run: serac auth login")
+              throw new Error(`Failed to obtain access token after 401 refresh.\n${DIAGNOSE_HINT}`)
             }
 
             // Update request with new token
@@ -308,7 +317,7 @@ export class ServiceNowAuthManager {
 
     // Check if instance URL is valid
     if (!context.instanceUrl || context.instanceUrl === "" || context.instanceUrl.includes("your-instance")) {
-      throw new Error("ServiceNow credentials not configured. Please run: serac auth login")
+      throw new Error(`ServiceNow credentials not configured.\n${DIAGNOSE_HINT}`)
     }
 
     // Check for valid OAuth credentials
@@ -326,7 +335,7 @@ export class ServiceNowAuthManager {
 
     // Must have at least one valid auth method
     if (!hasValidOAuth && !hasValidBasic) {
-      throw new Error("ServiceNow credentials not configured. Please run: serac auth login")
+      throw new Error(`ServiceNow credentials not configured.\n${DIAGNOSE_HINT}`)
     }
 
     // If only Basic auth is available, skip OAuth flows and go directly to Basic auth

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/context-loader.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/context-loader.ts
@@ -17,35 +17,47 @@ import { type ServiceNowContext } from "./types.js"
 import { mcpDebug } from "../../shared/mcp-debug.js"
 
 /**
+ * The auth.json locations `loadFromAuthJson()` reads, in the order it tries them.
+ *
+ * NOTE: snow-code uses xdg-basedir which returns different paths per platform:
+ * - macOS: ~/Library/Application Support/
+ * - Linux: ~/.local/share/
+ * - Windows: %APPDATA%
+ *
+ * Exported so the setup doctor can report which of these files exist and which
+ * one actually supplied the credentials. A forgotten file early in this list
+ * silently outranking the one you just edited is a real failure mode, and it is
+ * invisible unless something enumerates the same list the loader walks.
+ *
+ * A function, not a constant: `os.homedir()` must be read per call.
+ */
+export const authJsonPaths = (): string[] => [
+  // 1. macOS: ~/Library/Application Support/snow-code/auth.json (XDG data dir on macOS)
+  ...(process.platform === "darwin"
+    ? [path.join(os.homedir(), "Library", "Application Support", "snow-code", "auth.json")]
+    : []),
+  // 2. Windows: %APPDATA%/snow-code/auth.json
+  ...(process.platform === "win32" && process.env.APPDATA
+    ? [path.join(process.env.APPDATA, "snow-code", "auth.json")]
+    : []),
+  // 3. Linux/fallback: ~/.local/share/snow-code/auth.json (XDG data dir on Linux)
+  path.join(os.homedir(), ".local", "share", "snow-code", "auth.json"),
+  // 4. Serac specific auth (~/.serac, falling back to legacy ~/.snow-flow)
+  path.join(os.homedir(), ".serac", "auth.json"),
+  path.join(os.homedir(), ".snow-flow", "auth.json"),
+  // 5. The removed CLI's data dir. Kept on purpose: deleting that package
+  //    does not delete the auth.json it wrote on users' machines, and this is
+  //    where an existing install's ServiceNow credentials still live.
+  path.join(os.homedir(), ".local", "share", "opencode", "auth.json"),
+]
+
+/**
  * Load ServiceNow credentials from auth.json files.
  * Checks multiple possible locations in priority order.
  * Returns undefined if no valid credentials found.
  */
 export const loadFromAuthJson = (): ServiceNowContext | undefined => {
-  // Possible auth.json locations in priority order
-  // NOTE: snow-code uses xdg-basedir which returns different paths per platform:
-  // - macOS: ~/Library/Application Support/
-  // - Linux: ~/.local/share/
-  // - Windows: %APPDATA%
-  const authPaths = [
-    // 1. macOS: ~/Library/Application Support/snow-code/auth.json (XDG data dir on macOS)
-    ...(process.platform === "darwin"
-      ? [path.join(os.homedir(), "Library", "Application Support", "snow-code", "auth.json")]
-      : []),
-    // 2. Windows: %APPDATA%/snow-code/auth.json
-    ...(process.platform === "win32" && process.env.APPDATA
-      ? [path.join(process.env.APPDATA, "snow-code", "auth.json")]
-      : []),
-    // 3. Linux/fallback: ~/.local/share/snow-code/auth.json (XDG data dir on Linux)
-    path.join(os.homedir(), ".local", "share", "snow-code", "auth.json"),
-    // 4. Serac specific auth (~/.serac, falling back to legacy ~/.snow-flow)
-    path.join(os.homedir(), ".serac", "auth.json"),
-    path.join(os.homedir(), ".snow-flow", "auth.json"),
-    // 5. The removed CLI's data dir. Kept on purpose: deleting that package
-    //    does not delete the auth.json it wrote on users' machines, and this is
-    //    where an existing install's ServiceNow credentials still live.
-    path.join(os.homedir(), ".local", "share", "opencode", "auth.json"),
-  ]
+  const authPaths = authJsonPaths()
 
   for (const authPath of authPaths) {
     try {
@@ -331,6 +343,49 @@ export const loadFromEnterprisePortal = async (): Promise<ServiceNowContext | un
 }
 
 /**
+ * Every environment variable this loader reads, per credential field, in
+ * precedence order.
+ *
+ * `SNOW_INSTANCE_URL` is in here because it is the name the quick start in
+ * README.md, the package README, CONTRIBUTING.md and SECURITY.md all tell
+ * people to set — and until this list existed, it was the one name the loader
+ * did not read. Everyone who copy-pasted the documented MCP config got a server
+ * with no instance URL, which surfaces much later as an auth error inside an
+ * unrelated tool call. Adding a documented variable here is cheap; the list is
+ * also what `shared/setup-doctor.ts` reports from, so a name that is not in it
+ * is a name the doctor will tell the user is being ignored.
+ */
+export const ENV_VARS = {
+  instanceUrl: ["SERVICENOW_INSTANCE_URL", "SNOW_INSTANCE_URL", "SNOW_INSTANCE"],
+  clientId: ["SERVICENOW_CLIENT_ID", "SNOW_CLIENT_ID"],
+  clientSecret: ["SERVICENOW_CLIENT_SECRET", "SNOW_CLIENT_SECRET"],
+  refreshToken: ["SERVICENOW_REFRESH_TOKEN", "SNOW_REFRESH_TOKEN"],
+  username: ["SERVICENOW_USERNAME", "SNOW_USERNAME"],
+  password: ["SERVICENOW_PASSWORD", "SNOW_PASSWORD"],
+  environmentType: ["SERVICENOW_ENVIRONMENT_TYPE", "SNOW_ENVIRONMENT_TYPE"],
+} as const
+
+/**
+ * First variable of a field that is actually set, with the name that supplied
+ * it. The doctor prints that name: "your instance URL came from SNOW_INSTANCE"
+ * is a different bug report than "…came from SERVICENOW_INSTANCE_URL".
+ * Whitespace-only values count as unset, as they always have.
+ */
+export const envCredential = (field: keyof typeof ENV_VARS): { name: string; value: string } | undefined =>
+  ENV_VARS[field]
+    .map((name) => ({ name, value: process.env[name] ?? "" }))
+    .find((candidate) => candidate.value.trim() !== "")
+
+/**
+ * Accept an instance that was given as a bare host ("dev12345.service-now.com")
+ * as well as a full URL. Historically only SNOW_INSTANCE got this treatment,
+ * so a scheme-less SERVICENOW_INSTANCE_URL became an axios baseURL of
+ * "dev12345.service-now.com" and every request failed with a URL parse error.
+ */
+const normalizeInstanceUrl = (value: string): string =>
+  value.startsWith("http://") || value.startsWith("https://") ? value : `https://${value}`
+
+/**
  * Load ServiceNow context from environment variables OR auth.json fallback.
  * Note: Server will start even without credentials (unauthenticated mode).
  *
@@ -344,26 +399,13 @@ export const loadFromEnterprisePortal = async (): Promise<ServiceNowContext | un
  */
 export const loadContext = (): ServiceNowContext => {
   // STEP 1: Try environment variables first
-  // Handle SNOW_INSTANCE with or without https:// prefix to avoid double-prefix issue
-  const snowInstance = process.env.SNOW_INSTANCE
-  const normalizedSnowInstance = snowInstance
-    ? snowInstance.startsWith("http://") || snowInstance.startsWith("https://")
-      ? snowInstance
-      : `https://${snowInstance}`
-    : undefined
-  const instanceUrl = process.env.SERVICENOW_INSTANCE_URL || normalizedSnowInstance
-  const clientId = process.env.SERVICENOW_CLIENT_ID || process.env.SNOW_CLIENT_ID
-  const clientSecret = process.env.SERVICENOW_CLIENT_SECRET || process.env.SNOW_CLIENT_SECRET
-  const refreshToken = process.env.SERVICENOW_REFRESH_TOKEN || process.env.SNOW_REFRESH_TOKEN
-  const username = process.env.SERVICENOW_USERNAME || process.env.SNOW_USERNAME
-  const password = process.env.SERVICENOW_PASSWORD || process.env.SNOW_PASSWORD
+  const instanceUrl = envCredential("instanceUrl")
+  const clientId = envCredential("clientId")
+  const clientSecret = envCredential("clientSecret")
   // OTAP classification (optional). Lets a self-hosted CLI user mark an instance
   // "production" so the call-tool prod-write guard applies. Invalid/absent ⇒ undefined.
-  const rawEnvironment = (process.env.SERVICENOW_ENVIRONMENT_TYPE || process.env.SNOW_ENVIRONMENT_TYPE || "").toLowerCase()
+  const rawEnvironment = (envCredential("environmentType")?.value || "").toLowerCase()
   const environmentType = (["production", "development", "test", "uat", "sandbox"] as const).find((v) => v === rawEnvironment)
-
-  // Helper: Convert empty strings to undefined (treat empty as missing)
-  const normalizeCredential = (val?: string) => (val && val.trim() !== "" ? val : undefined)
 
   // Check for placeholder values
   const isPlaceholder = (val?: string) => !val || val.includes("your-") || val.includes("placeholder")
@@ -373,19 +415,19 @@ export const loadContext = (): ServiceNowContext => {
     instanceUrl &&
     clientId &&
     clientSecret &&
-    !isPlaceholder(instanceUrl) &&
-    !isPlaceholder(clientId) &&
-    !isPlaceholder(clientSecret)
+    !isPlaceholder(instanceUrl.value) &&
+    !isPlaceholder(clientId.value) &&
+    !isPlaceholder(clientSecret.value)
 
   if (hasValidEnvVars) {
     mcpDebug("[Auth] Using credentials from environment variables")
     return {
-      instanceUrl: instanceUrl!,
-      clientId: clientId!,
-      clientSecret: clientSecret!,
-      refreshToken: normalizeCredential(refreshToken),
-      username: normalizeCredential(username),
-      password: normalizeCredential(password),
+      instanceUrl: normalizeInstanceUrl(instanceUrl.value),
+      clientId: clientId.value,
+      clientSecret: clientSecret.value,
+      refreshToken: envCredential("refreshToken")?.value,
+      username: envCredential("username")?.value,
+      password: envCredential("password")?.value,
       environmentType,
     }
   }

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
@@ -1,0 +1,986 @@
+/**
+ * Setup diagnosis: find out why ServiceNow calls fail, before a tool call has
+ * to fail to tell you.
+ *
+ * The quick start asks people to create an OAuth Application Registry entry on
+ * their instance before they have seen anything work. When they get it wrong,
+ * the first symptom is an error inside some unrelated tool — often a JSON parse
+ * error, because a hibernating developer instance answers every request with an
+ * HTML login page. This module walks the same chain the server walks at
+ * startup and says which link is broken and what to do about it.
+ *
+ * Two rules shape the design:
+ *
+ * 1. **Classification is pure.** Every "what does this mean" decision is a
+ *    function from an observed response (status, content-type, body) to a
+ *    `Check`. The network part only observes: `fetch` here never throws on a
+ *    4xx and never parses eagerly. That is what makes this testable against
+ *    real ServiceNow payloads without mocking an HTTP client.
+ * 2. **Report the chain, not just the verdict.** `context-loader.ts` resolves
+ *    credentials from env vars, then auth.json, then the enterprise portal, and
+ *    the loudest failure mode is the second link quietly winning: a stale
+ *    auth.json from an install you forgot about, pointing at a different
+ *    instance than the env vars you just edited. So the credentials check names
+ *    the file or variable that supplied each value, and lists the sources that
+ *    were present but not used.
+ *
+ * Nothing here prints. `renderReport()` returns a string; the callers decide
+ * where it goes — which matters on stdio, where stdout IS the JSON-RPC channel.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs"
+
+import { type ServiceNowContext } from "./types.js"
+import {
+  ENV_VARS,
+  authJsonPaths,
+  envCredential,
+  loadContext,
+  loadEnterpriseAuth,
+  loadFromEnterprisePortal,
+} from "./context-loader.js"
+
+export type CheckStatus = "ok" | "warn" | "fail" | "skip"
+
+export type CheckStep = "credentials" | "instance-url" | "instance" | "token" | "api" | "roles"
+
+export interface Check {
+  step: CheckStep
+  status: CheckStatus
+  /** Stable machine-readable classification, e.g. "instance-hibernating". */
+  code: string
+  /** One line naming what is wrong (or right). */
+  title: string
+  /** What was observed — including, verbatim, what ServiceNow answered. */
+  detail: string[]
+  /** Ordered next actions. Empty when there is nothing to do. */
+  fix: string[]
+}
+
+/** A response as observed, before anyone decided what it means. */
+export interface Observed {
+  status: number
+  contentType?: string
+  body: string
+  location?: string
+}
+
+/** A request that never got a response: DNS, TCP, TLS, or a timeout. */
+export interface TransportFailure {
+  code?: string
+  message: string
+}
+
+export interface SetupReport {
+  ok: boolean
+  instanceUrl?: string
+  checks: Check[]
+}
+
+const PROBE_TIMEOUT_MS = 10_000
+
+/**
+ * How much of a response body to keep. It has to be big enough to PARSE, not
+ * just to quote: an admin's sys_user_has_role answer runs to tens of kilobytes,
+ * and a body truncated mid-JSON parses as nothing at all — which would report
+ * "no roles" for exactly the accounts that hold the most. Capped so a
+ * misconfigured host cannot stream something unbounded into the report.
+ */
+const BODY_CAP = 256_000
+
+/**
+ * Run every check, in the order a request travels: which credentials the chain
+ * produced, whether the URL is usable, whether the instance answers, whether
+ * the token exchange succeeds, whether the API accepts the token, and what the
+ * authenticated account is actually allowed to do.
+ *
+ * Each step is skipped — not failed — when the step before it did not produce
+ * what it needs, so the report always shows where the walk stopped.
+ */
+export const runSetupDoctor = async (options: { context?: ServiceNowContext } = {}): Promise<SetupReport> => {
+  const chain = await resolveChain(options.context)
+  const url = inspectInstanceUrl(chain.context.instanceUrl)
+  const checks = [chain.check, url.check]
+
+  if (!url.baseUrl) return finish(checks, undefined)
+
+  const reachability = await probe(`${url.baseUrl}/api/now/table/sys_properties?sysparm_limit=1`)
+  const reach = "failure" in reachability ? classifyTransportFailure(reachability.failure) : classifyReachability(reachability.observed)
+  checks.push(reach)
+  if (reach.status === "fail") return finish(checks, url.baseUrl)
+
+  const hasOAuth = !!chain.context.clientId && !!chain.context.clientSecret
+  const basic =
+    chain.context.username && chain.context.password
+      ? `Basic ${Buffer.from(`${chain.context.username}:${chain.context.password}`).toString("base64")}`
+      : undefined
+
+  if (!hasOAuth && !basic) {
+    checks.push(skipped("token", "No credentials to exchange."), skipped("api", "No credentials to authenticate with."))
+    return finish(checks, url.baseUrl)
+  }
+
+  // Mirrors shared/auth.ts: a refresh token is tried first when there is one,
+  // and a refused refresh falls through to the client-credentials grant rather
+  // than ending the run. The doctor reports both outcomes so a stale refresh
+  // token in auth.json cannot masquerade as a bad client secret.
+  const refreshed = hasOAuth && chain.context.refreshToken ? await exchangeToken(url.baseUrl, chain.context, "refresh_token") : undefined
+  const exchange = hasOAuth && refreshed?.token === undefined ? await exchangeToken(url.baseUrl, chain.context, "client_credentials") : refreshed
+  const authorization = exchange?.token ? `Bearer ${exchange.token}` : basic
+
+  checks.push(
+    exchange
+      ? withDetail(exchange.check, refreshed && refreshed !== exchange ? [`the refresh_token grant was refused first: ${refreshed.check.title}`] : [])
+      : skipped("token", "Basic auth configured — no OAuth token exchange happens."),
+  )
+
+  if (!authorization) {
+    checks.push(skipped("api", "No usable credential — the token exchange did not produce one."))
+    return finish(checks, url.baseUrl)
+  }
+
+  const identity = await probe(
+    `${url.baseUrl}/api/now/table/sys_user?${new URLSearchParams({
+      sysparm_query: "sys_id=javascript:gs.getUserID()",
+      sysparm_fields: "user_name,name,active",
+      sysparm_limit: "1",
+    }).toString()}`,
+    authorization,
+  )
+  const api = "failure" in identity ? classifyTransportFailure(identity.failure) : classifyApiResponse(identity.observed)
+  checks.push(api)
+  if (api.status === "fail") return finish(checks, url.baseUrl)
+
+  // Same query snow_session_context uses. Reading sys_user_has_role itself
+  // needs a role, so a refusal here is a finding, not an error.
+  const granted = await probe(
+    `${url.baseUrl}/api/now/table/sys_user_has_role?${new URLSearchParams({
+      sysparm_query: "user=javascript:gs.getUserID()",
+      sysparm_fields: "role.name",
+      sysparm_limit: "500",
+    }).toString()}`,
+    authorization,
+  )
+  checks.push("failure" in granted ? classifyTransportFailure(granted.failure) : classifyRoles(granted.observed))
+
+  return finish(checks, url.baseUrl)
+}
+
+/**
+ * The report as a human reads it. Used by the `--doctor` flag and returned as
+ * the MCP tool's summary, so it must stay plain text: no ANSI colour, no box
+ * drawing, nothing that assumes a terminal.
+ */
+export const renderReport = (report: SetupReport): string => {
+  const label: Record<CheckStep, string> = {
+    credentials: "credentials",
+    "instance-url": "instance url",
+    instance: "instance",
+    token: "oauth token",
+    api: "api access",
+    roles: "roles",
+  }
+  const marker: Record<CheckStatus, string> = { ok: "ok  ", warn: "warn", fail: "FAIL", skip: "skip" }
+
+  // 2 spaces + a 4-char marker + 2 spaces + a 13-char label + 1 space, so
+  // continuation lines land under the title rather than under the label.
+  const indent = " ".repeat(22)
+  const lines = report.checks.flatMap((check) => [
+    `  ${marker[check.status]}  ${label[check.step].padEnd(13)} ${check.title}`,
+    ...check.detail.map((line) => `${indent}${line}`),
+    ...check.fix.map((line) => `${indent}-> ${line}`),
+  ])
+
+  const failed = report.checks.filter((check) => check.status === "fail")
+  const warned = report.checks.filter((check) => check.status === "warn")
+  const verdict =
+    failed.length > 0
+      ? `${failed.length} problem${failed.length === 1 ? "" : "s"} found. Fix the first FAIL above, then run this again.`
+      : warned.length > 0
+        ? `${warned.length} warning${warned.length === 1 ? "" : "s"}. The server will run, but read them.`
+        : "Everything the server needs is in place."
+
+  return ["ServiceNow MCP — setup check", "", ...lines, "", verdict].join("\n")
+}
+
+/**
+ * What is wrong with an instance URL, and the base URL to use if it is
+ * salvageable. Every case here is one someone actually pastes: the instance
+ * name on its own, a full record URL copied out of the browser, a trailing
+ * slash, http instead of https.
+ */
+export const inspectInstanceUrl = (raw: string | undefined): { check: Check; baseUrl?: string } => {
+  const value = (raw ?? "").trim()
+  if (value === "")
+    return {
+      check: {
+        step: "instance-url",
+        status: "fail",
+        code: "instance-url-missing",
+        title: "No instance URL configured.",
+        detail: [],
+        fix: ["Set SNOW_INSTANCE_URL to your instance, e.g. https://dev12345.service-now.com"],
+      },
+    }
+
+  if (value.includes("your-") || value.includes("placeholder") || value.includes("YOUR_"))
+    return {
+      check: {
+        step: "instance-url",
+        status: "fail",
+        code: "instance-url-placeholder",
+        title: "The instance URL is still a placeholder.",
+        detail: [`configured value: ${value}`],
+        fix: ["Replace it with your real instance host, e.g. https://dev12345.service-now.com"],
+      },
+    }
+
+  // URL.canParse rather than URL.parse: the latter only landed in Node 20.18,
+  // and this package supports Node 20.
+  const candidate = value.includes("://") ? value : `https://${value}`
+  const parsed = URL.canParse(candidate) ? new URL(candidate) : undefined
+  if (!parsed || parsed.hostname === "")
+    return {
+      check: {
+        step: "instance-url",
+        status: "fail",
+        code: "instance-url-unparseable",
+        title: "The instance URL is not a URL.",
+        detail: [`configured value: ${value}`],
+        fix: ["Use the host you log in to, with a scheme: https://dev12345.service-now.com"],
+      },
+    }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:")
+    return {
+      check: {
+        step: "instance-url",
+        status: "fail",
+        code: "instance-url-scheme",
+        title: `The instance URL uses the ${parsed.protocol} scheme.`,
+        detail: [`configured value: ${value}`],
+        fix: ["ServiceNow is reached over https: https://dev12345.service-now.com"],
+      },
+    }
+
+  // A bare name — "dev12345" — is what developer.servicenow.com shows you, so
+  // it gets pasted as-is. Complete it rather than failing on it, but say so:
+  // the user's config is still wrong for every other tool that reads it.
+  const named = !parsed.hostname.includes(".")
+  const baseUrl = named ? `${parsed.protocol}//${parsed.hostname}.service-now.com` : parsed.origin
+
+  const notes = [
+    ...(named ? [`"${parsed.hostname}" is an instance name, not a host — reading it as ${baseUrl}`] : []),
+    ...(!value.includes("://") ? ["no scheme — reading it as https"] : []),
+    ...(parsed.pathname !== "/" || parsed.search !== "" || parsed.hash !== ""
+      ? [`everything after the host is ignored (${parsed.pathname}${parsed.search}${parsed.hash}) — this looks like a page URL, not the instance root`]
+      : []),
+    // Left in place it becomes "https://host//oauth_token.do", because every
+    // caller concatenates a path onto this value.
+    ...(value.endsWith("/") ? ["trailing slash — request URLs built from it get a doubled slash"] : []),
+    ...(parsed.protocol === "http:" ? ["http, not https — credentials would cross the network in the clear"] : []),
+  ]
+
+  if (notes.length === 0)
+    return {
+      baseUrl,
+      check: { step: "instance-url", status: "ok", code: "instance-url-ok", title: baseUrl, detail: [], fix: [] },
+    }
+
+  return {
+    baseUrl,
+    check: {
+      step: "instance-url",
+      status: "warn",
+      code: "instance-url-normalized",
+      title: `Using ${baseUrl}`,
+      detail: [`configured value: ${value}`, ...notes],
+      fix: [
+        // Only worth saying when the value would actually change. An http URL
+        // that is otherwise correct gets the https advice instead.
+        ...(baseUrl === value ? [] : [`Set the instance URL to exactly ${baseUrl}`]),
+        ...(parsed.protocol === "http:" ? ["Use https, unless this is a local test server."] : []),
+      ],
+    },
+  }
+}
+
+/**
+ * Does this host answer like a ServiceNow instance? Probed unauthenticated, so
+ * it runs before credentials exist — which is the point: "your instance is
+ * asleep" is the answer far more often than "your OAuth entry is wrong", and it
+ * needs no OAuth entry to find out.
+ */
+export const classifyReachability = (observed: Observed): Check => {
+  const html = htmlDiagnosis("instance", observed)
+  if (html) return html
+
+  if (observed.status >= 300 && observed.status < 400)
+    return {
+      step: "instance",
+      status: "fail",
+      code: "instance-redirects",
+      title: "The instance redirected the REST API to a login page.",
+      detail: [`HTTP ${observed.status}`, ...(observed.location ? [`location: ${observed.location}`] : [])],
+      fix: [
+        "A hibernating developer instance does this — wake it at https://developer.servicenow.com and wait a minute.",
+        "Otherwise something in front of the instance (SSO portal, proxy, VPN gateway) is intercepting /api/now.",
+      ],
+    }
+
+  if (observed.status === 401 || observed.status === 403)
+    return {
+      step: "instance",
+      status: "ok",
+      code: "instance-awake",
+      title: "The instance is awake and answering the REST API.",
+      detail: [`the unauthenticated probe answered HTTP ${observed.status}, which is what a healthy instance does`],
+      fix: [],
+    }
+
+  if (observed.status === 404)
+    return {
+      step: "instance",
+      status: "fail",
+      code: "instance-not-servicenow",
+      title: "That host answers, but /api/now/table is not there.",
+      detail: ["HTTP 404", ...bodyDetail(observed)],
+      fix: ["Check the host — this does not look like a ServiceNow instance."],
+    }
+
+  if (observed.status >= 500)
+    return {
+      step: "instance",
+      status: "fail",
+      code: "instance-error",
+      title: `The instance answered HTTP ${observed.status}.`,
+      detail: bodyDetail(observed),
+      fix: [
+        observed.status === 502 || observed.status === 503
+          ? "502/503 from a developer instance usually means it is waking up or hibernating — open it in a browser, wait a minute, try again."
+          : "The instance is failing on its own side. Try again, then check the instance in a browser.",
+      ],
+    }
+
+  return {
+    step: "instance",
+    status: "ok",
+    code: "instance-reachable",
+    title: "The instance answered.",
+    detail: [`unauthenticated probe answered HTTP ${observed.status}`],
+    fix: [],
+  }
+}
+
+/**
+ * What `oauth_token.do` said. ServiceNow answers this endpoint with RFC 6749
+ * error codes, so classify on `error` and quote `error_description` verbatim —
+ * paraphrasing it is how "invalid_client" turns into a support thread.
+ */
+export const classifyTokenResponse = (observed: Observed): Check => {
+  const html = htmlDiagnosis("token", observed)
+  if (html) return html
+
+  const body = parseJson(observed.body)
+  const error = str(body?.error)
+  const description = str(body?.error_description)
+  const quoted = [`HTTP ${observed.status}`, ...(error ? [`ServiceNow said: ${error}${description ? ` — ${description}` : ""}`] : bodyDetail(observed))]
+
+  if (str(body?.access_token))
+    return {
+      step: "token",
+      status: "ok",
+      code: "token-ok",
+      title: "OAuth token exchange succeeded.",
+      detail: [`token type ${str(body?.token_type) ?? "unknown"}, expires in ${typeof body?.expires_in === "number" ? body.expires_in : "?"}s`],
+      fix: [],
+    }
+
+  if (error === "invalid_client")
+    return {
+      step: "token",
+      status: "fail",
+      code: "oauth-client-rejected",
+      title: "ServiceNow rejected the client id or client secret.",
+      detail: quoted,
+      fix: [
+        "Open System OAuth > Application Registry on the instance and compare the Client ID character for character.",
+        "The client secret is only shown when the entry is created — if you are unsure, generate a new one and update your config.",
+        "Copy the Client ID field, not the record's sys_id.",
+      ],
+    }
+
+  if (error === "invalid_grant")
+    return {
+      step: "token",
+      status: "fail",
+      code: "oauth-grant-rejected",
+      title: "The client is recognised, but the grant was refused.",
+      detail: quoted,
+      fix: [
+        "For client_credentials: the Application Registry entry needs an OAuth application user, and that user must be active and unlocked.",
+        "For refresh_token: refresh tokens expire (100 days by default) and are revoked when the entry changes — re-authorise to get a new one.",
+      ],
+    }
+
+  if (error === "unauthorized_client" || error === "unsupported_grant_type")
+    return {
+      step: "token",
+      status: "fail",
+      code: "oauth-grant-not-allowed",
+      title: "The OAuth entry does not allow this grant type.",
+      detail: quoted,
+      fix: [
+        "On the Application Registry entry, allow the Client Credentials grant type (older releases hide it until the OAuth plugin is upgraded).",
+        "If your instance cannot grant client_credentials, configure a refresh token or basic-auth credentials instead.",
+      ],
+    }
+
+  if (error)
+    return {
+      step: "token",
+      status: "fail",
+      code: "oauth-error",
+      title: `The token endpoint returned "${error}".`,
+      detail: quoted,
+      fix: ["Check the Application Registry entry on the instance against the message above."],
+    }
+
+  if (observed.status === 404)
+    return {
+      step: "token",
+      status: "fail",
+      code: "oauth-endpoint-missing",
+      title: "/oauth_token.do is not there.",
+      detail: quoted,
+      fix: ["Check the instance URL — a ServiceNow instance always serves that endpoint."],
+    }
+
+  return {
+    step: "token",
+    status: "fail",
+    code: "token-response-unrecognised",
+    title: "The token endpoint answered with something unrecognisable.",
+    detail: quoted,
+    fix: ["Re-run with SNOW_MCP_DEBUG=true for the full exchange, and include the body above in a bug report."],
+  }
+}
+
+/** What the REST API said when the token was actually used. */
+export const classifyApiResponse = (observed: Observed): Check => {
+  const html = htmlDiagnosis("api", observed)
+  if (html) return html
+
+  const body = parseJson(observed.body)
+  const message = str(asRecord(body?.error)?.message) ?? str(asRecord(body?.error)?.detail)
+
+  if (observed.status === 401)
+    return {
+      step: "api",
+      status: "fail",
+      code: "api-unauthorized",
+      title: "The API rejected the token that was just issued.",
+      detail: ["HTTP 401", ...(message ? [`ServiceNow said: ${message}`] : bodyDetail(observed))],
+      fix: [
+        "The account behind the OAuth entry may be inactive or locked out.",
+        "If you switched instances, delete the cached token: ~/.serac/token-cache.json",
+      ],
+    }
+
+  if (observed.status === 403)
+    return {
+      step: "api",
+      status: "fail",
+      code: "api-forbidden",
+      title: "Authenticated, but not allowed to read sys_user.",
+      detail: ["HTTP 403", ...(message ? [`ServiceNow said: ${message}`] : bodyDetail(observed))],
+      fix: ["The account authenticated fine — it just holds no role that can read sys_user. Ask an admin to grant it one (itil or snc_internal is enough to start)."],
+    }
+
+  if (observed.status !== 200)
+    return {
+      step: "api",
+      status: "fail",
+      code: "api-error",
+      title: `The API answered HTTP ${observed.status}.`,
+      detail: [...(message ? [`ServiceNow said: ${message}`] : bodyDetail(observed))],
+      fix: [],
+    }
+
+  const user = asRecord(asArray(asRecord(body)?.result)?.[0])
+  if (!user)
+    return {
+      step: "api",
+      status: "warn",
+      code: "api-user-unknown",
+      title: "The API accepted the credentials, but did not resolve the current user.",
+      detail: bodyDetail(observed),
+      fix: ["Harmless for most tools. It usually means the account cannot read its own sys_user record."],
+    }
+
+  return {
+    step: "api",
+    status: "ok",
+    code: "api-ok",
+    title: `Authenticated as ${str(user.user_name) ?? "unknown"}${str(user.name) ? ` (${str(user.name)})` : ""}.`,
+    detail: str(user.active) === "false" ? ["that account is marked inactive"] : [],
+    fix: [],
+  }
+}
+
+/**
+ * A request that never got an answer. Kept as one finding with a named reason:
+ * "unreachable" is the user's problem, "ENOTFOUND vs ECONNREFUSED" is the
+ * detail that tells them which thing to fix.
+ */
+export const classifyTransportFailure = (failure: TransportFailure): Check => {
+  const haystack = `${failure.code ?? ""} ${failure.message}`.toLowerCase()
+  const reason = haystack.includes("enotfound") || haystack.includes("eai_again") || haystack.includes("getaddrinfo") || haystack.includes("dns")
+    ? { code: "instance-dns", title: "The instance host does not resolve.", fix: ["Check the host for a typo. A developer instance is dev12345.service-now.com — the number is on your developer.servicenow.com dashboard."] }
+    : haystack.includes("econnrefused") || haystack.includes("connectionrefused") || haystack.includes("unable to connect")
+      ? { code: "instance-refused", title: "The instance refused the connection.", fix: ["Nothing is listening on that host and port. Check the URL, and whether the instance is reachable from this network (VPN, proxy)."] }
+      : haystack.includes("timeout") || haystack.includes("timed out") || haystack.includes("aborted")
+        ? { code: "instance-timeout", title: `The instance did not answer within ${PROBE_TIMEOUT_MS / 1000}s.`, fix: ["A hibernating instance can hang like this while it wakes. Open it in a browser, then try again."] }
+        : haystack.includes("cert") || haystack.includes("tls") || haystack.includes("ssl")
+          ? { code: "instance-tls", title: "The TLS handshake failed.", fix: ["A corporate proxy that re-signs TLS needs its CA trusted by node (NODE_EXTRA_CA_CERTS)."] }
+          : { code: "instance-unreachable", title: "The instance could not be reached.", fix: ["Check network access to the instance from this machine."] }
+
+  return {
+    step: "instance",
+    status: "fail",
+    code: reason.code,
+    title: reason.title,
+    detail: [`${failure.code ? `${failure.code}: ` : ""}${failure.message}`],
+    fix: reason.fix,
+  }
+}
+
+export interface RoleCoverage {
+  /** Tools in the manifest whose role requirement was resolved against a live instance. */
+  resolved: number
+  /** Tools the manifest could not resolve statically — no verdict either way. */
+  unresolved: number
+  unlocked: number
+  blocked: number
+  /** Roles that would unlock the most blocked tools, most first. */
+  openers: { role: string; tools: number }[]
+}
+
+/**
+ * How much of the catalog the given roles can actually run, from
+ * `sn-roles.manifest.json`.
+ *
+ * Manifest semantics (see script/probe-sn-roles/README.md): `anyOf` lists roles
+ * that suffice ALONE, `minimumBundle` is the smallest set needed TOGETHER, and
+ * an empty bundle means the tool needs no role at all.
+ */
+export const summarizeRoleCoverage = (manifest: unknown, held: string[]): RoleCoverage => {
+  const tools = Object.values(asRecord(asRecord(manifest)?.tools) ?? {})
+    .map((tool) => asRecord(asRecord(tool)?.snRoles))
+    .filter((roles): roles is Record<string, unknown> => roles !== undefined)
+    .map((roles) => ({
+      anyOf: (asArray(roles.anyOf) ?? []).map(String),
+      bundle: (asArray(roles.minimumBundle) ?? []).map(String),
+    }))
+
+  const owned = new Set(held)
+  const blocked = tools.filter(
+    (tool) => tool.bundle.length > 0 && !tool.anyOf.some((role) => owned.has(role)) && !tool.bundle.every((role) => owned.has(role)),
+  )
+
+  const openers = Object.entries(
+    blocked
+      .flatMap((tool) => tool.anyOf)
+      .filter((role) => !owned.has(role))
+      .reduce<Record<string, number>>((counts, role) => ({ ...counts, [role]: (counts[role] ?? 0) + 1 }), {}),
+  )
+    .map(([role, count]) => ({ role, tools: count }))
+    .sort((a, b) => b.tools - a.tools)
+    .slice(0, 5)
+
+  return {
+    resolved: tools.length,
+    unresolved: Object.keys(asRecord(asRecord(manifest)?.tools) ?? {}).length - tools.length,
+    unlocked: tools.length - blocked.length,
+    blocked: blocked.length,
+    openers,
+  }
+}
+
+/**
+ * The committed role manifest, or undefined when it is not on disk.
+ *
+ * Resolved relative to this module so it works from `src/` in a checkout and
+ * from `dist/` in the npm tarball — both sit three levels under the package
+ * root. `package.json` `files` ships it for exactly this reason.
+ */
+export const loadRolesManifest = (): unknown => readJson(new URL("../../../sn-roles.manifest.json", import.meta.url))
+
+// ---------------------------------------------------------------------------
+// Chain resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the credential chain the way the stdio bootstrap does, then report which
+ * link won — by comparing the resolved values against each source, not by
+ * re-deriving the decision. That is why a stale auth.json cannot hide here: if
+ * the loaded instance URL came out of a file, this says which file.
+ */
+const resolveChain = async (supplied?: ServiceNowContext): Promise<{ context: ServiceNowContext; check: Check }> => {
+  const envInstance = envCredential("instanceUrl")
+  const envClientId = envCredential("clientId")
+  const envClientSecret = envCredential("clientSecret")
+
+  const files = authJsonPaths()
+    .filter((path) => existsSync(path))
+    .map((path) => ({ path, ...summarizeAuthFile(path) }))
+
+  const local = loadContext()
+  const enterprise =
+    supplied === undefined && local.instanceUrl === "" && loadEnterpriseAuth() ? await loadFromEnterprisePortal() : undefined
+  const context = supplied ?? enterprise ?? local
+
+  const fromEnv = !!envInstance && !!context.instanceUrl && context.instanceUrl.includes(stripScheme(envInstance.value))
+  const fromFile = fromEnv
+    ? undefined
+    : files.find((file) => file.instance !== undefined && context.instanceUrl.includes(stripScheme(file.instance)))
+  const source = context.enterprise
+    ? "the enterprise portal (credentials fetched at runtime)"
+    : fromEnv
+      ? `environment variables (${[envInstance, envClientId, envClientSecret]
+          .filter((hit) => hit !== undefined)
+          .map((hit) => hit.name)
+          .join(", ")})`
+      : fromFile
+        ? `${fromFile.path} (modified ${fromFile.modified})`
+        : undefined
+
+  // Every source that carries credentials but did not supply these ones. This
+  // is the "stale auth.json you forgot about" report, and it is also how a
+  // half-set environment shows up: variables that are set but were skipped
+  // because the environment link needs instance + id + secret together.
+  const unused = [
+    ...(!fromEnv && (envInstance || envClientId || envClientSecret)
+      ? [
+          `environment: ${[envInstance, envClientId, envClientSecret]
+            .filter((hit) => hit !== undefined)
+            .map((hit) => hit.name)
+            .join(", ")} set, but the environment link needs instance + client id + client secret together, so it was skipped`,
+        ]
+      : []),
+    ...files
+      .filter((file) => file !== fromFile && file.instance !== undefined)
+      .map((file) => `${file.path} holds credentials for ${file.instance}, modified ${file.modified} — not used`),
+  ]
+
+  if (!context.instanceUrl && !context.clientId && !context.username)
+    return {
+      context,
+      check: {
+        step: "credentials",
+        status: "fail",
+        code: "credentials-missing",
+        title: "No ServiceNow credentials found anywhere in the chain.",
+        detail: [
+          `environment: none of ${[...ENV_VARS.instanceUrl, ...ENV_VARS.clientId].join(", ")} are set`,
+          `auth.json: ${files.length === 0 ? `no file at any of the ${authJsonPaths().length} known paths` : files.map((file) => file.path).join(", ")}`,
+          "enterprise portal: no enterprise session on this machine",
+        ],
+        fix: [
+          "Set SNOW_INSTANCE_URL, SNOW_CLIENT_ID and SNOW_CLIENT_SECRET in your MCP client's env block.",
+          "The client id and secret come from System OAuth > Application Registry on the instance.",
+        ],
+      },
+    }
+
+  const missing = [
+    ...(context.instanceUrl ? [] : ["instance URL"]),
+    ...(context.clientId || context.username ? [] : ["client id"]),
+    ...(context.clientSecret || context.password ? [] : ["client secret"]),
+  ]
+
+  if (missing.length > 0)
+    return {
+      context,
+      check: {
+        step: "credentials",
+        status: "fail",
+        code: "credentials-partial",
+        title: `Incomplete credentials — missing ${missing.join(" and ")}.`,
+        detail: [...(source ? [`what was found came from ${source}`] : []), ...unused],
+        fix: [`Supply the missing value from the same place as the rest: ${source ?? "your MCP client's env block"}.`],
+      },
+    }
+
+  return {
+    context,
+    check: {
+      step: "credentials",
+      status: unused.length > 0 ? "warn" : "ok",
+      code: unused.length > 0 ? "credentials-shadowed" : "credentials-ok",
+      title: `Loaded from ${source ?? "the running server's own context — no local source matches it"}.`,
+      detail: [
+        `instance ${context.instanceUrl}`,
+        context.clientId ? `client id ${redact(context.clientId)}, client secret ${context.clientSecret ? "set" : "MISSING"}` : `username ${context.username}, password ${context.password ? "set" : "MISSING"}`,
+        ...(context.refreshToken ? ["a refresh token is present and will be tried first"] : []),
+        ...unused,
+      ],
+      fix: unused.length > 0 ? ["If the credentials above are not the ones you meant to use, remove the source you no longer want."] : [],
+    },
+  }
+}
+
+/**
+ * Enough of an auth.json to report it: which instance it points at and whether
+ * it holds credentials at all. Deliberately shallow — `loadFromAuthJson()` owns
+ * the real validation, this only has to be able to name the file.
+ */
+const summarizeAuthFile = (path: string): { instance?: string; modified: string } => {
+  const parsed = readJson(path)
+  const servicenow = asRecord(parsed?.servicenow) ?? parsed
+  const instance = str(servicenow?.instance)
+  return {
+    instance: instance && (servicenow?.clientId || servicenow?.username) ? instance : undefined,
+    modified: statSync(path).mtime.toISOString().slice(0, 10),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probing — observe only, decide nothing
+// ---------------------------------------------------------------------------
+
+const probe = async (url: string, authorization?: string): Promise<{ observed: Observed } | { failure: TransportFailure }> =>
+  fetch(url, {
+    headers: { Accept: "application/json", ...(authorization ? { Authorization: authorization } : {}) },
+    // Manual: a redirect to a login page is a finding, and following it would
+    // hide the status that identifies it.
+    redirect: "manual",
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  })
+    .then(async (response) => ({
+      observed: {
+        status: response.status,
+        contentType: response.headers.get("content-type") ?? undefined,
+        location: response.headers.get("location") ?? undefined,
+        body: (await response.text()).slice(0, BODY_CAP),
+      },
+    }))
+    .catch((error: unknown) => ({ failure: transportFailure(error) }))
+
+const exchangeToken = async (
+  baseUrl: string,
+  context: ServiceNowContext,
+  grant: "client_credentials" | "refresh_token",
+): Promise<{ check: Check; token?: string }> => {
+  const response = await fetch(`${baseUrl}/oauth_token.do`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: new URLSearchParams({
+      grant_type: grant,
+      client_id: context.clientId,
+      client_secret: context.clientSecret,
+      ...(grant === "refresh_token" ? { refresh_token: context.refreshToken ?? "" } : {}),
+    }),
+    redirect: "manual",
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  })
+    .then(async (result) => ({
+      observed: {
+        status: result.status,
+        contentType: result.headers.get("content-type") ?? undefined,
+        location: result.headers.get("location") ?? undefined,
+        body: (await result.text()).slice(0, BODY_CAP),
+      },
+    }))
+    .catch((error: unknown) => ({ failure: transportFailure(error) }))
+
+  if ("failure" in response) return { check: { ...classifyTransportFailure(response.failure), step: "token" } }
+  return { check: classifyTokenResponse(response.observed), token: str(parseJson(response.observed.body)?.access_token) }
+}
+
+const transportFailure = (error: unknown): TransportFailure => {
+  const record = asRecord(error)
+  const cause = asRecord(record?.cause)
+  return {
+    code: str(record?.code) ?? str(cause?.code) ?? str(record?.name),
+    message: str(record?.message) ?? String(error),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared classification
+// ---------------------------------------------------------------------------
+
+/**
+ * The failure this whole feature exists for: a hibernating developer instance
+ * answers every request — REST included — with an HTML page, so every tool
+ * looks like it has a JSON parse bug. Detected by content, because the status
+ * is usually 200 and the content-type is not always set.
+ */
+const htmlDiagnosis = (step: CheckStep, observed: Observed): Check | undefined => {
+  const isHtml = (observed.contentType ?? "").includes("text/html") || /^\s*<(!doctype|html)/i.test(observed.body)
+  if (!isHtml) return undefined
+
+  if (/hibernat/i.test(observed.body))
+    return {
+      step,
+      status: "fail",
+      code: "instance-hibernating",
+      title: "The instance is hibernating.",
+      detail: [`HTTP ${observed.status}, ${observed.contentType ?? "no content-type"}`, ...bodyDetail(observed)],
+      fix: [
+        "Sign in at https://developer.servicenow.com, open your instance and press Wake.",
+        "Give it a minute or two, then run this check again.",
+        "Until then every tool call fails with what looks like a JSON parse error — that is this page, not a bug.",
+      ],
+    }
+
+  return {
+    step,
+    status: "fail",
+    code: "html-instead-of-json",
+    title: "The instance answered with an HTML page instead of JSON.",
+    detail: [`HTTP ${observed.status}, ${observed.contentType ?? "no content-type"}`, ...bodyDetail(observed)],
+    fix: [
+      "Almost always a hibernating developer instance — wake it at https://developer.servicenow.com and wait a minute.",
+      "Otherwise this is a login page: something in front of the instance is intercepting the REST API, or the URL is not the instance root.",
+    ],
+  }
+}
+
+const classifyRoles = (observed: Observed): Check => {
+  const html = htmlDiagnosis("roles", observed)
+  if (html) return html
+
+  const body = parseJson(observed.body)
+  if (observed.status !== 200)
+    return {
+      step: "roles",
+      status: "skip",
+      code: "roles-unreadable",
+      title: "Could not read the roles of the authenticated account.",
+      detail: [`HTTP ${observed.status}`, ...(str(asRecord(body?.error)?.message) ? [`ServiceNow said: ${str(asRecord(body?.error)?.message)}`] : [])],
+      fix: ["Reading sys_user_has_role needs a role itself, so this usually means the account holds very few. Tool calls will still work where its roles allow."],
+    }
+
+  const held = [
+    ...new Set(
+      (asArray(asRecord(body)?.result) ?? [])
+        .map((row) => str(asRecord(row)?.["role.name"]))
+        .filter((role): role is string => role !== undefined),
+    ),
+  ].sort()
+
+  // Admin accounts hold hundreds of roles; the list is a hint, not an inventory.
+  const listed = held.length > 12 ? `${held.slice(0, 12).join(", ")} and ${held.length - 12} more` : held.join(", ")
+
+  const manifest = loadRolesManifest()
+  if (!manifest)
+    return {
+      step: "roles",
+      status: "ok",
+      code: "roles-listed",
+      title: held.length === 0 ? "The account holds no roles." : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
+      detail: ["sn-roles.manifest.json is not installed, so tool coverage was not computed"],
+      fix: [],
+    }
+
+  const coverage = summarizeRoleCoverage(manifest, held)
+  const detail = [
+    `${coverage.unlocked} of ${coverage.resolved} tools with a known role requirement are within reach; ${coverage.blocked} are not`,
+    `${coverage.unresolved} more tools have no statically resolvable requirement and were not counted`,
+  ]
+
+  if (coverage.blocked === 0)
+    return {
+      step: "roles",
+      status: "ok",
+      code: "roles-sufficient",
+      title: held.length === 0 ? "No roles held, and none are needed for the resolved catalog." : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
+      detail,
+      fix: [],
+    }
+
+  return {
+    step: "roles",
+    status: "warn",
+    code: held.length === 0 ? "roles-none" : "roles-partial",
+    title:
+      held.length === 0
+        ? `Authenticated, but the account holds no roles — ${coverage.blocked} tools need one.`
+        : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
+    detail,
+    fix: [
+      `Roles that would unlock the most: ${coverage.openers.map((opener) => `${opener.role} (+${opener.tools})`).join(", ")}`,
+      "This is not a setup error — it is what the account can do. Ask an admin for the role a failing tool needs.",
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small shared pieces
+// ---------------------------------------------------------------------------
+
+/** The order a request travels, which is the order the report reads in. */
+const STEPS: CheckStep[] = ["credentials", "instance-url", "instance", "token", "api", "roles"]
+
+/**
+ * Close the report, filling in the steps the walk never reached so it always
+ * shows all six and where it stopped.
+ *
+ * A warning or a skipped step is not a broken setup: "your account holds two
+ * roles" and "basic auth needs no token exchange" are findings, not failures.
+ */
+const finish = (checks: Check[], instanceUrl: string | undefined): SetupReport => {
+  const reached = new Set(checks.map((check) => check.step))
+  const padded = [...checks, ...STEPS.filter((step) => !reached.has(step)).map((step) => skipped(step, "Not reached — fix the checks above first."))].sort(
+    (a, b) => STEPS.indexOf(a.step) - STEPS.indexOf(b.step),
+  )
+  return { ok: padded.every((check) => check.status !== "fail"), instanceUrl, checks: padded }
+}
+
+const skipped = (step: CheckStep, why: string): Check => ({ step, status: "skip", code: `${step}-skipped`, title: why, detail: [], fix: [] })
+
+const withDetail = (check: Check, detail: string[]): Check => (detail.length === 0 ? check : { ...check, detail: [...check.detail, ...detail] })
+
+/** One line of the body, quoted back. Users recognise their own error page. */
+const bodyDetail = (observed: Observed): string[] => {
+  const sample = observed.body.replace(/\s+/g, " ").trim()
+  return sample === "" ? ["empty body"] : [`body: ${sample.slice(0, 160)}${sample.length > 160 ? "…" : ""}`]
+}
+
+const redact = (value: string): string => (value.length <= 4 ? "****" : `…${value.slice(-4)}`)
+
+const stripScheme = (value: string): string => value.replace(/^https?:\/\//, "").replace(/\/+$/, "")
+
+/** JSON.parse that answers undefined instead of throwing — these bodies are whatever the network handed us. */
+const parseJson = (body: string): Record<string, unknown> | undefined => {
+  try {
+    return asRecord(JSON.parse(body))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Read and parse a JSON file, answering undefined for anything that goes wrong.
+ * The doctor runs on machines where these files are half-written, owned by
+ * another user, or not JSON at all — none of which is a reason to crash the one
+ * command that is supposed to explain the mess.
+ */
+const readJson = (path: string | URL): Record<string, unknown> | undefined => {
+  try {
+    return parseJson(readFileSync(path, "utf8"))
+  } catch {
+    return undefined
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined)
+
+const asArray = (value: unknown): unknown[] | undefined => (Array.isArray(value) ? value : undefined)
+
+const str = (value: unknown): string | undefined => (typeof value === "string" && value !== "" ? value : undefined)

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
@@ -89,6 +89,17 @@ const PROBE_TIMEOUT_MS = 10_000
 const BODY_CAP = 256_000
 
 /**
+ * How many sys_user_has_role rows to ask for. One page, no paging: the report
+ * is a diagnosis, not an inventory. 500 is well above any human account, but an
+ * admin on a large instance can pass it — and a silently short list makes the
+ * coverage numbers wrong in the worst direction, telling the most privileged
+ * account on the instance that tools are out of its reach. So when the page
+ * comes back full, the report says the counts are a floor instead of asserting
+ * them.
+ */
+const ROLE_ROWS_CAP = 500
+
+/**
  * Run every check, in the order a request travels: which credentials the chain
  * produced, whether the URL is usable, whether the instance answers, whether
  * the token exchange succeeds, whether the API accepts the token, and what the
@@ -105,7 +116,10 @@ export const runSetupDoctor = async (options: { context?: ServiceNowContext } = 
   if (!url.baseUrl) return finish(checks, undefined)
 
   const reachability = await probe(`${url.baseUrl}/api/now/table/sys_properties?sysparm_limit=1`)
-  const reach = "failure" in reachability ? classifyTransportFailure(reachability.failure) : classifyReachability(reachability.observed)
+  const reach =
+    "failure" in reachability
+      ? classifyTransportFailure(reachability.failure)
+      : classifyReachability(reachability.observed)
   checks.push(reach)
   if (reach.status === "fail") return finish(checks, url.baseUrl)
 
@@ -124,13 +138,24 @@ export const runSetupDoctor = async (options: { context?: ServiceNowContext } = 
   // and a refused refresh falls through to the client-credentials grant rather
   // than ending the run. The doctor reports both outcomes so a stale refresh
   // token in auth.json cannot masquerade as a bad client secret.
-  const refreshed = hasOAuth && chain.context.refreshToken ? await exchangeToken(url.baseUrl, chain.context, "refresh_token") : undefined
-  const exchange = hasOAuth && refreshed?.token === undefined ? await exchangeToken(url.baseUrl, chain.context, "client_credentials") : refreshed
+  const refreshed =
+    hasOAuth && chain.context.refreshToken
+      ? await exchangeToken(url.baseUrl, chain.context, "refresh_token")
+      : undefined
+  const exchange =
+    hasOAuth && refreshed?.token === undefined
+      ? await exchangeToken(url.baseUrl, chain.context, "client_credentials")
+      : refreshed
   const authorization = exchange?.token ? `Bearer ${exchange.token}` : basic
 
   checks.push(
     exchange
-      ? withDetail(exchange.check, refreshed && refreshed !== exchange ? [`the refresh_token grant was refused first: ${refreshed.check.title}`] : [])
+      ? withDetail(
+          exchange.check,
+          refreshed && refreshed !== exchange
+            ? [`the refresh_token grant was refused first: ${refreshed.check.title}`]
+            : [],
+        )
       : skipped("token", "Basic auth configured — no OAuth token exchange happens."),
   )
 
@@ -147,7 +172,8 @@ export const runSetupDoctor = async (options: { context?: ServiceNowContext } = 
     }).toString()}`,
     authorization,
   )
-  const api = "failure" in identity ? classifyTransportFailure(identity.failure) : classifyApiResponse(identity.observed)
+  const api =
+    "failure" in identity ? classifyTransportFailure(identity.failure) : classifyApiResponse(identity.observed)
   checks.push(api)
   if (api.status === "fail") return finish(checks, url.baseUrl)
 
@@ -157,7 +183,7 @@ export const runSetupDoctor = async (options: { context?: ServiceNowContext } = 
     `${url.baseUrl}/api/now/table/sys_user_has_role?${new URLSearchParams({
       sysparm_query: "user=javascript:gs.getUserID()",
       sysparm_fields: "role.name",
-      sysparm_limit: "500",
+      sysparm_limit: String(ROLE_ROWS_CAP),
     }).toString()}`,
     authorization,
   )
@@ -266,14 +292,22 @@ export const inspectInstanceUrl = (raw: string | undefined): { check: Check; bas
   // A bare name — "dev12345" — is what developer.servicenow.com shows you, so
   // it gets pasted as-is. Complete it rather than failing on it, but say so:
   // the user's config is still wrong for every other tool that reads it.
-  const named = !parsed.hostname.includes(".")
-  const baseUrl = named ? `${parsed.protocol}//${parsed.hostname}.service-now.com` : parsed.origin
+  //
+  // Only when the value is nothing BUT that name, though. A single-label host
+  // with a scheme or a port is an on-prem instance behind corporate DNS
+  // ("https://snprod:8443") or a local test server, and rewriting it would
+  // point the probe — and the OAuth POST that carries the client secret —
+  // at a service-now.com tenant the user never configured.
+  const named = !parsed.hostname.includes(".") && parsed.port === "" && !value.includes("://")
+  const baseUrl = named ? `https://${parsed.hostname}.service-now.com` : parsed.origin
 
   const notes = [
     ...(named ? [`"${parsed.hostname}" is an instance name, not a host — reading it as ${baseUrl}`] : []),
     ...(!value.includes("://") ? ["no scheme — reading it as https"] : []),
     ...(parsed.pathname !== "/" || parsed.search !== "" || parsed.hash !== ""
-      ? [`everything after the host is ignored (${parsed.pathname}${parsed.search}${parsed.hash}) — this looks like a page URL, not the instance root`]
+      ? [
+          `everything after the host is ignored (${parsed.pathname}${parsed.search}${parsed.hash}) — this looks like a page URL, not the instance root`,
+        ]
       : []),
     // Left in place it becomes "https://host//oauth_token.do", because every
     // caller concatenates a path onto this value.
@@ -384,7 +418,10 @@ export const classifyTokenResponse = (observed: Observed): Check => {
   const body = parseJson(observed.body)
   const error = str(body?.error)
   const description = str(body?.error_description)
-  const quoted = [`HTTP ${observed.status}`, ...(error ? [`ServiceNow said: ${error}${description ? ` — ${description}` : ""}`] : bodyDetail(observed))]
+  const quoted = [
+    `HTTP ${observed.status}`,
+    ...(error ? [`ServiceNow said: ${error}${description ? ` — ${description}` : ""}`] : bodyDetail(observed)),
+  ]
 
   if (str(body?.access_token))
     return {
@@ -392,7 +429,9 @@ export const classifyTokenResponse = (observed: Observed): Check => {
       status: "ok",
       code: "token-ok",
       title: "OAuth token exchange succeeded.",
-      detail: [`token type ${str(body?.token_type) ?? "unknown"}, expires in ${typeof body?.expires_in === "number" ? body.expires_in : "?"}s`],
+      detail: [
+        `token type ${str(body?.token_type) ?? "unknown"}, expires in ${typeof body?.expires_in === "number" ? body.expires_in : "?"}s`,
+      ],
       fix: [],
     }
 
@@ -494,7 +533,9 @@ export const classifyApiResponse = (observed: Observed): Check => {
       code: "api-forbidden",
       title: "Authenticated, but not allowed to read sys_user.",
       detail: ["HTTP 403", ...(message ? [`ServiceNow said: ${message}`] : bodyDetail(observed))],
-      fix: ["The account authenticated fine — it just holds no role that can read sys_user. Ask an admin to grant it one (itil or snc_internal is enough to start)."],
+      fix: [
+        "The account authenticated fine — it just holds no role that can read sys_user. Ask an admin to grant it one (itil or snc_internal is enough to start).",
+      ],
     }
 
   if (observed.status !== 200)
@@ -535,15 +576,45 @@ export const classifyApiResponse = (observed: Observed): Check => {
  */
 export const classifyTransportFailure = (failure: TransportFailure): Check => {
   const haystack = `${failure.code ?? ""} ${failure.message}`.toLowerCase()
-  const reason = haystack.includes("enotfound") || haystack.includes("eai_again") || haystack.includes("getaddrinfo") || haystack.includes("dns")
-    ? { code: "instance-dns", title: "The instance host does not resolve.", fix: ["Check the host for a typo. A developer instance is dev12345.service-now.com — the number is on your developer.servicenow.com dashboard."] }
-    : haystack.includes("econnrefused") || haystack.includes("connectionrefused") || haystack.includes("unable to connect")
-      ? { code: "instance-refused", title: "The instance refused the connection.", fix: ["Nothing is listening on that host and port. Check the URL, and whether the instance is reachable from this network (VPN, proxy)."] }
-      : haystack.includes("timeout") || haystack.includes("timed out") || haystack.includes("aborted")
-        ? { code: "instance-timeout", title: `The instance did not answer within ${PROBE_TIMEOUT_MS / 1000}s.`, fix: ["A hibernating instance can hang like this while it wakes. Open it in a browser, then try again."] }
-        : haystack.includes("cert") || haystack.includes("tls") || haystack.includes("ssl")
-          ? { code: "instance-tls", title: "The TLS handshake failed.", fix: ["A corporate proxy that re-signs TLS needs its CA trusted by node (NODE_EXTRA_CA_CERTS)."] }
-          : { code: "instance-unreachable", title: "The instance could not be reached.", fix: ["Check network access to the instance from this machine."] }
+  const reason =
+    haystack.includes("enotfound") ||
+    haystack.includes("eai_again") ||
+    haystack.includes("getaddrinfo") ||
+    haystack.includes("dns")
+      ? {
+          code: "instance-dns",
+          title: "The instance host does not resolve.",
+          fix: [
+            "Check the host for a typo. A developer instance is dev12345.service-now.com — the number is on your developer.servicenow.com dashboard.",
+          ],
+        }
+      : haystack.includes("econnrefused") ||
+          haystack.includes("connectionrefused") ||
+          haystack.includes("unable to connect")
+        ? {
+            code: "instance-refused",
+            title: "The instance refused the connection.",
+            fix: [
+              "Nothing is listening on that host and port. Check the URL, and whether the instance is reachable from this network (VPN, proxy).",
+            ],
+          }
+        : haystack.includes("timeout") || haystack.includes("timed out") || haystack.includes("aborted")
+          ? {
+              code: "instance-timeout",
+              title: `The instance did not answer within ${PROBE_TIMEOUT_MS / 1000}s.`,
+              fix: ["A hibernating instance can hang like this while it wakes. Open it in a browser, then try again."],
+            }
+          : haystack.includes("cert") || haystack.includes("tls") || haystack.includes("ssl")
+            ? {
+                code: "instance-tls",
+                title: "The TLS handshake failed.",
+                fix: ["A corporate proxy that re-signs TLS needs its CA trusted by node (NODE_EXTRA_CA_CERTS)."],
+              }
+            : {
+                code: "instance-unreachable",
+                title: "The instance could not be reached.",
+                fix: ["Check network access to the instance from this machine."],
+              }
 
   return {
     step: "instance",
@@ -585,7 +656,10 @@ export const summarizeRoleCoverage = (manifest: unknown, held: string[]): RoleCo
 
   const owned = new Set(held)
   const blocked = tools.filter(
-    (tool) => tool.bundle.length > 0 && !tool.anyOf.some((role) => owned.has(role)) && !tool.bundle.every((role) => owned.has(role)),
+    (tool) =>
+      tool.bundle.length > 0 &&
+      !tool.anyOf.some((role) => owned.has(role)) &&
+      !tool.bundle.every((role) => owned.has(role)),
   )
 
   const openers = Object.entries(
@@ -637,7 +711,9 @@ const resolveChain = async (supplied?: ServiceNowContext): Promise<{ context: Se
 
   const local = loadContext()
   const enterprise =
-    supplied === undefined && local.instanceUrl === "" && loadEnterpriseAuth() ? await loadFromEnterprisePortal() : undefined
+    supplied === undefined && local.instanceUrl === "" && loadEnterpriseAuth()
+      ? await loadFromEnterprisePortal()
+      : undefined
   const context = supplied ?? enterprise ?? local
 
   const fromEnv = !!envInstance && !!context.instanceUrl && context.instanceUrl.includes(stripScheme(envInstance.value))
@@ -665,7 +741,9 @@ const resolveChain = async (supplied?: ServiceNowContext): Promise<{ context: Se
           `environment: ${[envInstance, envClientId, envClientSecret]
             .filter((hit) => hit !== undefined)
             .map((hit) => hit.name)
-            .join(", ")} set, but the environment link needs instance + client id + client secret together, so it was skipped`,
+            .join(
+              ", ",
+            )} set, but the environment link needs instance + client id + client secret together, so it was skipped`,
         ]
       : []),
     ...files
@@ -721,11 +799,16 @@ const resolveChain = async (supplied?: ServiceNowContext): Promise<{ context: Se
       title: `Loaded from ${source ?? "the running server's own context — no local source matches it"}.`,
       detail: [
         `instance ${context.instanceUrl}`,
-        context.clientId ? `client id ${redact(context.clientId)}, client secret ${context.clientSecret ? "set" : "MISSING"}` : `username ${context.username}, password ${context.password ? "set" : "MISSING"}`,
+        context.clientId
+          ? `client id ${redact(context.clientId)}, client secret ${context.clientSecret ? "set" : "MISSING"}`
+          : `username ${context.username}, password ${context.password ? "set" : "MISSING"}`,
         ...(context.refreshToken ? ["a refresh token is present and will be tried first"] : []),
         ...unused,
       ],
-      fix: unused.length > 0 ? ["If the credentials above are not the ones you meant to use, remove the source you no longer want."] : [],
+      fix:
+        unused.length > 0
+          ? ["If the credentials above are not the ones you meant to use, remove the source you no longer want."]
+          : [],
     },
   }
 }
@@ -749,7 +832,10 @@ const summarizeAuthFile = (path: string): { instance?: string; modified: string 
 // Probing — observe only, decide nothing
 // ---------------------------------------------------------------------------
 
-const probe = async (url: string, authorization?: string): Promise<{ observed: Observed } | { failure: TransportFailure }> =>
+const probe = async (
+  url: string,
+  authorization?: string,
+): Promise<{ observed: Observed } | { failure: TransportFailure }> =>
   fetch(url, {
     headers: { Accept: "application/json", ...(authorization ? { Authorization: authorization } : {}) },
     // Manual: a redirect to a login page is a finding, and following it would
@@ -795,7 +881,10 @@ const exchangeToken = async (
     .catch((error: unknown) => ({ failure: transportFailure(error) }))
 
   if ("failure" in response) return { check: { ...classifyTransportFailure(response.failure), step: "token" } }
-  return { check: classifyTokenResponse(response.observed), token: str(parseJson(response.observed.body)?.access_token) }
+  return {
+    check: classifyTokenResponse(response.observed),
+    token: str(parseJson(response.observed.body)?.access_token),
+  }
 }
 
 const transportFailure = (error: unknown): TransportFailure => {
@@ -859,17 +948,24 @@ const classifyRoles = (observed: Observed): Check => {
       status: "skip",
       code: "roles-unreadable",
       title: "Could not read the roles of the authenticated account.",
-      detail: [`HTTP ${observed.status}`, ...(str(asRecord(body?.error)?.message) ? [`ServiceNow said: ${str(asRecord(body?.error)?.message)}`] : [])],
-      fix: ["Reading sys_user_has_role needs a role itself, so this usually means the account holds very few. Tool calls will still work where its roles allow."],
+      detail: [
+        `HTTP ${observed.status}`,
+        ...(str(asRecord(body?.error)?.message) ? [`ServiceNow said: ${str(asRecord(body?.error)?.message)}`] : []),
+      ],
+      fix: [
+        "Reading sys_user_has_role needs a role itself, so this usually means the account holds very few. Tool calls will still work where its roles allow.",
+      ],
     }
 
+  const rows = asArray(asRecord(body)?.result) ?? []
   const held = [
-    ...new Set(
-      (asArray(asRecord(body)?.result) ?? [])
-        .map((row) => str(asRecord(row)?.["role.name"]))
-        .filter((role): role is string => role !== undefined),
-    ),
+    ...new Set(rows.map((row) => str(asRecord(row)?.["role.name"])).filter((role): role is string => role !== undefined)),
   ].sort()
+
+  const capped =
+    rows.length >= ROLE_ROWS_CAP
+      ? [`the query returned its full ${ROLE_ROWS_CAP}-row page, so this list is cut off and the counts below are a floor`]
+      : []
 
   // Admin accounts hold hundreds of roles; the list is a hint, not an inventory.
   const listed = held.length > 12 ? `${held.slice(0, 12).join(", ")} and ${held.length - 12} more` : held.join(", ")
@@ -880,13 +976,17 @@ const classifyRoles = (observed: Observed): Check => {
       step: "roles",
       status: "ok",
       code: "roles-listed",
-      title: held.length === 0 ? "The account holds no roles." : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
-      detail: ["sn-roles.manifest.json is not installed, so tool coverage was not computed"],
+      title:
+        held.length === 0
+          ? "The account holds no roles."
+          : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
+      detail: [...capped, "sn-roles.manifest.json is not installed, so tool coverage was not computed"],
       fix: [],
     }
 
   const coverage = summarizeRoleCoverage(manifest, held)
   const detail = [
+    ...capped,
     `${coverage.unlocked} of ${coverage.resolved} tools with a known role requirement are within reach; ${coverage.blocked} are not`,
     `${coverage.unresolved} more tools have no statically resolvable requirement and were not counted`,
   ]
@@ -896,7 +996,10 @@ const classifyRoles = (observed: Observed): Check => {
       step: "roles",
       status: "ok",
       code: "roles-sufficient",
-      title: held.length === 0 ? "No roles held, and none are needed for the resolved catalog." : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
+      title:
+        held.length === 0
+          ? "No roles held, and none are needed for the resolved catalog."
+          : `${held.length} role${held.length === 1 ? "" : "s"}: ${listed}`,
       detail,
       fix: [],
     }
@@ -933,15 +1036,26 @@ const STEPS: CheckStep[] = ["credentials", "instance-url", "instance", "token", 
  */
 const finish = (checks: Check[], instanceUrl: string | undefined): SetupReport => {
   const reached = new Set(checks.map((check) => check.step))
-  const padded = [...checks, ...STEPS.filter((step) => !reached.has(step)).map((step) => skipped(step, "Not reached — fix the checks above first."))].sort(
-    (a, b) => STEPS.indexOf(a.step) - STEPS.indexOf(b.step),
-  )
+  const padded = [
+    ...checks,
+    ...STEPS.filter((step) => !reached.has(step)).map((step) =>
+      skipped(step, "Not reached — fix the checks above first."),
+    ),
+  ].sort((a, b) => STEPS.indexOf(a.step) - STEPS.indexOf(b.step))
   return { ok: padded.every((check) => check.status !== "fail"), instanceUrl, checks: padded }
 }
 
-const skipped = (step: CheckStep, why: string): Check => ({ step, status: "skip", code: `${step}-skipped`, title: why, detail: [], fix: [] })
+const skipped = (step: CheckStep, why: string): Check => ({
+  step,
+  status: "skip",
+  code: `${step}-skipped`,
+  title: why,
+  detail: [],
+  fix: [],
+})
 
-const withDetail = (check: Check, detail: string[]): Check => (detail.length === 0 ? check : { ...check, detail: [...check.detail, ...detail] })
+const withDetail = (check: Check, detail: string[]): Check =>
+  detail.length === 0 ? check : { ...check, detail: [...check.detail, ...detail] }
 
 /** One line of the body, quoted back. Users recognise their own error page. */
 const bodyDetail = (observed: Observed): string[] => {

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/connectors/snow_check_health.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/connectors/snow_check_health.ts
@@ -65,8 +65,8 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
     if (msg.includes("Failed to obtain access token") || status === 401) {
       return createErrorResult(
         `Authentication failed. Your access token may be expired.\n\n` +
-        `Run: serac auth login\n\n` +
-        `If you've already logged in, check: serac auth status`
+        `Run \`servicenow-mcp-stdio --doctor\`, or call snow_diagnose_setup, to find out which part of the setup is wrong. ` +
+        `It reads the raw responses instead of going through the auth manager, so it still answers when this tool cannot.`
       )
     }
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/index.ts
@@ -4,6 +4,10 @@
 
 export { toolDefinition as snow_url_doctor_def, execute as snow_url_doctor_exec } from "./snow_url_doctor.js"
 export {
+  toolDefinition as snow_diagnose_setup_def,
+  execute as snow_diagnose_setup_exec,
+} from "./snow_diagnose_setup.js"
+export {
   toolDefinition as snow_session_context_def,
   execute as snow_session_context_exec,
 } from "./snow_session_context.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_diagnose_setup.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_diagnose_setup.ts
@@ -1,0 +1,56 @@
+/**
+ * snow_diagnose_setup - Explain why ServiceNow calls fail
+ *
+ * The model's half of the diagnostic. `servicenow-mcp-stdio --doctor` prints
+ * the same report in a terminal, but an MCP server usually runs inside a client
+ * that hides its stderr, so the person who has to fix the OAuth entry never
+ * sees it. Here the report comes back in the conversation, where they are.
+ *
+ * Everything it knows lives in shared/setup-doctor.ts.
+ *
+ * Why this is not snow_test_connection / snow_check_health /
+ * snow_validate_live_connection: all three start with
+ * `getAuthenticatedClient()`, so when the credentials are the problem they
+ * fail with the same opaque error the user already had, before they can report
+ * anything. This one never goes through the auth manager. It observes the raw
+ * responses — status, content-type, body — and classifies them, which is the
+ * only way to say "that is a hibernation page, not a parse bug" about a
+ * response that arrives as HTTP 200.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { createSuccessResult } from "../../shared/error-handler.js"
+import { renderReport, runSetupDoctor } from "../../shared/setup-doctor.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_diagnose_setup",
+  description:
+    "Diagnose the ServiceNow connection: which credential source was used (environment variables, auth.json, enterprise portal), whether the instance URL is well-formed, whether the instance is awake or hibernating, whether the OAuth token exchange succeeds, and which roles the authenticated account holds. Call this when a tool fails with an authentication error, a 401, or a response that will not parse as JSON — a hibernating developer instance answers with an HTML login page, and every tool then looks like it has a parse bug. Returns a report naming the broken link and what to do about it.",
+  category: "platform",
+  subcategory: "diagnostics",
+  use_cases: ["setup", "authentication", "credentials", "oauth", "connection", "hibernating", "troubleshooting", "roles"],
+  complexity: "beginner",
+  frequency: "medium",
+  permission: "read",
+  allowedRoles: ["developer", "stakeholder", "admin"],
+  // stdio only, and not for the usual filesystem reason: the report names this
+  // process's environment variables and auth.json files. On HTTP one process
+  // serves every customer, so that report would describe the server's own
+  // configuration to whichever tenant asked for it.
+  transports: ["stdio"],
+  inputSchema: {
+    type: "object",
+    properties: {},
+  },
+}
+
+export async function execute(_args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const report = await runSetupDoctor({ context })
+  // Always a success envelope: the diagnosis ran. Whether the setup is healthy
+  // is `report.ok`, and an error envelope here would read as "the diagnostic
+  // failed" and invite a retry.
+  return createSuccessResult(report, { ok: report.ok }, renderReport(report))
+}
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_diagnose_setup.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_diagnose_setup.ts
@@ -9,10 +9,13 @@
  * Everything it knows lives in shared/setup-doctor.ts.
  *
  * Why this is not snow_test_connection / snow_check_health /
- * snow_validate_live_connection: all three start with
+ * snow_validate_live_connection / snow_auth_diagnostics: all four start with
  * `getAuthenticatedClient()`, so when the credentials are the problem they
  * fail with the same opaque error the user already had, before they can report
- * anything. This one never goes through the auth manager. It observes the raw
+ * anything. snow_auth_diagnostics is the closest by name, and the one a search
+ * for "authentication diagnostics" is most likely to surface — it reports on a
+ * connection that already works. This one never goes through the auth manager.
+ * It observes the raw
  * responses — status, content-type, body — and classifies them, which is the
  * only way to say "that is a hibernation page, not a parse bug" about a
  * response that arrives as HTTP 200.
@@ -28,7 +31,16 @@ export const toolDefinition: MCPToolDefinition = {
     "Diagnose the ServiceNow connection: which credential source was used (environment variables, auth.json, enterprise portal), whether the instance URL is well-formed, whether the instance is awake or hibernating, whether the OAuth token exchange succeeds, and which roles the authenticated account holds. Call this when a tool fails with an authentication error, a 401, or a response that will not parse as JSON — a hibernating developer instance answers with an HTML login page, and every tool then looks like it has a parse bug. Returns a report naming the broken link and what to do about it.",
   category: "platform",
   subcategory: "diagnostics",
-  use_cases: ["setup", "authentication", "credentials", "oauth", "connection", "hibernating", "troubleshooting", "roles"],
+  use_cases: [
+    "setup",
+    "authentication",
+    "credentials",
+    "oauth",
+    "connection",
+    "hibernating",
+    "troubleshooting",
+    "roles",
+  ],
   complexity: "beginner",
   frequency: "medium",
   permission: "read",

--- a/packages/servicenow-mcp/tools.json
+++ b/packages/servicenow-mcp/tools.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-15T13:16:53.565Z",
-  "count": 437,
+  "generatedAt": "2026-08-16T21:13:18.874Z",
+  "count": 438,
   "groups": [
     {
       "name": "access-control",
@@ -8204,6 +8204,32 @@
       "name": "diagnostics",
       "displayName": "Diagnostics",
       "tools": [
+        {
+          "name": "snow_diagnose_setup",
+          "description": "Diagnose the ServiceNow connection: which credential source was used (environment variables, auth.json, enterprise portal), whether the instance URL is well-formed, whether the instance is awake or hibernating, whether the OAuth token exchange succeeds, and which roles the authenticated account holds. Call this when a tool fails with an authentication error, a 401, or a response that will not parse as JSON — a hibernating developer instance answers with an HTML login page, and every tool then looks like it has a parse bug. Returns a report naming the broken link and what to do about it.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "setup",
+            "authentication",
+            "credentials",
+            "oauth",
+            "connection",
+            "hibernating",
+            "troubleshooting",
+            "roles"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
         {
           "name": "snow_validate_live_connection",
           "description": "Validates ServiceNow connection status, authentication tokens, and user permissions. Returns detailed diagnostics with response times.",


### PR DESCRIPTION
### Issue for this PR

Closes #293

### Type of change

- [x] Bug fix
- [x] New tool or skill
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Setting up OAuth on an instance you have never used is where people fall off, and when it goes wrong the
error turns up much later inside some unrelated tool call. `servicenow-mcp-stdio --doctor` (and
`snow_diagnose_setup`, so the model can ask too) walks the same credential chain the server walks and says
which link is broken: which source supplied the credentials and which sources were present but ignored,
whether the URL is usable, whether the instance is awake, whether the token exchange succeeded and what
ServiceNow actually returned, and how much of the catalog the account's roles reach according to
`sn-roles.manifest.json`. A hibernating developer instance gets named outright, since it answers with an HTML
login page and that is why every tool looks like it has a parse bug.

The first commit is a separate bug I hit while reading the chain: `loadContext()` never read
`SNOW_INSTANCE_URL`, the variable the quick start, CONTRIBUTING and SECURITY.md all tell you to set. Copy the
documented config and you got a server with no instance URL. Say the word and I will split it onto its own
issue.

The classifiers are pure functions from (status, content-type, body) to a diagnosis, so they are tested
against ServiceNow-shaped payloads instead of a mocked HTTP client.

### How did you verify it works?

`bun typecheck` clean, `bun run lint` 0 errors / 1758 warnings (1761 on main), 294 tests in servicenow-mcp
and 60 in skills, `generate:tools-json --check` in sync at 438.

Behaviour I drove against a real local HTTP server standing in for an instance: a hibernation page gives
`instance-hibernating` and nothing is ever POSTed to `/oauth_token.do`; `invalid_client` is reported apart
from `invalid_grant` with ServiceNow's own text quoted; an account with no roles warns rather than fails. I
built the package and ran the built `--doctor` under node 20, where the report goes to stdout and the manifest
resolves from `dist/`. I also replayed the publish workflow's JSON-purity assert against that build: one
stdout line, valid JSON, nothing on stderr. The `--doctor` path exits before the transport connects, so it
cannot touch the protocol channel.

I have no ServiceNow instance and no outbound network here, so none of this has talked to a real box. The
payload shapes are modelled on what ServiceNow documents, not captured, which is why the classifiers key off
structure and the RFC 6749 error code rather than ServiceNow's prose. Against a developer instance, please
run `--doctor` with good credentials, then with the secret mangled (expect `oauth-client-rejected`), then
against a hibernating instance (expect `instance-hibernating`), then with an OAuth entry that has no OAuth
application user (expect `oauth-grant-rejected`, not the client one).

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json`
- [x] If I added or changed a skill, I re-ran the skills `generate`
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
