### PR TITLE
feat(skills): publish @serac-labs/skills to npm

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -9,17 +9,27 @@ name: Publish skills
 # IMPORTANT: npm binds a Trusted Publisher to owner + repo + WORKFLOW FILENAME.
 # This file must stay named "publish-skills.yml", and a trusted publisher for
 # @serac-labs/skills pointing at serac-labs/serac + publish-skills.yml
-# (environment blank) must exist on npmjs.com before the first publish from
-# here. IT DOES NOT EXIST YET — the package has never been published, and npm
-# configures the binding on the package's own settings page, so a human has to
-# put the first version on the registry by hand (from packages/skills, after
-# `bun run script/build-for-publish.ts`, with a granular write token), bind the
-# publisher, and release everything after that from here. The provenance check
-# at the end of this job is what makes a missing or mis-typed binding loud: a
-# publish that lands without an attestation fails the run instead of quietly
-# shipping unsigned bits. Note that after a manual 0.1.0 the first dispatch of
-# this workflow must carry a bumped version — the pre-flight below refuses to
-# republish a version that is already on the registry.
+# (environment blank) has to exist on npmjs.com for anything here to publish —
+# check that on the package's settings page before dispatching. The provenance
+# check at the end of this job is what makes a missing or mis-typed binding
+# loud: a publish that lands without an attestation fails the run instead of
+# quietly shipping unsigned bits.
+#
+# FIRST RELEASE ONLY: npm configures that binding on a package's own settings
+# page, and a name that has never been published has no such page. That was the
+# state when this file was written, so unless npm has since grown a way to
+# pre-register an unpublished name, version one goes out by hand — and
+# therefore unsigned — and everything after it from here:
+#
+#   cd packages/skills
+#   bun install
+#   bun run script/build-for-publish.ts   # rewrites exports to dist/ IN PLACE
+#   npm publish --access public           # with a granular write token
+#   git checkout package.json             # that rewrite is not undone for you
+#
+# Then create the trusted publisher, and bump the version before the first
+# dispatch: the pre-flight below refuses to republish a version that is already
+# on the registry.
 #
 # TRIGGER: workflow_dispatch, deliberately, not a tag or a branch push.
 #   - The version is read from packages/skills/package.json and nowhere else. A
@@ -303,6 +313,19 @@ jobs:
             const missing = targets.filter(([, file]) => !inTarball(file))
             const unshipped = onDisk.filter((name) => !files.has(`${name}/SKILL.md`))
 
+            // The other direction, and the one a wildcard `files` actually gets
+            // wrong: everything in the tarball must be something we meant to
+            // publish. `*/**` matches dot-directories — that is why `!.turbo/**`
+            // is in `files` — so the junit report the test step writes three
+            // steps above shipped to the registry until `!.artifacts/**` was
+            // added. No absence check can ever see that; only a list of what
+            // belongs can.
+            const skillFiles = new Set(onDisk.map((name) => `${name}/SKILL.md`))
+            const documentation = (path) => !path.includes("/") && /^(package\.json|README|LICEN[CS]E|NOTICE|CHANGELOG)/.test(path)
+            const unexpected = [...files].filter(
+              (path) => !path.startsWith("dist/") && !skillFiles.has(path) && !documentation(path),
+            )
+
             for (const [name, file] of targets) console.log(`${inTarball(file) ? "ok  " : "MISS"}  ${name} -> ${file}`)
             console.log(`\n${packed.name}@${packed.version}: ${packed.entryCount} files, ${(packed.size / 1024).toFixed(1)} kB packed`)
 
@@ -318,12 +341,16 @@ jobs:
               console.error(`\n::error::${unshipped.length} skill director(ies) on disk are not in the tarball — check "files"`)
               for (const name of unshipped) console.error(`  ${name}`)
             }
+            if (unexpected.length > 0) {
+              console.error(`\n::error::${unexpected.length} file(s) in the tarball are neither dist/, a skill, nor documentation — check "files"`)
+              for (const path of unexpected) console.error(`  ${path}`)
+            }
             if (onDisk.length < 50) {
               console.error(`\n::error::only ${onDisk.length} skill directories on disk; the working tree is not what we think it is`)
               process.exit(1)
             }
-            if (unbuilt.length + missing.length + unshipped.length > 0) process.exit(1)
-            console.log(`gate: ${targets.length} published entrypoints and all ${onDisk.length} skill directories are in the tarball`)
+            if (unbuilt.length + missing.length + unshipped.length + unexpected.length > 0) process.exit(1)
+            console.log(`gate: ${targets.length} published entrypoints and all ${onDisk.length} skill directories are in the tarball, and nothing else is`)
         run: |
           set -euo pipefail
           printf '%s' "$GATE_JS" > "$RUNNER_TEMP/gate.mjs"

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,0 +1,512 @@
+name: Publish skills
+
+# Standalone release for @serac-labs/skills, modelled on publish-mcp.yml.
+#
+# The skills half of this repo has never been on npm: consuming it meant
+# cloning the repo, while the MCP server it is meant to be paired with installs
+# in one command. This workflow is the other half of that pair.
+#
+# IMPORTANT: npm binds a Trusted Publisher to owner + repo + WORKFLOW FILENAME.
+# This file must stay named "publish-skills.yml", and a trusted publisher for
+# @serac-labs/skills pointing at serac-labs/serac + publish-skills.yml
+# (environment blank) must exist on npmjs.com before the first publish from
+# here. IT DOES NOT EXIST YET — the package has never been published, and npm
+# configures the binding on the package's own settings page, so a human has to
+# put the first version on the registry by hand (from packages/skills, after
+# `bun run script/build-for-publish.ts`, with a granular write token), bind the
+# publisher, and release everything after that from here. The provenance check
+# at the end of this job is what makes a missing or mis-typed binding loud: a
+# publish that lands without an attestation fails the run instead of quietly
+# shipping unsigned bits. Note that after a manual 0.1.0 the first dispatch of
+# this workflow must carry a bumped version — the pre-flight below refuses to
+# republish a version that is already on the registry.
+#
+# TRIGGER: workflow_dispatch, deliberately, not a tag or a branch push.
+#   - The version is read from packages/skills/package.json and nowhere else. A
+#     tag would be a second version source that can disagree with the manifest.
+#   - Publishing is not idempotent: npm 403s on a republish. An automatic
+#     trigger therefore makes most runs guaranteed failures, and the pressure to
+#     silence those failures is how `continue-on-error` got bolted onto the old
+#     publish-npm.yml — which then reported success while publishing nothing for
+#     two months.
+#   - GitHub records who dispatched a run, so releases stay attributable.
+#   - The npm trusted publisher binds to the workflow file, not to the event, so
+#     dispatch is fully compatible with OIDC provenance.
+# pull_request runs the SAME build/test/gate steps and stops short of
+# publishing, so the release path is exercised on every PR that touches the
+# package instead of being discovered broken at release time.
+#
+# PROMOTION IS NOT A DISPATCH OF THIS WORKFLOW. dist_tag chooses the tag a NEW
+# version publishes under; it cannot re-tag a version already on npm. Moving
+# `latest` onto a published version is one command, run by a human with npm
+# write access:
+#
+#   npm dist-tag add @serac-labs/skills@<version> latest
+#
+# It is not automated here because OIDC trusted publishing mints credentials as
+# part of `npm publish` itself — `npm dist-tag` in this job would have no token
+# to authenticate with.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "npm dist-tag for the version in package.json. Cannot re-tag an already-published version — see the header."
+        type: choice
+        options:
+          - next
+          - latest
+        default: next
+      dry_run:
+        description: "Build, test and gate, but stop before npm publish"
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - "packages/skills/**"
+      - ".github/workflows/publish-skills.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # A publish is not idempotent, so an in-flight release must never be cancelled
+  # out from under itself by a newer run. PR verification is disposable.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    # Every shell step runs inside the package. Nothing here reads the repo
+    # root's node_modules or its install.
+    working-directory: packages/skills
+
+jobs:
+  publish:
+    name: build, gate and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing + signed provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          # Repo-root package.json — its packageManager field is the single bun
+          # pin for the monorepo. Action inputs are not affected by defaults.run.
+          bun-version-file: package.json
+
+      # npm pinned to a major rather than `@latest`: npm 12 requires node >= 22,
+      # so `@latest` would silently break this job on an older runner image. A
+      # major pin still satisfies the >= 11.5.1 that OIDC trusted publishing
+      # needs and will not jump an engine requirement underneath us.
+      - name: Upgrade npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@^12
+
+      - name: Configure npm for OIDC publishing
+        # The empty _authToken line is required for npm to recognise OIDC mode;
+        # without it the CLI falls back to anonymous and 401s.
+        run: |
+          rm -f ~/.npmrc .npmrc
+          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=" >> ~/.npmrc
+          echo "npm $(npm --version) configured for OIDC"
+
+      - name: Read version from packages/skills/package.json
+        id: version
+        # The ONLY version source. No tag name, no sibling package, no
+        # registry-derived increment: what the manifest says is what publishes,
+        # so "git show <sha>:packages/skills/package.json" always explains a
+        # published version.
+        run: |
+          set -euo pipefail
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          test -n "$VERSION" || { echo "::error::package.json has no version"; exit 1; }
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "$NAME@$VERSION (from packages/skills/package.json)"
+
+      # Only on the publish path. On a pull_request run nothing is published, so
+      # "this version already exists" is not a problem to report — it is the
+      # normal state between releases.
+      - name: Pre-flight — version is publishable
+        if: github.event_name != 'pull_request'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag || 'next' }}
+        # Fail here, before a full build, rather than on npm's 403 at the very
+        # end. "npm view pkg@missing-version" exits non-zero with E404, so empty
+        # stdout is the "not published yet" signal — which is also the state of
+        # the whole package until the first release.
+        run: |
+          set -euo pipefail
+          PUBLISHED=$(npm view "$NAME@$VERSION" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "::error::$NAME@$VERSION is already on npm. Bump the version in packages/skills/package.json."
+            exit 1
+          fi
+          case "$VERSION" in
+            *-*)
+              if [ "$DIST_TAG" = "latest" ]; then
+                echo "::error::$VERSION is a prerelease; publishing it as latest would hand it to every plain npm install. Use dist_tag=latest only for a stable version."
+                exit 1
+              fi
+              ;;
+          esac
+
+          CURRENT=$(npm view "$NAME" version 2>/dev/null || true)
+          echo "current registry latest: ${CURRENT:-none}"
+
+          # Monotonicity. "Not yet published" is not the same as "newer": a
+          # hotfix branch can hold an unpublished 0.1.1 long after 0.2.0 went
+          # out, and dispatching that with dist_tag=latest walks the tag
+          # BACKWARDS — every plain `npm install` silently downgrades. The check
+          # applies to `latest` only; staging an older line on `next` is fine.
+          if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ]; then
+            NEWEST=$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -1)
+            if [ "$NEWEST" != "$VERSION" ]; then
+              echo "::error::$VERSION is older than the registry's current latest ($CURRENT). Publishing it as latest would downgrade every consumer. Use dist_tag=next."
+              exit 1
+            fi
+          fi
+          echo "$NAME@$VERSION is unpublished; will go out under dist-tag '$DIST_TAG'"
+
+      - name: Install dependencies
+        # This resolves through the WORKSPACE, not just this directory: `bun
+        # install` inside a workspace member walks up to the repo-root
+        # package.json and writes the root bun.lock.
+        #
+        # --ignore-scripts keeps the release independent of whatever lifecycle
+        # scripts the repo root grows. Nothing in this package's dependency tree
+        # declares an install script; it has no runtime dependencies at all.
+        run: bun install --frozen-lockfile --ignore-scripts
+        working-directory: .
+
+      - name: Run tests
+        run: bun run test:ci
+
+      - name: Gate — the package builds and tests with no monorepo around it
+        # This package must survive the rest of the repo being deleted around
+        # it. Copy it out of the workspace and do a real install/build/test
+        # there: no repo-root package.json, no root node_modules, no hoisting,
+        # no workspace: links. A missing devDependency (this package grew a tsc
+        # dependency the moment it grew a build) fails here, on every PR.
+        #
+        # The suite is written to tolerate the sibling MCP package being absent
+        # — the "every tool a skill declares exists" test skips rather than
+        # fails — so this leg checks the skills themselves, and the leg above,
+        # inside the workspace, is the one that checks them against the tools.
+        run: |
+          set -euo pipefail
+          STANDALONE="$RUNNER_TEMP/standalone"
+          rm -rf "$STANDALONE"
+          mkdir -p "$STANDALONE"
+          tar -cf - --exclude=node_modules --exclude=dist . | tar -xf - -C "$STANDALONE"
+          cd "$STANDALONE"
+          test ! -e ../package.json || { echo "::error::standalone dir has a parent manifest; the test is meaningless"; exit 1; }
+          # Resolve fresh rather than from a committed lockfile: no lockfile ever
+          # reaches a consumer, so this reproduces what they actually get.
+          bun install
+          bun run typecheck
+          bun run build
+          bun test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: skills-unit-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/skills/.artifacts/unit/junit.xml
+
+      - name: Build and rewrite exports to dist/
+        # Verifies the embedded map is not stale, compiles src/ to dist/ and
+        # repoints package.json exports from ./src/*.ts to ./dist/*.js. The
+        # skills markdown ships verbatim; the three modules that make it
+        # reachable cannot, because npm consumers on node cannot load .ts.
+        # Bun's $ throws on a non-zero tsc, which aborts before anything is
+        # rewritten or published.
+        run: bun run script/build-for-publish.ts
+
+      - name: Gate — tarball contains every entrypoint and every skill
+        env:
+          # Passed as an env value rather than a heredoc: a quoted heredoc
+          # terminator has to sit at column 0, which is not expressible inside a
+          # YAML block scalar, and this way nothing in the script is exposed to
+          # shell expansion.
+          GATE_JS: |
+            // Two things must be true of the tarball npm is about to publish:
+            // every entrypoint package.json advertises is inside it, and every
+            // skill directory on disk is inside it. Reads what `npm pack` wrote.
+            //
+            // Checking the TARBALL rather than the working directory is
+            // deliberate: it is the only check that catches a `files` field that
+            // forgot to ship dist/. And tsc writes dist/ even when it exits
+            // non-zero, so "dist/index.js exists" is not evidence of a good
+            // build.
+            //
+            // The skill-directory half is specific to this package and not
+            // optional. skillsRoot() hands consumers a filesystem path they read
+            // the markdown from, so those directories are payload, not
+            // documentation — and they are shipped by a wildcard (`*/**` with
+            // exclusions), exactly the kind of pattern that silently stops
+            // matching. An exports-only gate would call a tarball with no skills
+            // in it healthy.
+            import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+            import { join } from "node:path"
+
+            const pkg = JSON.parse(readFileSync("package.json", "utf8"))
+
+            // `npm pack --json` has had three shapes across majors: npm 11 emits
+            // an array of results, and npm 12 emits an object KEYED BY PACKAGE
+            // NAME. A bare result object is the third possibility. Rather than
+            // track npm's releases, take the first candidate that actually
+            // carries a files array.
+            const raw = JSON.parse(readFileSync(process.argv[2], "utf8"))
+            const candidates = Array.isArray(raw) ? raw : [raw, ...Object.values(raw)]
+            const packed = candidates.find((c) => c && Array.isArray(c.files))
+            if (!packed?.files) {
+              console.error("::error::could not read the file list from `npm pack --json`")
+              console.error(`top-level keys: ${Object.keys(packed ?? {}).join(", ") || "(none)"}`)
+              process.exit(1)
+            }
+            const files = new Set(packed.files.map((f) => f.path))
+
+            const targets = Object.entries(pkg.exports ?? {}).flatMap(([key, value]) =>
+              typeof value === "string"
+                ? [[`exports["${key}"]`, value]]
+                : Object.entries(value).map(([condition, file]) => [`exports["${key}"].${condition}`, file]),
+            )
+            const inTarball = (file) => files.has(file.replace(/^\.\//, ""))
+
+            // A skill is a top-level directory with a SKILL.md — the same rule
+            // the generator, the tests and the Serac Portal use.
+            const onDisk = readdirSync(".")
+              .filter((entry) => !entry.startsWith("."))
+              .filter((entry) => statSync(entry).isDirectory())
+              .filter((entry) => existsSync(join(entry, "SKILL.md")))
+
+            const unbuilt = targets.filter(([, file]) => file.startsWith("./src/") && file.endsWith(".ts"))
+            const missing = targets.filter(([, file]) => !inTarball(file))
+            const unshipped = onDisk.filter((name) => !files.has(`${name}/SKILL.md`))
+
+            for (const [name, file] of targets) console.log(`${inTarball(file) ? "ok  " : "MISS"}  ${name} -> ${file}`)
+            console.log(`\n${packed.name}@${packed.version}: ${packed.entryCount} files, ${(packed.size / 1024).toFixed(1)} kB packed`)
+
+            if (unbuilt.length > 0) {
+              console.error(`\n::error::package.json still points at TypeScript source — the export rewrite did not run`)
+              for (const [name, file] of unbuilt) console.error(`  ${name} -> ${file}`)
+            }
+            if (missing.length > 0) {
+              console.error(`\n::error::${missing.length} published entrypoint(s) are not in the tarball`)
+              for (const [name, file] of missing) console.error(`  ${name} -> ${file}`)
+            }
+            if (unshipped.length > 0) {
+              console.error(`\n::error::${unshipped.length} skill director(ies) on disk are not in the tarball — check "files"`)
+              for (const name of unshipped) console.error(`  ${name}`)
+            }
+            if (onDisk.length < 50) {
+              console.error(`\n::error::only ${onDisk.length} skill directories on disk; the working tree is not what we think it is`)
+              process.exit(1)
+            }
+            if (unbuilt.length + missing.length + unshipped.length > 0) process.exit(1)
+            console.log(`gate: ${targets.length} published entrypoints and all ${onDisk.length} skill directories are in the tarball`)
+        run: |
+          set -euo pipefail
+          printf '%s' "$GATE_JS" > "$RUNNER_TEMP/gate.mjs"
+          npm pack --pack-destination "$RUNNER_TEMP" --json > "$RUNNER_TEMP/pack.json"
+          node "$RUNNER_TEMP/gate.mjs" "$RUNNER_TEMP/pack.json"
+
+      - name: Gate — every published subpath loads under node, from a real install
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          SMOKE_JS: |
+            // Every published subpath must load under NODE, from a real npm
+            // install of the tarball. Bun's resolver is more forgiving than
+            // Node's — it finds "./embedded" without an extension and reads .ts
+            // straight through — so a package that works under every bun check
+            // in this repo can still be dead on arrival for `npm install`
+            // users. The MCP package learned that the expensive way: a named
+            // import of a CJS module Node's lexer could not read took out 5 of
+            // 13 subpaths while every bun-based check stayed green.
+            //
+            // Loading is not enough here, though. The headline export returns a
+            // FILESYSTEM PATH, so a successful import proves nothing:
+            // skillsRoot() can resolve cleanly and point at a directory with no
+            // skills in it, which is exactly what happens if the emitted module
+            // lands one level deeper than src/ was. So the second half drives
+            // the two documented ways to consume this package against each
+            // other INSIDE the installed tree: every skill directory
+            // skillsRoot() finds must have an entry in BUNDLED_SKILLS, and
+            // every BUNDLED_SKILLS entry must be a file that really shipped,
+            // with the contents the map claims. Either half alone can be green
+            // while the package is useless.
+            import { spawnSync } from "node:child_process"
+            import { readFileSync } from "node:fs"
+
+            const name = process.argv[2]
+            // Read the INSTALLED manifest — package.json is not itself an
+            // export, so it cannot be resolved through the exports map.
+            const pkg = JSON.parse(readFileSync(`node_modules/${name}/package.json`, "utf8"))
+
+            const subpaths = Object.keys(pkg.exports)
+              .filter((key) => !key.includes("*"))
+              .map((key) => (key === "." ? name : `${name}/${key.slice(2)}`))
+
+            const node = (source) =>
+              spawnSync(process.execPath, ["--input-type=module", "-e", source], { encoding: "utf8", timeout: 60000 })
+
+            const results = subpaths.map((subpath) => {
+              const child = node(`await import(${JSON.stringify(subpath)})`)
+              return { label: subpath, ok: child.status === 0, err: (child.stderr ?? "").trim() }
+            })
+            for (const { label, ok } of results) console.log(`${ok ? "ok  " : "FAIL"}  ${label}`)
+
+            const failed = results.filter((r) => !r.ok)
+            if (failed.length > 0) {
+              console.error(`\n::error::${failed.length} of ${results.length} published subpaths are broken under node ${process.version}`)
+              for (const { label, err } of failed) console.error(`  ${label}\n      ${err.split("\n").slice(0, 3).join("\n      ")}`)
+              process.exit(1)
+            }
+
+            const probe = node(`
+              import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+              import { join } from "node:path"
+              const { skillsRoot } = await import(${JSON.stringify(`${name}/root`)})
+              const { BUNDLED_SKILLS } = await import(${JSON.stringify(name)})
+              const root = skillsRoot()
+              const dirs = existsSync(root)
+                ? readdirSync(root)
+                    .filter((entry) => !entry.startsWith("."))
+                    .filter((entry) => statSync(join(root, entry)).isDirectory())
+                    .filter((entry) => existsSync(join(root, entry, "SKILL.md")))
+                : []
+              console.log(JSON.stringify({
+                root,
+                dirs,
+                unembedded: dirs.filter((dir) => BUNDLED_SKILLS[dir + "/SKILL.md"] === undefined),
+                // An embedded entry with no file behind it means the tarball
+                // dropped content the map still promises — the shape of the
+                // 55-of-58 bug, inverted.
+                unshipped: Object.keys(BUNDLED_SKILLS).filter((rel) => !existsSync(join(root, rel))),
+                mismatched: Object.keys(BUNDLED_SKILLS).filter(
+                  (rel) => existsSync(join(root, rel)) && readFileSync(join(root, rel), "utf8") !== BUNDLED_SKILLS[rel],
+                ),
+              }))
+            `)
+            if (probe.status !== 0) {
+              console.error("::error::could not read skillsRoot()/BUNDLED_SKILLS from the installed package")
+              console.error(probe.stderr)
+              process.exit(1)
+            }
+
+            const payload = JSON.parse(probe.stdout)
+            console.log(`\nskillsRoot() -> ${payload.root}`)
+            console.log(`${payload.dirs.length} skill directories on disk, ${payload.unembedded.length} of them not embedded`)
+
+            // A floor, not an exact count: a consumer that resolves the wrong
+            // directory sees an empty tree rather than an error, and 50 is far
+            // enough below the 57 shipped that adding a skill never touches it.
+            if (payload.dirs.length < 50) {
+              console.error(`::error::skillsRoot() resolves to ${payload.root}, which holds ${payload.dirs.length} skill directories`)
+              process.exit(1)
+            }
+            const problems = [
+              ["skill directories with no embedded entry", payload.unembedded],
+              ["embedded entries with no file in the tarball", payload.unshipped],
+              ["embedded entries whose contents differ from the shipped file", payload.mismatched],
+            ].filter(([, list]) => list.length > 0)
+            if (problems.length > 0) {
+              for (const [label, list] of problems) console.error(`::error::${list.length} ${label}: ${list.slice(0, 5).join(", ")}`)
+              process.exit(1)
+            }
+            console.log(`\nsmoke: ${subpaths.length} subpaths import under node ${process.version}, and both consumption paths agree`)
+        run: |
+          set -euo pipefail
+          printf '%s' "$SMOKE_JS" > "$RUNNER_TEMP/smoke.mjs"
+          TARBALL=$(ls "$RUNNER_TEMP"/*.tgz)
+          CONSUMER="$RUNNER_TEMP/consumer"
+          rm -rf "$CONSUMER"
+          mkdir -p "$CONSUMER"
+          cd "$CONSUMER"
+          node -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "skills-smoke", private: true, type: "module" }))'
+          npm install --no-audit --no-fund "$TARBALL"
+          node "$RUNNER_TEMP/smoke.mjs" "$NAME"
+
+      - name: Publish to npm (OIDC, signed provenance)
+        # No continue-on-error. A publish that cannot happen must turn the run
+        # red; continue-on-error on the old publish-npm.yml step is what let two
+        # months of releases report success while npm stayed on 0.1.0.
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' && github.repository == 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          echo "Publishing $NAME@$VERSION with tag: $DIST_TAG"
+
+          # Sigstore's transparency log occasionally 409s with
+          # TLOG_CREATE_ENTRY_ERROR when npm's internal retry races its own
+          # first, successfully landed tlog write. A fresh publish signs with a
+          # new ephemeral cert and goes through, so retry the whole publish on
+          # that transient only.
+          for attempt in 1 2 3; do
+            if out=$(npm publish --access public --provenance --tag "$DIST_TAG" 2>&1); then
+              echo "$out"
+              exit 0
+            fi
+            echo "$out"
+            if echo "$out" | grep -qiE "TLOG_CREATE_ENTRY_ERROR|transparency log"; then
+              echo "transient sigstore tlog conflict (attempt $attempt) — retrying in 20s"
+              sleep 20
+              continue
+            fi
+            exit 1
+          done
+          echo "::error::npm publish failed after 3 tlog retries"
+          exit 1
+
+      - name: Verify the published version carries provenance
+        # A publish can succeed with a classic token and no attestation. Assert
+        # the trusted publisher actually signed this one, so a mis-wired binding
+        # is loud instead of invisible.
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true' && github.repository == 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            ATTESTATIONS=$(npm view "$NAME@$VERSION" dist.attestations --json 2>/dev/null || true)
+            if [ -n "$ATTESTATIONS" ]; then
+              echo "$ATTESTATIONS"
+              echo "$NAME@$VERSION published under dist-tag '$DIST_TAG' with signed provenance"
+              exit 0
+            fi
+            echo "no attestation visible yet (attempt $attempt) — waiting 10s"
+            sleep 10
+          done
+          echo "::error::$NAME@$VERSION published WITHOUT provenance. The npm Trusted Publisher for $NAME is probably not bound to serac-labs/serac + .github/workflows/publish-skills.yml."
+          exit 1
+
+      - name: Summary (nothing published)
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run == 'true' || github.repository != 'serac-labs/serac'
+        env:
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: echo "$NAME@$VERSION built, tested and gated. Not published (pull request, dry run, or fork)."

--- a/README.md
+++ b/README.md
@@ -140,7 +140,13 @@ trusted publishing and signed provenance. Every PR that touches the package runs
 packaging gates without publishing, including one that copies the package out of the workspace entirely and
 proves it installs, builds and tests with no monorepo around it.
 
-`@serac-labs/skills` is not on npm today. It is consumed from a checkout.
+`@serac-labs/skills` releases the same way, from `.github/workflows/publish-skills.yml`, with gates
+adapted to what that package actually ships: the tarball must contain every entrypoint **and** every skill
+directory, and every published subpath must load under node from a real `npm install` — `skillsRoot()`
+hands consumers a filesystem path, so an import that merely succeeds proves nothing.
+
+Its npm trusted publisher does not exist yet, so no version has gone out. Creating it (bound to
+`serac-labs/serac` + `publish-skills.yml`) is a manual step on npmjs.com; see the workflow header.
 
 ## What used to be here
 

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
       "devDependencies": {
         "@types/bun": "1.3.13",
         "@typescript/native-preview": "7.0.0-dev.20251207.1",
+        "typescript": "5.8.2",
       },
     },
   },

--- a/packages/skills/LICENSE
+++ b/packages/skills/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Serac Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/skills/NOTICE
+++ b/packages/skills/NOTICE
@@ -1,0 +1,40 @@
+Serac
+Copyright 2026 Serac Labs
+
+This product is licensed under the Apache License, Version 2.0 (see the
+LICENSE file).
+
+------------------------------------------------------------------------
+Third-party attributions
+------------------------------------------------------------------------
+
+This repository began as a fork of the opencode project
+(https://github.com/anomalyco/opencode), which is licensed under the MIT
+License. Serac's ServiceNow tool layer, agents and skills were built on top of
+it. The opencode code itself has since been removed from this repository — what
+remains is the ServiceNow MCP server and its skill guides — but this project's
+history derives from opencode, and any portions still derived from it remain
+subject to the MIT License terms reproduced below. Serac's own work is licensed
+under the Apache License, Version 2.0.
+
+    MIT License
+
+    Copyright (c) 2025 opencode
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,50 +1,89 @@
 # @serac-labs/skills
 
-The bundled ServiceNow skill guides. One directory per skill, each holding a
-single `SKILL.md` with YAML frontmatter (`name`, `description`, and the
-`snow_*` tools the skill expects to be available).
+The bundled ServiceNow skill guides: 57 directories of plain markdown that teach an agent to
+work on a ServiceNow instance like a practitioner — which update set to be in, why a Business
+Rule fires twice, what ES5-only really rules out. Part of [Serac](https://serac.build).
 
-Skills and the ServiceNow MCP server are the two things this repository ships.
-The layout here is a contract, not an implementation detail.
+```bash
+npm install @serac-labs/skills
+```
+
+They pair with [`@serac-labs/servicenow-mcp`](https://www.npmjs.com/package/@serac-labs/servicenow-mcp):
+the MCP server gives a model the ability to change an instance, the skills give it the judgement
+to do so without breaking one.
+
+## What a skill is
+
+One directory, one `SKILL.md`, YAML frontmatter and then prose:
+
+```yaml
+---
+name: es5-compliance
+description: Enforce ES5-only syntax for ServiceNow server-side scripts (Rhino engine) — …
+tools:
+  - snow_execute_script
+  - snow_convert_es6_to_es5
+---
+```
+
+The directory name and the frontmatter `name` always match, and `tools:` only ever names tools
+the MCP server really has — `bun test` in this repo fails on either.
+
+Nothing loads a skill automatically. A host decides which ones to put in front of the model,
+usually by matching the task; putting all 57 in a prompt is not the intended use. They are worth
+reading on their own, agent or no agent.
 
 ## Consuming them
 
-**As files.** `skillsRoot()` returns the directory that holds the skill
-directories:
+**As files.** `skillsRoot()` returns the directory that holds the skill directories:
 
 ```ts
 import { skillsRoot } from "@serac-labs/skills/root"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+readFileSync(join(skillsRoot(), "es5-compliance", "SKILL.md"), "utf8")
 ```
 
-This is the path anything with a real filesystem should use. The Serac Portal
-reads the tree directly out of a checkout, keying on "top-level directory
-containing a `SKILL.md`" — which is why `src/`, `script/` and `test/` are
-deliberately not skill-shaped, and why no skill directory may be renamed
-without changing the portal first.
+This is the path anything with a real filesystem should use, and the markdown ships in the npm
+tarball for exactly that reason. Skills are keyed by "top-level directory containing a
+`SKILL.md`" — which is why `dist/` is not skill-shaped, and why no skill directory can be renamed
+without breaking every consumer that reads the tree.
 
-**As an embedded string map.** `BUNDLED_SKILLS` maps a path relative to the
-skills root (`incident-management/SKILL.md`) to that file's contents:
+**As an embedded string map.** `BUNDLED_SKILLS` maps a path relative to the skills root
+(`incident-management/SKILL.md`) to that file's contents:
 
 ```ts
 import { BUNDLED_SKILLS } from "@serac-labs/skills"
 ```
 
-This exists for consumers with no source filesystem alongside them — a bundled
-single file, a `bun build --compile` binary, a serverless deploy. It is
-generated: do not edit `src/embedded.ts` by hand.
+This exists for consumers with no source filesystem alongside them — a bundled single file, a
+`bun build --compile` binary, a serverless deploy. It costs a few hundred KB of string literals
+at import time, so import `@serac-labs/skills/root` instead if you only need the path.
 
-## After changing a skill
+## Requirements
 
+Node 20+ or Bun 1.2+. ESM only — there is no CommonJS `require` entrypoint.
+
+## Working on them
+
+The skills are edited in [the repo](https://github.com/serac-labs/serac/tree/main/packages/skills),
+not in `node_modules`. After adding, renaming or deleting one, regenerate the embedded map:
+
+```bash
+bun run --cwd packages/skills generate        # writes src/embedded.ts
+bun run --cwd packages/skills generate:check  # drift gate, no write
 ```
-bun packages/skills/script/generate-embedded.ts
-```
 
-`--check` verifies the checked-in module matches the tree without writing, and
-`bun test` asserts the same thing. That gate is not decorative: before it
-existed, the shipped binary carried 55 of 58 skills and three Fluent skills
-never reached a single user, because the generator lived in `/tmp` and nothing
-compared its output to reality.
+`bun test` asserts the same thing. That gate is not decorative: before it existed the shipped
+binary carried 55 of 58 skills and three Fluent skills never reached a single user, because the
+generator lived in `/tmp` and nothing compared its output to reality.
 
-`bun test` also asserts that every tool named in frontmatter actually exists in
-`@serac-labs/servicenow-mcp`, so a skill cannot promise the agent a tool the
-server does not have.
+## Links
+
+- [`@serac-labs/servicenow-mcp`](https://www.npmjs.com/package/@serac-labs/servicenow-mcp) — the 437 `snow_*` tools these guides drive
+- [Serac](https://serac.build) — the product they were written for
+- [Issues](https://github.com/serac-labs/serac/issues)
+- [Source](https://github.com/serac-labs/serac/tree/main/packages/skills)
+
+Apache-2.0

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -8,6 +8,10 @@ Rule fires twice, what ES5-only really rules out. Part of [Serac](https://serac.
 npm install @serac-labs/skills
 ```
 
+That command does not work yet — nothing has been published under this name. The first release is
+waiting on an npm trusted publisher that only a maintainer can create, so for now the guides come
+from [the repo](https://github.com/serac-labs/serac/tree/main/packages/skills).
+
 They pair with [`@serac-labs/servicenow-mcp`](https://www.npmjs.com/package/@serac-labs/servicenow-mcp):
 the MCP server gives a model the ability to change an instance, the skills give it the judgement
 to do so without breaking one.
@@ -47,8 +51,9 @@ readFileSync(join(skillsRoot(), "es5-compliance", "SKILL.md"), "utf8")
 
 This is the path anything with a real filesystem should use, and the markdown ships in the npm
 tarball for exactly that reason. Skills are keyed by "top-level directory containing a
-`SKILL.md`" — which is why `dist/` is not skill-shaped, and why no skill directory can be renamed
-without breaking every consumer that reads the tree.
+`SKILL.md`", which is why `dist/` is not skill-shaped. The Serac Portal reads that tree straight
+out of a checkout and keys on the same rule, so renaming a skill directory is a breaking change:
+change the portal first, rename second.
 
 **As an embedded string map.** `BUNDLED_SKILLS` maps a path relative to the skills root
 (`incident-management/SKILL.md`) to that file's contents:

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -15,9 +15,11 @@
   "type": "module",
   "private": false,
   "files": [
-    "src",
+    "dist",
     "*/**",
     "!.turbo/**",
+    "!script/**",
+    "!src/**",
     "!test/**"
   ],
   "exports": {
@@ -27,6 +29,7 @@
   },
   "scripts": {
     "typecheck": "tsgo --project tsconfig.json --noEmit",
+    "build": "tsc --project tsconfig.build.json",
     "test": "bun test",
     "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "generate": "bun script/generate-embedded.ts",
@@ -34,6 +37,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.13",
-    "@typescript/native-preview": "7.0.0-dev.20251207.1"
+    "@typescript/native-preview": "7.0.0-dev.20251207.1",
+    "typescript": "5.8.2"
   }
 }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -16,7 +16,9 @@
   "private": false,
   "files": [
     "dist",
+    "NOTICE",
     "*/**",
+    "!.artifacts/**",
     "!.turbo/**",
     "!script/**",
     "!src/**",

--- a/packages/skills/script/build-for-publish.ts
+++ b/packages/skills/script/build-for-publish.ts
@@ -94,3 +94,10 @@ if (root !== process.cwd())
 
 await Bun.write("package.json", JSON.stringify({ ...pkg, exports }, null, 2) + "\n")
 console.log(`rewrote ${targets.length} published entrypoints to dist/ — all present, skillsRoot() -> ${root}`)
+
+// A CI runner is thrown away; a developer's checkout is not, and publishing the
+// first version by hand is a documented path (see publish-skills.yml). A
+// manifest left pointing at gitignored dist/ files is easy to commit by
+// accident, and nothing in the repo would catch it: the tests import ../src
+// relatively and typecheck never reads the exports map.
+if (!process.env.CI) console.log("package.json now points at dist/ — `git checkout package.json` when you are done")

--- a/packages/skills/script/build-for-publish.ts
+++ b/packages/skills/script/build-for-publish.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+// Build the package to dist/ and rewrite package.json exports from ./src/*.ts
+// to ./dist/*.js (+ .d.ts) so the published tarball resolves to the built
+// output. Run right before `npm publish` in CI. The runner is ephemeral, so
+// package.json is intentionally NOT restored afterwards.
+//
+// Why this package needs a build at all, given the skills are markdown: the
+// markdown ships verbatim (see `files`), but the three modules that make it
+// reachable — skillsRoot(), BUNDLED_SKILLS and the index that re-exports both —
+// are TypeScript. An npm consumer on node cannot load a .ts file, so exports
+// pointing at src/ would publish a package whose every entrypoint throws.
+//
+// Everything this needs (tsc, @types/bun) is declared in this package's own
+// devDependencies, so `bun install && bun run script/build-for-publish.ts`
+// works from this directory alone — no monorepo root, no hoisted toolchain.
+import { $ } from "bun"
+import { existsSync, rmSync } from "node:fs"
+
+process.chdir(new URL("..", import.meta.url).pathname)
+
+// src/embedded.ts is generated, and it is the payload of the ./embedded and .
+// subpaths — a stale one publishes skills that no longer exist and omits ones
+// that do. That is not hypothetical: a shipped binary carried 55 of 58 skills
+// for weeks. `bun test` checks the same thing, but a release must not be able
+// to skip it by running this script alone. --check never writes.
+await $`bun run generate:check`
+
+// Start from an empty dist/. `files` ships whatever is in there, so without
+// this a stale artifact from an earlier build — a file whose source has since
+// been deleted or renamed — rides along into the tarball.
+rmSync("dist", { recursive: true, force: true })
+
+// Delegates to the package's own "build" script so the compiler flags have a
+// single source of truth. `$` throws on a non-zero exit, which aborts before
+// anything is rewritten or published.
+await $`bun run build`
+
+type Entry = string | { types: string; import: string }
+type Manifest = Record<string, unknown> & { exports?: Record<string, Entry> }
+
+const pkg: Manifest = await Bun.file("package.json").json()
+if (!pkg.exports) throw new Error("package.json must declare exports to rewrite for publish")
+
+const exports: Record<string, Entry> = Object.fromEntries(
+  Object.entries(pkg.exports).map(([key, value]) => {
+    // Anything already rewritten (a re-run on the same checkout) is left alone.
+    if (typeof value !== "string" || !value.endsWith(".ts")) return [key, value]
+    // `types` is listed FIRST: export conditions are matched in declaration
+    // order, and publint / are-the-types-wrong flag a `types` condition that
+    // trails `import`, because a resolver can match the .js before it ever
+    // reaches the declarations.
+    const built = value.replace("./src/", "./dist/").replace(/\.ts$/, "")
+    return [key, { types: built + ".d.ts", import: built + ".js" }]
+  }),
+)
+
+const targets = Object.entries(exports).flatMap(([key, value]) =>
+  typeof value === "string"
+    ? [{ name: `exports["${key}"]`, file: value }]
+    : [
+        { name: `exports["${key}"].types`, file: value.types },
+        { name: `exports["${key}"].import`, file: value.import },
+      ],
+)
+
+// tsc writes dist/ even when it exits non-zero, so "some dist file exists" is
+// not evidence of a successful build. Assert instead that EVERY published
+// entrypoint resolves to a file that is really on disk.
+const missing = targets.filter((target) => !existsSync(target.file.replace(/^\.\//, "")))
+if (missing.length > 0)
+  throw new Error(
+    `build produced no file for ${missing.length} published entrypoint(s):\n` +
+      missing.map((target) => `  ${target.name} -> ${target.file}`).join("\n"),
+  )
+
+const unbuilt = targets.filter((target) => target.file.startsWith("./src/"))
+if (unbuilt.length > 0)
+  throw new Error(
+    `package.json still points at TypeScript source after the rewrite:\n` +
+      unbuilt.map((target) => `  ${target.name} -> ${target.file}`).join("\n"),
+  )
+
+// The headline export is a PATH, so "the file exists" proves nothing about
+// whether it is correct. skillsRoot() resolves the skill tree as `<its own
+// directory>/..`, which only lands on the package root while the emitted module
+// sits exactly as deep as src/ did. Widen rootDir in tsconfig.build.json and
+// tsc emits dist/src/root.js instead; the export still loads, and every
+// consumer that reads skills off disk gets <pkg>/dist — a directory with no
+// skills in it. Load the built module and check where it actually points.
+// (Specifier built from a URL because dist/ does not exist at typecheck time.)
+const root = await import(new URL("../dist/root.js", import.meta.url).href).then((module) => module.skillsRoot())
+if (root !== process.cwd())
+  throw new Error(`built skillsRoot() resolves to ${root}, not the package root ${process.cwd()}`)
+
+await Bun.write("package.json", JSON.stringify({ ...pkg, exports }, null, 2) + "\n")
+console.log(`rewrote ${targets.length} published entrypoints to dist/ — all present, skillsRoot() -> ${root}`)

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -17,5 +17,9 @@
  * literals). Import `@serac-labs/skills/root` instead if you only need the
  * directory path.
  */
-export { BUNDLED_SKILLS } from "./embedded"
-export { skillsRoot } from "./root"
+// `.js` specifiers, not extensionless: tsc preserves the specifier verbatim, and
+// Node's ESM resolver does no extension guessing, so an extensionless import
+// here is an ERR_MODULE_NOT_FOUND for every npm consumer on node. Bun and
+// TypeScript both map the .js back onto the .ts source in this repo.
+export { BUNDLED_SKILLS } from "./embedded.js"
+export { skillsRoot } from "./root.js"

--- a/packages/skills/test/skills.test.ts
+++ b/packages/skills/test/skills.test.ts
@@ -3,7 +3,7 @@
  *
  * Skills are markdown, so nothing about them fails at compile time — every
  * mistake here is silent until it reaches a user's system prompt. These are the
- * three failures that have actually happened or are one edit away:
+ * four failures that have actually happened or are one edit away:
  *
  *   1. The embedded map drifting from the tree on disk. That is not
  *      hypothetical: the shipped binary carried 55 of 58 skills for weeks and
@@ -13,6 +13,9 @@
  *      tool exists, calls it, and gets an unknown-tool error at runtime.
  *   3. A skill directory whose frontmatter `name` does not match its directory
  *      name, which breaks any consumer that keys skills by directory.
+ *   4. src/ importing a sibling module the way bun resolves rather than the way
+ *      node does. That one is invisible to every other check in this repo,
+ *      because every other check runs under bun.
  */
 
 import { describe, expect, test } from "bun:test"
@@ -135,5 +138,24 @@ describe("frontmatter tools", () => {
       (frontmatter(name)?.tools ?? []).filter((tool) => !known.has(tool)).map((tool) => `${name}: ${tool}`),
     )
     expect(unknown).toEqual([])
+  })
+})
+
+describe("published modules", () => {
+  // src/ is the only part of this package that is not markdown, and it is what
+  // an npm consumer imports: script/build-for-publish.ts compiles it to dist/,
+  // and tsc copies relative specifiers through verbatim. Node's ESM resolver
+  // does no extension guessing, so an extensionless specifier here — which bun
+  // and tsc both accept, and which nothing else in this repo would flag,
+  // because every other check runs under bun — is an ERR_MODULE_NOT_FOUND on
+  // import for everyone who installs the package from npm.
+  test.each(readdirSync(join(ROOT, "src")))("%s imports its siblings the way node resolves", (file) => {
+    const specifiers = [...readFileSync(join(ROOT, "src", file), "utf8").matchAll(/\bfrom "(\.[^"]*)"/g)].map(
+      (match) => match[1],
+    )
+    expect(specifiers.filter((specifier) => !specifier.endsWith(".js"))).toEqual([])
+    expect(specifiers.filter((specifier) => !existsSync(join(ROOT, "src", specifier.replace(/\.js$/, ".ts"))))).toEqual(
+      [],
+    )
   })
 })

--- a/packages/skills/tsconfig.build.json
+++ b/packages/skills/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    // rootDir is load-bearing, not tidiness: skillsRoot() resolves the skill
+    // tree as `<its own directory>/..`, so the emitted module must sit exactly
+    // one level below the package root, the same depth src/ sits at. Widening
+    // rootDir (adding script/ or test/ to `include` would do it) makes tsc emit
+    // dist/src/root.js, and skillsRoot() then returns <pkg>/dist — a directory
+    // with no skills in it. The gates in publish-skills.yml catch that, but the
+    // cheapest place to not cause it is here.
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Issue for this PR

Closes #290

### Type of change

- [ ] Bug fix
- [ ] New tool or skill
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The MCP server installs in one command; the skills needed a git clone. This makes
`@serac-labs/skills` publishable.

The part that isn't copied from publish-mcp.yml: the exports pointed at `.ts` source and there was no
build. There is one now — tsc to `dist/`, and `build-for-publish.ts` rewrites the exports map right
before publish. `rootDir` has to stay `"src"`: `skillsRoot()` resolves `<its own dir>/..`, so a module
emitted one level deeper hands consumers a directory with no skills in it. The build script asserts
that, and the gates assert it again against the installed tarball.

Two gates, adapted from the MCP release: everything the manifest advertises has to be in the tarball —
plus every skill directory, and nothing else — and every subpath has to load under node from a real
`npm install`, where `skillsRoot()` and `BUNDLED_SKILLS` are checked against each other.

I also added `.js` to the two relative imports in `src/index.ts`. Extensionless resolves under bun and
tsc and is `ERR_MODULE_NOT_FOUND` for anyone on node; there's a test for it now.

### How did you verify it works?

`bun typecheck`, `bun run lint` (1761 warnings, 0 errors — unchanged) and `bun test` in both packages:
63 skills, 252 MCP.

Then the release path in a scratch dir: package copied out of the workspace, fresh install, build,
`test:ci`, build-for-publish, `npm pack`. 67 files / 311 kB — 57 SKILL.md, 6 dist files,
LICENSE/NOTICE/README/package.json, nothing else. I ran the two gate scripts by parsing them out of the
YAML rather than retyping them, then npm-installed the tarball into a bare node consumer (node
20.19.5): all three subpaths import, `skillsRoot()` lands on the installed package, and the embedded
map is byte-identical to the shipped files. I broke each check on purpose to watch it fail.

The PR run then exercised the workflow itself on a runner (node 24, npm 12.0.2) and got the same
67 files / 311.1 kB with both gates green; publish and provenance skip on a pull request, as designed.

So the publish half is the part still unproven. Nothing is published, and the npm trusted publisher for
`@serac-labs/skills` does not exist — someone with npm write access has to create it, bound to
`serac-labs/serac` + `publish-skills.yml`. npm offers that binding on an existing package's settings
page, so 0.1.0 probably has to go out by hand, and therefore unsigned; the recipe is in the workflow
header. Worth re-reading npm's docs first in case they have added pre-registration since.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json`
- [x] If I added or changed a skill, I re-ran the skills `generate`
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch
