### PR TITLE
docs: name the instance variable the published server reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ developer instance from [developer.servicenow.com](https://developer.servicenow.
 under `System OAuth > Application Registry`, and export:
 
 ```bash
-export SNOW_INSTANCE_URL=https://dev12345.service-now.com
+export SNOW_INSTANCE=https://dev12345.service-now.com
 export SNOW_CLIENT_ID=…
 export SNOW_CLIENT_SECRET=…
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Point your MCP client at the `servicenow-mcp-stdio` binary:
     "servicenow": {
       "command": "servicenow-mcp-stdio",
       "env": {
-        "SNOW_INSTANCE_URL": "https://dev12345.service-now.com",
+        "SNOW_INSTANCE": "https://dev12345.service-now.com",
         "SNOW_CLIENT_ID": "…",
         "SNOW_CLIENT_SECRET": "…"
       }
@@ -89,10 +89,8 @@ The repository is also a plugin marketplace, so the server and all 57 skills arr
 /plugin install servicenow@serac
 ```
 
-The server runs through `npx`, so nothing has to be installed first: export `SNOW_INSTANCE`,
-`SNOW_CLIENT_ID` and `SNOW_CLIENT_SECRET` and it is ready. `SNOW_INSTANCE` rather than the
-`SNOW_INSTANCE_URL` used further up on purpose — `npx` fetches the released package, and the release that
-first reads `SNOW_INSTANCE_URL` has not gone out yet. `SNOW_INSTANCE` is read by both. The same entry is in [`.mcp.json`](.mcp.json) at
+The server runs through `npx`, so nothing has to be installed first: export the same three variables as
+above and it is ready. The same entry is in [`.mcp.json`](.mcp.json) at
 the repo root, which Claude Code reads for this project. Other clients each want it somewhere else: copy it
 into `.cursor/mcp.json` (Cursor), `~/.codeium/windsurf/mcp_config.json` (Windsurf), or `.vscode/mcp.json`
 for VS Code, which names the same block `servers` rather than `mcpServers`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ that is what it is.
 
 ### The credentials are the crown jewels
 
-`servicenow-mcp-stdio` reads `SNOW_INSTANCE_URL`, `SNOW_CLIENT_ID` and `SNOW_CLIENT_SECRET` (or basic-auth
+`servicenow-mcp-stdio` reads `SNOW_INSTANCE`, `SNOW_CLIENT_ID` and `SNOW_CLIENT_SECRET` (or basic-auth
 equivalents) from its environment, and caches the resulting OAuth token in process. Anything that can read
 that process's environment, or drive its stdin, can act on your instance with those credentials. Give the
 OAuth user the least privilege that lets it do the job.

--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -17,7 +17,7 @@ Point any MCP client at the `servicenow-mcp-stdio` binary:
     "servicenow": {
       "command": "servicenow-mcp-stdio",
       "env": {
-        "SNOW_INSTANCE_URL": "https://dev12345.service-now.com",
+        "SNOW_INSTANCE": "https://dev12345.service-now.com",
         "SNOW_CLIENT_ID": "…",
         "SNOW_CLIENT_SECRET": "…"
       }
@@ -25,6 +25,10 @@ Point any MCP client at the `servicenow-mcp-stdio` binary:
   }
 }
 ```
+
+`SNOW_INSTANCE` takes either a bare host or a full URL. `SERVICENOW_INSTANCE_URL` and `SNOW_INSTANCE_URL`
+are accepted as aliases, in that order of precedence — but `SNOW_INSTANCE_URL` only from 0.2.2 onwards, so
+prefer `SNOW_INSTANCE` in anything you hand to someone else.
 
 The catalog is large enough to blow a context window, so tools are **deferred** by default: `tools/list`
 returns two meta-tools, and the model widens its own surface as it goes.

--- a/packages/servicenow-mcp/src/__tests__/documented-env-vars.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/documented-env-vars.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Every ServiceNow environment variable the documentation tells someone to set has to be one the code
+ * actually reads.
+ *
+ * The quick start told people to export `SNOW_INSTANCE_URL` while the loader read only
+ * `SERVICENOW_INSTANCE_URL` and `SNOW_INSTANCE` (#316). Nothing failed: the server started
+ * unauthenticated and then reported missing *credentials*, which points a reader at the wrong thing
+ * entirely. Docs and loader get edited in different PRs by different people, so the only thing that keeps
+ * them in step is a check.
+ *
+ * The set of readable names is derived from the source, not listed here — adding a variable should not
+ * mean editing this file too.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { ENV_VARS } from "../servicenow-mcp-unified/shared/context-loader"
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..")
+const REPO = resolve(PACKAGE_ROOT, "..", "..")
+
+// Tests are excluded on purpose, and it matters: context-loader.test.ts assigns
+// `process.env.SNOW_INSTANCE_URL` to exercise the loader, and counting that as "the code reads it" made
+// this check pass against a faithful reconstruction of the very bug it exists for.
+const sources = (
+  await Array.fromAsync(new Bun.Glob("**/*.ts").scan({ cwd: join(PACKAGE_ROOT, "src"), absolute: true }))
+).filter((file) => !file.includes("__tests__"))
+
+// ENV_VARS is resolved through `process.env[name]` at runtime, so its entries are string literals no
+// `process.env.X` scan can see. Both halves are needed.
+const readByCode = new Set([
+  ...Object.values(ENV_VARS).flat(),
+  ...(await Promise.all(sources.map((file) => Bun.file(file).text()))).flatMap((text) =>
+    [...text.matchAll(/process\.env(?:\.([A-Z0-9_]+)|\["([A-Z0-9_]+)"\])/g)].map((match) => match[1] ?? match[2]),
+  ),
+])
+
+// The package README ships inside the package and is always here. The repo-root docs are not: the publish
+// gate copies this package out of the workspace and runs the suite with no repo around it, where they
+// genuinely do not exist. The last test below stops that from hiding a deletion inside a real checkout.
+const rootDocs = ["README.md", "CONTRIBUTING.md", "SECURITY.md"].map((name) => join(REPO, name))
+const docs = [join(PACKAGE_ROOT, "README.md"), ...rootDocs.filter((path) => existsSync(path))]
+
+describe("documented environment variables", () => {
+  docs.forEach((path) => {
+    test(`${relative(REPO, path)} names only variables the code reads`, async () => {
+      const documented = [
+        ...new Set(
+          [...(await Bun.file(path).text()).matchAll(/\b((?:SNOW|SERVICENOW)_[A-Z0-9_]+)\b/g)].map((match) => match[1]),
+        ),
+      ]
+      expect(
+        documented
+          .filter((name) => !readByCode.has(name))
+          .map((name) => `${name}: documented here, read nowhere in src — fix the doc or the loader`),
+      ).toEqual([])
+    })
+  })
+
+  test("the repo-root docs are checked wherever the repo is", () => {
+    expect(existsSync(join(REPO, "package.json")) ? rootDocs.every((path) => existsSync(path)) : true).toBe(true)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
@@ -245,7 +245,7 @@ export const inspectInstanceUrl = (raw: string | undefined): { check: Check; bas
         code: "instance-url-missing",
         title: "No instance URL configured.",
         detail: [],
-        fix: ["Set SNOW_INSTANCE_URL to your instance, e.g. https://dev12345.service-now.com"],
+        fix: ["Set SNOW_INSTANCE to your instance, e.g. https://dev12345.service-now.com"],
       },
     }
 
@@ -765,7 +765,7 @@ const resolveChain = async (supplied?: ServiceNowContext): Promise<{ context: Se
           "enterprise portal: no enterprise session on this machine",
         ],
         fix: [
-          "Set SNOW_INSTANCE_URL, SNOW_CLIENT_ID and SNOW_CLIENT_SECRET in your MCP client's env block.",
+          "Set SNOW_INSTANCE, SNOW_CLIENT_ID and SNOW_CLIENT_SECRET in your MCP client's env block.",
           "The client id and secret come from System OAuth > Application Registry on the instance.",
         ],
       },


### PR DESCRIPTION
### Issue for this PR

Closes #316

### Type of change

- [x] Bug fix
- [ ] New tool or skill
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Both quick starts, CONTRIBUTING and SECURITY told people to set `SNOW_INSTANCE_URL`. The published server does not read it — 0.2.1 knows `SERVICENOW_INSTANCE_URL` and `SNOW_INSTANCE` — so following the docs got you a server that came up unauthenticated and then complained about credentials, which sends you looking in the wrong place. They now say `SNOW_INSTANCE`, which every version reads and which `server.json` already uses for the registry listing. The package README gains a line about the two aliases and when `SNOW_INSTANCE_URL` started working.

The new test is the point of the PR, really. It collects every `SNOW_*`/`SERVICENOW_*` name in the docs and fails on any that no non-test source reads. Excluding the tests from that scan matters: `context-loader.test.ts` assigns `SNOW_INSTANCE_URL` itself, and while I was counting that the check passed against a faithful rebuild of this exact bug.

### How did you verify it works?

`bun typecheck`, `bun run lint` (0 errors, 1757 warnings, same as main), 323 MCP tests and 71 skills tests.

For the test itself I checked it fails for the right reasons rather than trusting it: putting a made-up `SNOW_INSTANCE_HOST` in SECURITY.md fails it, and removing `SNOW_INSTANCE_URL` from `ENV_VARS` while the README still names it — which is exactly the state this bug shipped in — fails it too, naming the variable.

I did not reformat `setup-doctor.ts`; it is already Prettier-dirty on main and I only changed two strings in it.

### Checklist

- [x] `bun typecheck` and `bun run test` pass
- [x] If I added or changed a tool, I re-ran `generate:tools-json`
- [x] If I added or changed a skill, I re-ran the skills `generate`
- [x] I have not included unrelated changes or reformatted files I did not otherwise touch