### PR TITLE
feat(mcp): six tools for questions the catalog could not answer, and stop three from lying

### DIFF
--- a/packages/servicenow-mcp/src/__tests__/acl-candidate-names.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/acl-candidate-names.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The set of ACL names `snow_acl_explain` looks for is the whole tool: whatever is missing from that list
+ * is a rule the report cannot name, and the report exists to name the rule that is blocking someone.
+ *
+ * Both bugs this replaces are in the tree today. `snow_table_schema_discovery` queries
+ * `name=<t>^ORname=*<t>.*`, whose second clause is a literal equality against the string `*incident.*` and
+ * therefore matches nothing on any instance — the ACL name column holds literal names, never glob patterns.
+ * And a report that stops at `<table>.<field>` names the wrong blocker in exactly the case it exists for:
+ * when the rule with the roles on it sits on a parent table or on a wildcard.
+ *
+ * Nothing here needs an instance — the name set is derived from the table chain, which the executor reads
+ * separately.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { aclCandidateNames } from "../servicenow-mcp-unified/tools/access-control/snow_acl_explain"
+
+// A literal ACL name: a table or field identifier, or `*` in either position. Anything else is a pattern
+// that will silently match zero rows through the Table API.
+const LITERAL_NAME = /^(\*|[a-z0-9_$]+)(\.(\*|[a-z0-9_$]+))?$/
+
+describe("aclCandidateNames", () => {
+  test("covers all six field levels, most specific first", () => {
+    expect(aclCandidateNames("incident", ["task"], "priority").field).toEqual([
+      "incident.priority",
+      "task.priority",
+      "*.priority",
+      "incident.*",
+      "task.*",
+      "*.*",
+    ])
+  })
+
+  test("covers the table, every ancestor and the wildcard at record level", () => {
+    expect(aclCandidateNames("sc_req_item", ["task"], "").record).toEqual(["sc_req_item", "task", "*"])
+  })
+
+  test("asks for no field-level names when no field was given", () => {
+    expect(aclCandidateNames("incident", ["task"], "").field).toEqual([])
+  })
+
+  test("keeps every ancestor in the chain, not just the nearest one", () => {
+    const names = aclCandidateNames("sn_hr_core_case", ["task", "sys_metadata"], "state")
+    expect(names.field).toContain("sys_metadata.state")
+    expect(names.record).toContain("sys_metadata")
+  })
+
+  test("collapses a table that repeats in the chain instead of querying it twice", () => {
+    const names = aclCandidateNames("incident", ["incident", "task"], "priority")
+    expect(names.record).toEqual(["incident", "task", "*"])
+    expect(names.field.filter((name) => name === "incident.priority")).toHaveLength(1)
+  })
+
+  test("emits only literal names — a wildcard belongs in a position, never inside one", () => {
+    const names = aclCandidateNames("incident", ["task"], "priority")
+    ;[...names.record, ...names.field].forEach((name) => expect(name).toMatch(LITERAL_NAME))
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/app-repo-manage.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/app-repo-manage.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for snow_app_repo_manage that need no instance.
+ *
+ * Four things here are worth pinning down. reportProgress is the single place
+ * that decides what a CI/CD progress record means, and the tool exists because
+ * the thing it replaced reported deployments it never performed — so "a job
+ * that is not Successful is never reported as a success" is the property the
+ * tool is for, not an implementation detail. progressPath decides which
+ * address gets polled: the client it runs on carries the instance's
+ * Authorization header on every request, so a host arriving in a response body
+ * must not survive into the request. pollUntilFinal has to tell "I could not
+ * read the progress record" apart from "the job failed", because an install can
+ * knock the node out for a poll or two. And snow_install_application, the tool
+ * this one replaces, must stay incapable of reporting an install again.
+ */
+
+import { describe, expect, test } from "bun:test"
+import type { AxiosInstance } from "axios"
+import {
+  ACTIONS,
+  execute,
+  pollUntilFinal,
+  progressPath,
+  reportProgress,
+  toolDefinition,
+} from "../servicenow-mcp-unified/tools/applications/snow_app_repo_manage"
+
+describe("reportProgress", () => {
+  test("a Successful job is the only thing that comes back as a success", () => {
+    const result = reportProgress("Install of x_acme_app", "install", { status: "2", status_label: "Successful" }, "p1")
+    expect(result.success).toBe(true)
+    expect(result.data.state).toBe("successful")
+    expect(result.data.finished).toBe(true)
+  })
+
+  test("a Failed job is an error carrying ServiceNow's own message", () => {
+    const result = reportProgress(
+      "Install of x_acme_app",
+      "install",
+      { status: "3", status_label: "Failed", error: "Dependency x_acme_lib is not installed" },
+      "p1",
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("Failed")
+    expect(result.error).toContain("Dependency x_acme_lib is not installed")
+  })
+
+  test("a Canceled job is an error too", () => {
+    const result = reportProgress("Publish of x_acme_app", "publish", { status: "4", status_label: "Canceled" }, "p1")
+    expect(result.success).toBe(false)
+  })
+
+  test("a running job is never reported as finished", () => {
+    const result = reportProgress(
+      "Install of x_acme_app",
+      "install",
+      { status: "1", status_label: "Running", percent_complete: 40 },
+      "p1",
+    )
+    expect(result.data.finished).toBe(false)
+    expect(result.data.state).toBe("running")
+    expect(result.summary).toContain("NOT finished")
+  })
+
+  test("an unrecognised status is unknown, not assumed complete", () => {
+    const result = reportProgress("Install of x_acme_app", "install", { status: "9" }, "p1")
+    expect(result.data.state).toBe("unknown")
+    expect(result.data.finished).toBe(false)
+  })
+})
+
+describe("progressPath", () => {
+  test("follows the returned link, but only its path — never its host", () => {
+    expect(
+      progressPath({
+        id: "d174f8e11bd800103d374087bc4bcbd9",
+        url: "https://dev12345.service-now.com/api/sn_cicd/progress/d174f8e11bd800103d374087bc4bcbd9",
+      }),
+    ).toBe("/api/sn_cicd/progress/d174f8e11bd800103d374087bc4bcbd9")
+  })
+
+  test("a host swapped into the response body does not become the request target", () => {
+    const path = progressPath({ id: "abc", url: "https://attacker.example.com/api/sn_cicd/progress/abc" })
+    expect(path).toBe("/api/sn_cicd/progress/abc")
+    expect(path).not.toContain("attacker.example.com")
+  })
+
+  test("falls back to the id when the link has no usable url", () => {
+    expect(progressPath({ id: "abc" })).toBe("/api/sn_cicd/progress/abc")
+    expect(progressPath({ id: "abc", url: "/api/sn_cicd/progress/abc" })).toBe("/api/sn_cicd/progress/abc")
+  })
+
+  test("returns nothing when ServiceNow returned no progress link at all", () => {
+    expect(progressPath({})).toBeUndefined()
+  })
+})
+
+describe("pollUntilFinal", () => {
+  // A stand-in for the axios client rather than a mocking framework: the point
+  // is what pollUntilFinal does with a GET that rejects, and there is no way to
+  // make a real client reject on demand without an instance.
+  const failing = (message: string) => ({ get: () => Promise.reject(new Error(message)) }) as unknown as AxiosInstance
+
+  test("a progress GET that fails does not abort the wait", async () => {
+    // Regression: fetchProgress used to throw straight out of settle(), so a
+    // 502 during an install — which auth.ts renders as "hibernating or starting
+    // up" — was reported instead of the install, and the progress_id went with
+    // it. An unreadable poll is now a poll to retry, not an outcome.
+    const polled = await pollUntilFinal(
+      failing("ServiceNow instance is hibernating or starting up (HTTP 503)."),
+      "/api/sn_cicd/progress/p1",
+      // Already spent, so this returns after one attempt instead of sleeping.
+      Date.now(),
+    )
+    expect(polled.final).toBe(false)
+    expect(polled.progress.poll_error).toContain("HTTP 503")
+    expect(polled.progress.status).toBeUndefined()
+  })
+
+  test("the last status this loop did read survives a later failed poll", async () => {
+    const polled = await pollUntilFinal(failing("socket hang up"), "/api/sn_cicd/progress/p1", Date.now(), {
+      status: "1",
+      status_label: "Running",
+      percent_complete: 40,
+    })
+    expect(polled.final).toBe(false)
+    expect(polled.progress.status_label).toBe("Running")
+    expect(polled.progress.poll_error).toBe("socket hang up")
+  })
+})
+
+describe("snow_install_application is retired, not fabricating", () => {
+  test("it makes no request and routes to the tool that installs", async () => {
+    // It used to POST { sys_id, version } to /api/now/table/sys_store_app and
+    // return { installed: true } from the row the Table API echoed back. The
+    // executor no longer imports an auth client at all, so there is no path on
+    // which it can report an install again.
+    const retired = await import("../servicenow-mcp-unified/tools/applications/snow_install_application")
+    const result = await retired.execute({ app_id: "abc123", version: "1.2.0" })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("snow_app_repo_manage")
+    expect(retired.toolDefinition.description.slice(0, 60)).toMatch(/\bdeprecated\b/i)
+  })
+})
+
+describe("snow_app_repo_manage dispatch", () => {
+  test("every action the schema advertises is one the executor dispatches", () => {
+    expect(Object.keys(ACTIONS).sort()).toEqual(
+      [...(toolDefinition.inputSchema.properties.action.enum as string[])].sort(),
+    )
+  })
+
+  test("an unknown action is rejected before anything touches the instance", async () => {
+    // Deliberately unreachable credentials: if the executor authenticated
+    // first, this would fail with a connection error instead of the argument
+    // error.
+    const result = await execute(
+      { action: "deploy" },
+      { instanceUrl: "https://unreachable.invalid", clientId: "", clientSecret: "" },
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("Unknown action: deploy")
+    expect(result.error).toContain("publish, install, progress")
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/cmdb-identify-reconcile.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/cmdb-identify-reconcile.test.ts
@@ -1,0 +1,118 @@
+/**
+ * snow_cmdb_identify_reconcile rejects a malformed payload before it touches
+ * the instance.
+ *
+ * The context below carries no usable credentials, so getAuthenticatedClient()
+ * throws on it. That is the point: every case here must return a ToolResult, and
+ * a rejected promise means the executor reached the network with a payload it
+ * should have refused. Ordering is the thing being pinned — validation first,
+ * client second.
+ *
+ * The data_source case is the one that matters most. Per the API reference,
+ * POST /api/now/identifyreconcile without sysparm_data_source does not fail: it
+ * stores the payload in the incomplete-payloads table. A caller who drops the
+ * parameter gets HTTP 200 and an unchanged CMDB, so the parameter has to be
+ * refused here rather than defaulted.
+ *
+ * Nothing beyond this point can be tested without an instance — identification
+ * is the engine's work, not ours.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import { execute } from "../servicenow-mcp-unified/tools/cmdb/snow_cmdb_identify_reconcile"
+import { type ServiceNowContext } from "../servicenow-mcp-unified/shared/types"
+
+const unusable: ServiceNowContext = {
+  instanceUrl: "https://unreachable.invalid",
+  clientId: "",
+  clientSecret: "",
+  tenantId: "cmdb-identify-reconcile-test",
+}
+
+const item = { className: "cmdb_ci_linux_server", values: { name: "host1", serial_number: "SN-1" } }
+
+describe("snow_cmdb_identify_reconcile input validation", () => {
+  test("an empty or missing items array is refused", async () => {
+    expect(await execute({ data_source: "ServiceNow" }, unusable)).toMatchObject({ success: false })
+    expect(await execute({ items: [], data_source: "ServiceNow" }, unusable)).toMatchObject({ success: false })
+  })
+
+  test("an item without className is refused, and the message names the index", async () => {
+    const noClass = await execute({ items: [item, { values: { name: "x" } }], data_source: "ServiceNow" }, unusable)
+    expect(noClass.success).toBe(false)
+    expect(noClass.error).toContain("items[1]")
+
+    const badValues = await execute(
+      { items: [{ className: "cmdb_ci_server", values: [] }], data_source: "ServiceNow" },
+      unusable,
+    )
+    expect(badValues.success).toBe(false)
+    expect(badValues.error).toContain("items[0]")
+  })
+
+  test("an item identified without values is not refused locally", async () => {
+    // The reference marks className as the only required field on an item: a CI
+    // can be identified through sys_object_source_info or lookup alone. Refusing
+    // that here would be stricter than the API this tool claims to mirror, so it
+    // runs on to the client and rejects on the unusable credentials instead.
+    await expect(
+      execute(
+        {
+          items: [
+            {
+              className: "cmdb_ci_server",
+              sys_object_source_info: { source_name: "ServiceNow", source_native_key: "host1" },
+            },
+          ],
+          data_source: "ServiceNow",
+        },
+        unusable,
+      ),
+    ).rejects.toThrow()
+  })
+
+  test("a missing data_source is refused rather than defaulted", async () => {
+    const result = await execute({ items: [item] }, unusable)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("data_source")
+  })
+
+  test("a relation with neither index pair nor id pair is refused", async () => {
+    const noTarget = await execute(
+      { items: [item, item], data_source: "ServiceNow", relations: [{ type: "Runs on::Runs" }] },
+      unusable,
+    )
+    expect(noTarget.success).toBe(false)
+    expect(noTarget.error).toContain("relations[0]")
+
+    const noType = await execute(
+      { items: [item, item], data_source: "ServiceNow", relations: [{ parent: 0, child: 1 }] },
+      unusable,
+    )
+    expect(noType.success).toBe(false)
+    expect(noType.error).toContain("relations[0]")
+  })
+
+  test("a parent/child index outside the items array is refused, and id pairs are not index-checked", async () => {
+    const outside = await execute(
+      { items: [item], data_source: "ServiceNow", relations: [{ parent: 0, child: 3, type: "Runs on::Runs" }] },
+      unusable,
+    )
+    expect(outside.success).toBe(false)
+    expect(outside.error).toContain("relations[0]")
+
+    // parent_id/child_id name internal_ids, which may belong to a lookup or
+    // related entry rather than a top-level item — bounds do not apply. This one
+    // is valid, so it runs on to the client and rejects instead of returning.
+    await expect(
+      execute(
+        {
+          items: [item],
+          data_source: "ServiceNow",
+          relations: [{ parent_id: "a", child_id: "b", type: "Runs on::Runs" }],
+        },
+        unusable,
+      ),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/scripted-rest-api-manage.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/scripted-rest-api-manage.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for snow_scripted_rest_api_manage that need no instance.
+ *
+ * Two things are worth pinning down here. The URL candidate list is the part of
+ * the tool that decides which address it reports back and probes — get it wrong
+ * and the tool confidently hands out a URL that 404s, which is precisely the
+ * failure the tool exists to avoid. And the update-set classification is a
+ * metadata-only property that is easy to get wrong by choosing the wrong
+ * category: sys_ws_definition and sys_ws_operation are configuration, so a
+ * create has to be gated by the update-set guard rather than sliding into the
+ * Default update set untracked.
+ */
+
+import { describe, expect, test } from "bun:test"
+import {
+  ACTIONS,
+  aclWarnings,
+  buildResourceUrlCandidates,
+  execute,
+  toolDefinition,
+} from "../servicenow-mcp-unified/tools/integration/snow_scripted_rest_api_manage"
+import { requiresUpdateSet } from "../servicenow-mcp-unified/shared/update-set-guard"
+
+describe("buildResourceUrlCandidates", () => {
+  test("puts the URI ServiceNow computed first", () => {
+    const candidates = buildResourceUrlCandidates({
+      operationUri: "/api/x_snc_shop/orders/list",
+      baseUri: "/api/x_snc_shop/orders",
+      namespace: "x_snc_shop",
+      serviceId: "orders",
+      relativePath: "/list",
+    })
+    expect(candidates[0]).toBe("/api/x_snc_shop/orders/list")
+  })
+
+  test("does not double the slash when base_uri ends in one", () => {
+    const candidates = buildResourceUrlCandidates({
+      baseUri: "/api/x_snc_shop/orders/",
+      relativePath: "/list",
+    })
+    expect(candidates).toEqual(["/api/x_snc_shop/orders/list"])
+  })
+
+  test("accepts a relative path written without a leading slash", () => {
+    const candidates = buildResourceUrlCandidates({
+      baseUri: "/api/x_snc_shop/orders",
+      relativePath: "list",
+    })
+    expect(candidates).toEqual(["/api/x_snc_shop/orders/list"])
+  })
+
+  test("keeps the namespaced and unnamespaced fallbacks apart", () => {
+    expect(
+      buildResourceUrlCandidates({
+        namespace: "x_snc_shop",
+        serviceId: "orders",
+        relativePath: "/list",
+      }),
+    ).toEqual(["/api/x_snc_shop/orders/list", "/api/orders/list"])
+  })
+
+  test("collapses candidates that resolve to the same URL", () => {
+    const candidates = buildResourceUrlCandidates({
+      operationUri: "/api/x_snc_shop/orders/list",
+      baseUri: "/api/x_snc_shop/orders",
+      namespace: "x_snc_shop",
+      serviceId: "orders",
+      relativePath: "/list",
+    })
+    expect(new Set(candidates).size).toBe(candidates.length)
+    expect(candidates).toEqual(["/api/x_snc_shop/orders/list", "/api/orders/list"])
+  })
+
+  test("a root resource keeps the API's own base as its URL", () => {
+    expect(
+      buildResourceUrlCandidates({
+        baseUri: "/api/x_snc_shop/orders",
+        relativePath: "/",
+      }),
+    ).toEqual(["/api/x_snc_shop/orders"])
+  })
+
+  test("returns nothing rather than a bare /api when it knows nothing", () => {
+    expect(buildResourceUrlCandidates({})).toEqual([])
+  })
+})
+
+/**
+ * The security warning is the tool's only statement about who can call the
+ * endpoint it just built, and it used to be computed from the caller's argument:
+ * ask for requires_acl_authorization=true and the warning disappeared, whether or
+ * not the instance stored anything. The column is one this repo has never proven
+ * against a live instance (shared/scripted-exec.ts names it in a comment and
+ * deliberately does not send it), so "the caller asked for it" is exactly the
+ * evidence that must not count.
+ */
+describe("aclWarnings", () => {
+  test("silence is only earned by the instance saying the flag is on", () => {
+    expect(aclWarnings(true, true)).toEqual([])
+    expect(aclWarnings(false, true)).toEqual([])
+  })
+
+  test("asking for enforcement the instance did not store still warns", () => {
+    const warnings = aclWarnings(true, false)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain("any authenticated user")
+  })
+
+  test("a column the instance never returned is unconfirmed, not off", () => {
+    const missing = aclWarnings(true, undefined)
+    expect(missing).toHaveLength(1)
+    expect(missing[0]).toContain("unconfirmed")
+    // The distinction has to survive into the text: "off" is a claim about the
+    // instance, "unconfirmed" is a claim about what we were told.
+    expect(aclWarnings(false, false)[0]).not.toContain("unconfirmed")
+  })
+})
+
+describe("snow_scripted_rest_api_manage classification", () => {
+  test("writing a Scripted REST API is gated by the update-set guard", () => {
+    expect(requiresUpdateSet(toolDefinition, { action: "create" })).toBe(true)
+    expect(requiresUpdateSet(toolDefinition, { action: "add_operation" })).toBe(true)
+  })
+
+  test("the read-only actions are not gated", () => {
+    expect(requiresUpdateSet(toolDefinition, { action: "get" })).toBe(false)
+    expect(requiresUpdateSet(toolDefinition, { action: "list" })).toBe(false)
+    // "verify" only calls the endpoint back; it writes no configuration.
+    expect(requiresUpdateSet(toolDefinition, { action: "verify" })).toBe(false)
+  })
+
+  test("every action the schema advertises is one the executor dispatches", () => {
+    expect(Object.keys(ACTIONS).sort()).toEqual(
+      [...(toolDefinition.inputSchema.properties.action.enum as string[])].sort(),
+    )
+  })
+
+  test("no field an update action can write advertises a schema default", () => {
+    // A model that echoes a schema default while meaning to change one other
+    // field is normal behaviour, and on the update actions it is destructive:
+    // http_method and relative_path move a live endpoint, and
+    // requires_acl_authorization=false disarms it. The create-side defaults live
+    // in the executor, where they cannot be read back as an instruction.
+    const properties = toolDefinition.inputSchema.properties as Record<string, { default?: unknown }>
+    for (const field of [
+      "name",
+      "short_description",
+      "active",
+      "operation_name",
+      "http_method",
+      "relative_path",
+      "operation_script",
+      "requires_authentication",
+      "requires_acl_authorization",
+    ]) {
+      expect(properties[field]).toBeDefined()
+      expect(properties[field].default).toBeUndefined()
+    }
+  })
+
+  test("an unknown action is rejected before anything touches the instance", async () => {
+    // Deliberately unreachable credentials: if the executor authenticated first,
+    // this would fail with a connection error instead of the argument error.
+    const result = await execute(
+      { action: "creat" },
+      { instanceUrl: "https://unreachable.invalid", clientId: "", clientSecret: "" },
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("Unknown action: creat")
+    expect(result.error).toContain("add_operation")
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/server-instructions.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/server-instructions.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The two things `createServer` puts on the initialize response — the MCP
+ * `instructions` string and the `tools.listChanged` capability — checked where
+ * they actually land, plus the notification that capability promises.
+ *
+ * `createServer` can look correct and still ship nothing: the SDK only puts
+ * `instructions` on the initialize result when `ServerOptions.instructions` is
+ * a non-empty string, and drops it silently otherwise. So this test does not
+ * read the constant — it runs a real handshake over the SDK's in-memory
+ * transport pair and asks a real `Client` what the server told it. If the
+ * option is dropped, misspelled, or moved out of the options object, the
+ * client's `getInstructions()` comes back undefined and every case here fails.
+ *
+ * The content assertions guard the three things that made this string worth
+ * writing, each of which a well-meaning edit can quietly undo:
+ *
+ *   - It has to name tool_search and tool_execute. On the stdio server those
+ *     are the entire visible surface; a model that is not told to widen the
+ *     catalog concludes the instance is read-only and stops.
+ *   - It has to stay tenant-neutral. transports/http.ts builds a fresh server
+ *     per request from this same constant while serving many customers, so an
+ *     instance URL added "just for stdio" would be handed to the next tenant
+ *     that connects.
+ *   - It must not vouch for tools it cannot vouch for. Part of this catalog
+ *     never contacts an instance, so a blanket "every tool call is real" here
+ *     is the server lending its own credibility to a fabricated result.
+ */
+
+import { describe, expect, test, afterEach } from "@jest/globals"
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join, resolve } from "path"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import { MCPPromptManager } from "../shared/mcp-prompt-manager"
+import { createServer } from "../servicenow-mcp-unified/shared/server-factory"
+import { META_TOOLS } from "../servicenow-mcp-unified/tools/meta/index"
+import { ToolSearch, buildToolIndex, setSessionStore } from "../servicenow-mcp-unified/shared/tool-search"
+import { FileToolSessionStore } from "../servicenow-mcp-unified/shared/tool-session-store"
+import { STDIO_TENANT } from "../servicenow-mcp-unified/shared/tenant-scope"
+
+/**
+ * Run one real initialize round-trip and hand back the live pair, so a test
+ * can go on to make real tool calls over the same connection.
+ */
+const connected = async (resolveContext: Parameters<typeof createServer>[0]["resolveContext"]) => {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  const server = createServer({ resolveContext, promptManager: new MCPPromptManager("servicenow-unified") })
+  const client = new Client({ name: "server-instructions-test", version: "0.0.0" })
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return {
+    client,
+    server,
+    close: async () => {
+      await client.close()
+      await server.close()
+    },
+  }
+}
+
+/**
+ * Initialize with a resolver that refuses to run: the instructions string and
+ * the capability set are static and tenant-neutral by design, so needing a
+ * ServiceNow context to complete a handshake is itself the regression. This
+ * throws rather than quietly passing a placeholder context in.
+ */
+const initialized = () =>
+  connected(async () => {
+    throw new Error("resolveContext must not be called during initialize")
+  })
+
+/** What the client was told at initialize. */
+const handshake = async () => {
+  const session = await initialized()
+  const instructions = session.client.getInstructions()
+  await session.close()
+  return instructions
+}
+
+/**
+ * The same round-trip, but refusing to hand back a missing string — otherwise
+ * every content assertion below would pass vacuously against `""` the moment
+ * the option stopped being set, and only the first case would report it.
+ */
+const instructionsText = async () => {
+  const instructions = await handshake()
+  if (typeof instructions !== "string" || instructions.length === 0)
+    throw new Error("initialize response carried no instructions — see ServerOptions.instructions in server-factory.ts")
+  return instructions
+}
+
+/**
+ * Every `snow_*` name declared anywhere under tools/. Read from source rather
+ * than from `toolRegistry.initialize()` so one unrelated tool file failing to
+ * import cannot turn this into a false accusation about the instructions.
+ */
+const toolNamesOnDisk = () => {
+  const dir = resolve(__dirname, "..", "servicenow-mcp-unified", "tools")
+  return new Set(
+    readdirSync(dir, { recursive: true })
+      .map(String)
+      .filter((entry) => entry.endsWith(".ts") && !entry.includes("__tests__"))
+      .flatMap((entry) => [
+        ...readFileSync(resolve(dir, entry), "utf-8").matchAll(/name:\s*["'](snow_[a-z0-9_]+)["']/g),
+      ])
+      .map((match) => match[1]),
+  )
+}
+
+describe("MCP server instructions", () => {
+  test("the initialize response carries them", async () => {
+    const instructions = await handshake()
+    expect(typeof instructions).toBe("string")
+    expect((instructions ?? "").length).toBeGreaterThan(200)
+  })
+
+  test("they tell the model how to widen a deferred catalog", async () => {
+    const instructions = await instructionsText()
+    for (const meta of META_TOOLS) {
+      expect(instructions).toContain(meta.definition.name)
+    }
+    // The status markers are what tool_search actually returns
+    // (tools/meta/index.ts statusFor) — telling the model to read a marker we
+    // do not emit would send it looking for something that is not there.
+    expect(instructions).toContain("[DEFERRED]")
+  })
+
+  test("every tool it names is a tool this server has", async () => {
+    const instructions = await instructionsText()
+    const known = toolNamesOnDisk()
+    for (const meta of META_TOOLS) known.add(meta.definition.name)
+    // Existence only. `known` is every snow_* name declared under tools/, so
+    // this catches a typo or a tool that was deleted — it does not catch a name
+    // that exists but does not do what it says. Some executors in this catalog
+    // never contact the instance; recommending one of those from the initialize
+    // string would pass here and still be a lie. Read the executor before
+    // adding a name.
+    expect(known.size).toBeGreaterThan(100)
+    expect([...new Set(instructions.match(/snow_[a-z0-9_]{3,}/g) ?? [])].filter((n) => !known.has(n))).toEqual([])
+  })
+
+  test("they carry no instance identity", async () => {
+    const instructions = await instructionsText()
+    // A per-request HTTP server hands this same string to every tenant.
+    expect(instructions).not.toMatch(/https?:\/\//)
+    expect(instructions).not.toMatch(/service-now\.com/i)
+  })
+
+  test("they do not vouch for the whole catalog", async () => {
+    const instructions = await instructionsText()
+    // 71 executors in this catalog never construct a client, and 18 POST to
+    // sys_script_execution and return the Table API's echo as if it were script
+    // output. An earlier revision opened with "Every tool call is a real REST
+    // call against that instance ... and writes are real writes", which reads
+    // as the server vouching for all of them and makes a fabricated success
+    // envelope more credible rather than less. The wording below is not sacred;
+    // what has to survive an edit is that the caveat is stated at all and that
+    // the model is told how to check — so this asserts the two halves of that,
+    // and will fail if a tidy-up deletes either.
+    expect(instructions).toMatch(/without ever calling the instance/i)
+    expect(instructions).toMatch(/read the record back/i)
+  })
+})
+
+/**
+ * The other half of the initialize response: the server says the tool list can
+ * change, so it has to actually say when it changes.
+ *
+ * On stdio the whole catalog is registered `deferred: true`, so `tools/list`
+ * returns two meta-tools until a `tool_search` enables more — a change a client
+ * that cached the list can only learn about from
+ * `notifications/tools/list_changed`. These run a real handshake and a real
+ * `tools/call` and watch the wire, because a declared capability with no
+ * emitter is a false claim and reads identically in the source.
+ *
+ * No ServiceNow instance is involved: `tool_search` only reads the in-process
+ * index and the session store, both of which are set up here for real.
+ */
+describe("tools/list_changed", () => {
+  const dirs: string[] = []
+  afterEach(() => {
+    while (dirs.length > 0) rmSync(dirs.pop()!, { recursive: true, force: true })
+    ToolSearch.clearIndex()
+  })
+
+  /**
+   * A stdio session pointed at a throwaway session store, with `snow_query_table`
+   * in the search index at the given deferral. The name is a real tool so the
+   * index entry is the shape the transports build; nothing executes it.
+   */
+  const stdioSession = async (deferred: boolean) => {
+    const dir = mkdtempSync(join(tmpdir(), "mcp-list-changed-"))
+    dirs.push(dir)
+    setSessionStore(new FileToolSessionStore(dir))
+    ToolSearch.clearIndex()
+    ToolSearch.registerTools(
+      buildToolIndex(
+        [{ name: "snow_query_table", description: "Query any ServiceNow table with an encoded query." }],
+        () => "operations",
+        deferred,
+      ),
+    )
+    return connected(async () => ({
+      sessionId: "ses_list_changed",
+      origin: "stdio" as const,
+      // tool_search never authenticates, and leaving these blank keeps it that
+      // way: if this test ever starts needing real credentials, something on
+      // the meta path has started reaching for the instance.
+      serviceNow: { instanceUrl: "", clientId: "", clientSecret: "", tenantId: STDIO_TENANT },
+    }))
+  }
+
+  /** Call tool_search over the wire and hand back the payload it reported. */
+  const search = async (client: Client) => {
+    const result = await client.callTool({ name: "tool_search", arguments: { query: "query table" } })
+    return JSON.parse((result.content as { text: string }[])[0].text)
+  }
+
+  test("the capability is declared on the initialize response", async () => {
+    const session = await initialized()
+    expect(session.client.getServerCapabilities()?.tools?.listChanged).toBe(true)
+    await session.close()
+  })
+
+  test("a tool_search that enables deferred tools notifies the client", async () => {
+    const session = await stdioSession(true)
+    // InMemoryTransport delivers synchronously and the notification is sent
+    // before the tools/call response, so by the time the call resolves the
+    // handler has either run or never will — no timers, no flake.
+    const notifications: unknown[] = []
+    session.client.setNotificationHandler(ToolListChangedNotificationSchema, async (n) => {
+      notifications.push(n)
+    })
+    expect((await search(session.client)).enabled_tools).toEqual(["snow_query_table"])
+    expect(notifications.length).toBe(1)
+    await session.close()
+  })
+
+  test("a search that enabled nothing stays quiet", async () => {
+    // Mirrors the shipped HTTP server, which registers the catalog with
+    // `deferred: false`: nothing is gated, so nothing is written to the session
+    // store and the tool list did not change. Notifying anyway would train
+    // clients to re-list on every search.
+    const session = await stdioSession(false)
+    const notifications: unknown[] = []
+    session.client.setNotificationHandler(ToolListChangedNotificationSchema, async (n) => {
+      notifications.push(n)
+    })
+    expect((await search(session.client)).enabled_tools).toEqual([])
+    expect(notifications.length).toBe(0)
+    await session.close()
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
@@ -38,7 +38,11 @@ const PACKAGE_ROOT = resolve(__dirname, "..", "..")
  * list cannot quietly drift out of date the way an unchecked manifest can.
  */
 const AWAITING_PROBE = [
+  "snow_acl_explain",
+  "snow_app_repo_manage",
   "snow_blast_radius_sys_properties",
+  "snow_cmdb_identify_reconcile",
+  "snow_describe_field",
   "snow_diagnose_setup",
   "snow_fluent_build",
   "snow_fluent_dependencies",
@@ -48,6 +52,8 @@ const AWAITING_PROBE = [
   "snow_fluent_install",
   "snow_fluent_status",
   "snow_fluent_transform",
+  "snow_scripted_rest_api_manage",
+  "snow_validate_query",
 ]
 
 const manifest = loadSnRolesManifest()

--- a/packages/servicenow-mcp/src/__tests__/snow-aggregate-metrics.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/snow-aggregate-metrics.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The two pure halves of snow_aggregate_metrics: the arguments it turns into
+ * Aggregate API parameters, and the payload it turns back into rows.
+ *
+ * Both are the bug this tool shipped with. It sent `sysparm_query: ""` however
+ * it was called, so a filtered COUNT quietly counted the whole table, and the
+ * only aggregate parameter it ever sent was sysparm_count, so an AVG asked the
+ * API to average nothing and still reported success. Neither failure needs an
+ * instance to detect: the first is visible in the parameters, the second in
+ * how the response is read.
+ *
+ * The fixture in the second block is the grouped-average response body from
+ * the Aggregate API reference, not an invented one:
+ * https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_AggregateAPI.html
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import {
+  buildStatsParams,
+  readStats,
+  resolveMaxGroups,
+} from "../servicenow-mcp-unified/tools/aggregators/snow_aggregate_metrics"
+
+describe("buildStatsParams", () => {
+  test("regression: the caller's filter reaches sysparm_query", () => {
+    expect(buildStatsParams({ query: "active=true^priority=1" }).params).toMatchObject({
+      sysparm_query: "active=true^priority=1",
+      sysparm_count: "true",
+    })
+  })
+
+  test("no filter sends no sysparm_query at all, rather than an empty one", () => {
+    expect(buildStatsParams({}).params).not.toHaveProperty("sysparm_query")
+  })
+
+  test("regression: each aggregation carries the field in its own documented parameter", () => {
+    expect(buildStatsParams({ aggregation: "AVG", field: "reassignment_count" }).params).toMatchObject({
+      sysparm_avg_fields: "reassignment_count",
+    })
+    expect(buildStatsParams({ aggregation: "SUM", field: "business_stc" }).params).toMatchObject({
+      sysparm_sum_fields: "business_stc",
+    })
+    expect(buildStatsParams({ aggregation: "MIN", field: "business_stc" }).params).toMatchObject({
+      sysparm_min_fields: "business_stc",
+    })
+    expect(buildStatsParams({ aggregation: "MAX", field: "business_stc" }).params).toMatchObject({
+      sysparm_max_fields: "business_stc",
+    })
+  })
+
+  test("COUNT sends no field list even when a field is passed", () => {
+    const params = buildStatsParams({ aggregation: "COUNT", field: "reassignment_count" }).params
+    expect(Object.keys(params).filter((key) => key.endsWith("_fields"))).toEqual([])
+  })
+
+  test("several fields go into one comma-separated list", () => {
+    expect(buildStatsParams({ aggregation: "AVG", field: "business_stc, reassignment_count" }).params).toMatchObject({
+      sysparm_avg_fields: "business_stc,reassignment_count",
+    })
+  })
+
+  test("an aggregation that needs a field refuses to run without one", () => {
+    expect(() => buildStatsParams({ aggregation: "AVG" })).toThrow(/needs a field/)
+    expect(() => buildStatsParams({ aggregation: "SUM", field: "  " })).toThrow(/needs a field/)
+  })
+
+  test("an unsupported aggregation is refused instead of silently aggregating nothing", () => {
+    expect(() => buildStatsParams({ aggregation: "MEDIAN", field: "business_stc" })).toThrow(/must be one of/)
+  })
+
+  test("the case a model sends is accepted", () => {
+    expect(buildStatsParams({ aggregation: "avg", field: "business_stc" }).aggregation).toBe("AVG")
+  })
+
+  test("a filter that is not a string is refused rather than sent as [object Object]", () => {
+    // The stringified version reaches sysparm_query as an unparseable encoded
+    // query, and the caller would read the answer as a filtered number.
+    expect(() => buildStatsParams({ query: { active: true } })).toThrow(/query must be an encoded query string/)
+    expect(() => buildStatsParams({ having: 3 })).toThrow(/having must be/)
+  })
+
+  test("group_by stays lenient, because a list of field names stringifies correctly", () => {
+    expect(buildStatsParams({ group_by: ["assignment_group", "state"] }).params.sysparm_group_by).toBe(
+      "assignment_group,state",
+    )
+  })
+
+  test("display_value takes the boolean a model sends as well as the API's own values", () => {
+    expect(buildStatsParams({ display_value: true }).params.sysparm_display_value).toBe("true")
+    expect(buildStatsParams({ display_value: "all" }).params.sysparm_display_value).toBe("all")
+    expect(buildStatsParams({ display_value: false }).params).not.toHaveProperty("sysparm_display_value")
+  })
+})
+
+describe("readStats", () => {
+  const grouped = [
+    {
+      stats: { avg: { business_stc: "804162.7143", reassignment_count: "1.0000" } },
+      groupby_fields: [{ value: "", field: "assignment_group" }],
+    },
+  ]
+
+  test("a grouped average is read out of stats.avg.<field>", () => {
+    expect(readStats(grouped, "AVG", ["business_stc"])[0]).toMatchObject({
+      group: { assignment_group: "" },
+      value: "804162.7143",
+    })
+  })
+
+  test("an aggregate the instance did not return stays undefined, never 0", () => {
+    const row = readStats(grouped, "SUM", ["business_stc"])[0]
+    expect(row?.value).toBeUndefined()
+    // The raw stats still travel back, so the caller can see what did come.
+    expect(row?.stats).toEqual(grouped[0].stats)
+  })
+
+  test("an ungrouped response is a single object, not an array", () => {
+    expect(readStats({ stats: { count: "249" } }, "COUNT", [])).toEqual([
+      { group: undefined, count: "249", value: "249", stats: { count: "249" } },
+    ])
+  })
+
+  test("no matching records is an empty list, not a row of zeroes", () => {
+    expect(readStats([], "COUNT", [])).toEqual([])
+    expect(readStats(undefined, "COUNT", [])).toEqual([])
+  })
+
+  test("a group label uses the display value when the instance sends one", () => {
+    const row = readStats(
+      [
+        {
+          stats: { count: "3" },
+          groupby_fields: [{ field: "assignment_group", value: "abc123", display_value: "Network" }],
+        },
+      ],
+      "COUNT",
+      [],
+    )[0]
+    expect(row?.group).toEqual({ assignment_group: "Network" })
+  })
+})
+
+describe("resolveMaxGroups", () => {
+  test("a value that is not a row count falls back to the default instead of becoming NaN", () => {
+    // Math.max(1, Number("all")) is NaN and slice(0, NaN) is [], so this used
+    // to return zero rows and then report that the instance answered nothing.
+    expect(resolveMaxGroups("all")).toBe(100)
+    expect(resolveMaxGroups("")).toBe(100)
+    expect(resolveMaxGroups({})).toBe(100)
+    expect(resolveMaxGroups(undefined)).toBe(100)
+    expect(resolveMaxGroups(-5)).toBe(100)
+  })
+
+  test("a usable cap is kept", () => {
+    expect(resolveMaxGroups(25)).toBe(25)
+    expect(resolveMaxGroups("25")).toBe(25)
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/snow-describe-field.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/snow-describe-field.test.ts
@@ -1,0 +1,269 @@
+/**
+ * The two resolution rules snow_describe_field exists for.
+ *
+ * Both are rules the rest of the repo gets wrong today, and both are pure
+ * functions of rows already fetched — so they can be pinned without an
+ * instance, and a regression in either is invisible from the tool's output
+ * shape alone.
+ *
+ *   1. A child table's sys_choice rows *replace* its parent's for that element.
+ *      Merging the two sets produces a list containing values the child cannot
+ *      hold, which is worse than returning nothing: it reads as authoritative.
+ *      snow_fsm_work_order_manage hardcodes its own state list under a TODO
+ *      rather than reading this, so nothing else in the repo would catch it.
+ *
+ *   2. Dictionary overrides apply nearest-table-last. The override rows arrive
+ *      in chain order (most-derived first) and are applied in reverse, so the
+ *      override closest to the queried table survives. Applying them in the
+ *      order received silently hands the win to the root class.
+ *
+ * The row shapes below are the two the Table API actually produces: plain
+ * strings, and the `{ display_value, value }` cells that sysparm_display_value=all
+ * returns. Both paths go through the same cell reader, so both are exercised.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import { applyOverrides, readOverride, selectChoiceSet, toolDefinition } from "../servicenow-mcp-unified/tools/operations/snow_describe_field"
+
+const choice = (table: string, value: string, label: string, extra: Record<string, string> = {}) => ({
+  name: table,
+  element: "state",
+  value,
+  label,
+  sequence: "0",
+  inactive: "false",
+  language: "en",
+  ...extra,
+})
+
+const cell = (value: string) => ({ display_value: value, value })
+
+describe("selectChoiceSet", () => {
+  test("a child table's choices replace its parent's, they are not merged", () => {
+    const result = selectChoiceSet(
+      ["incident", "task"],
+      [
+        choice("task", "1", "Open"),
+        choice("task", "3", "Closed Complete"),
+        choice("incident", "1", "New"),
+        choice("incident", "6", "Resolved"),
+      ],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.source_table).toBe("incident")
+    expect(result.choices.map((entry) => entry.value)).toEqual(["1", "6"])
+    expect(result.choices.map((entry) => entry.label)).toEqual(["New", "Resolved"])
+    // The parent's set is reported as a count so the caller can see it exists,
+    // but none of its values leak into the answer.
+    expect(result.counts_by_table).toEqual([
+      { table: "incident", count: 2 },
+      { table: "task", count: 2 },
+    ])
+  })
+
+  test("the parent's choices apply when the child defines none", () => {
+    const result = selectChoiceSet(["incident", "task"], [choice("task", "1", "Open")], {
+      language: "en",
+      includeInactive: false,
+    })
+
+    expect(result.source_table).toBe("task")
+    expect(result.choices.map((entry) => entry.value)).toEqual(["1"])
+    expect(result.counts_by_table).toEqual([{ table: "task", count: 1 }])
+  })
+
+  test("a table with only inactive choices does not shadow its parent's list", () => {
+    const result = selectChoiceSet(
+      ["incident", "task"],
+      [choice("incident", "9", "Retired", { inactive: "true" }), choice("task", "1", "Open")],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.source_table).toBe("task")
+    expect(result.choices.map((entry) => entry.value)).toEqual(["1"])
+    expect(result.inactive_excluded).toBe(1)
+  })
+
+  test("include_inactive_choices brings the inactive rows back and keeps the flag visible", () => {
+    const result = selectChoiceSet(
+      ["incident", "task"],
+      [choice("incident", "9", "Retired", { inactive: "true" }), choice("task", "1", "Open")],
+      { language: "en", includeInactive: true },
+    )
+
+    expect(result.source_table).toBe("incident")
+    expect(result.choices).toEqual([
+      { value: "9", label: "Retired", sequence: "0", inactive: "true", language: "en" },
+    ])
+  })
+
+  test("rows in another language are excluded, rows with no language set are kept", () => {
+    const result = selectChoiceSet(
+      ["incident"],
+      [
+        choice("incident", "1", "Nieuw", { language: "nl" }),
+        choice("incident", "1", "New"),
+        choice("incident", "2", "In Progress", { language: "" }),
+      ],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.choices.map((entry) => entry.label)).toEqual(["New", "In Progress"])
+  })
+
+  test("choices are ordered by sequence and each keeps its own dependent_value", () => {
+    const result = selectChoiceSet(
+      ["sc_cat_item"],
+      [
+        choice("sc_cat_item", "b", "Second", { sequence: "20", dependent_value: "hardware" }),
+        choice("sc_cat_item", "a", "First", { sequence: "10", dependent_value: "software" }),
+      ],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.choices.map((entry) => entry.value)).toEqual(["a", "b"])
+    expect(result.choices.map((entry) => entry.dependent_value)).toEqual(["software", "hardware"])
+  })
+
+  test("a child whose choices exist only in another language is reported, not silently skipped", () => {
+    // The dangerous case: the parent's list is returned for a child that has its own,
+    // which is the union-vs-replace error inverted. Answering is fine; answering
+    // without saying the child was dropped is not.
+    const result = selectChoiceSet(
+      ["incident", "task"],
+      [choice("incident", "6", "Opgelost", { language: "nl" }), choice("task", "1", "Open")],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.source_table).toBe("task")
+    expect(result.skipped_for_language).toEqual(["incident"])
+  })
+
+  test("a parent skipped for language is not reported — its list was never going to win", () => {
+    const result = selectChoiceSet(
+      ["incident", "task"],
+      [choice("incident", "1", "New"), choice("task", "1", "Open", { language: "nl" })],
+      { language: "en", includeInactive: false },
+    )
+
+    expect(result.source_table).toBe("incident")
+    expect(result.skipped_for_language).toEqual([])
+  })
+
+  test("no rows anywhere on the chain leaves the source table unset rather than guessing one", () => {
+    const result = selectChoiceSet(["incident", "task"], [], { language: "en", includeInactive: false })
+
+    expect(result.source_table).toBeUndefined()
+    expect(result.choices).toEqual([])
+    expect(result.counts_by_table).toEqual([])
+  })
+})
+
+describe("readOverride", () => {
+  /**
+   * The row below is ServiceNow's own, field for field: the sys_dictionary_override
+   * shipped in the NeedIt training application, which overrides task.state to default
+   * to 13. It is here because the flag columns are *suffixed* (`default_value_override`),
+   * and an earlier version of this file looked for `override_default_value` — every
+   * override silently produced an empty `sets` while the summary still reported
+   * "1 dictionary override(s) applied".
+   *
+   * https://raw.githubusercontent.com/ServiceNow/devtraining-needit-utah/master/update/sys_dictionary_override_5bd046529f703200bde5f79ff57fcfe2.xml
+   */
+  test("a real sys_dictionary_override row yields the one attribute its flag marks", () => {
+    const result = readOverride("x_58872_needit_needit", {
+      name: cell("x_58872_needit_needit"),
+      element: cell("state"),
+      base_table: cell("task"),
+      sys_id: cell("5bd046529f703200bde5f79ff57fcfe2"),
+      attributes: cell(""),
+      attributes_override: cell("false"),
+      calculation: cell(""),
+      calculation_override: cell("false"),
+      default_value: cell("13"),
+      default_value_override: cell("true"),
+      dependent: cell(""),
+      dependent_override: cell("false"),
+      display_override: cell("false"),
+      mandatory: cell("false"),
+      mandatory_override: cell("false"),
+      read_only: cell("false"),
+      read_only_override: cell("false"),
+      reference_qual: cell(""),
+      reference_qual_override: cell("false"),
+    })
+
+    expect(result.sets).toEqual({ default_value: "13" })
+    expect(result.base_table).toBe("task")
+    expect(result.unpaired).toBeUndefined()
+  })
+
+  test("an attribute whose flag is false or empty is left to the base dictionary row", () => {
+    const result = readOverride("incident", {
+      name: cell("incident"),
+      mandatory: cell("true"),
+      mandatory_override: cell("true"),
+      default_value: cell("1"),
+      default_value_override: cell("false"),
+      read_only: cell("true"),
+      read_only_override: cell(""),
+    })
+
+    expect(result.sets).toEqual({ mandatory: "true" })
+  })
+
+  test("an override flag with no matching column is reported, not dropped", () => {
+    // display_override is the real one: sys_dictionary_override carries the flag but
+    // has no `display` column beside it, so this is expected output on such a row.
+    const result = readOverride("incident", {
+      name: cell("incident"),
+      display_override: cell("true"),
+    })
+
+    expect(result.sets).toBeUndefined()
+    expect(result.unpaired).toEqual(["display"])
+  })
+
+  test("plain (non display_value) rows read the same way", () => {
+    const result = readOverride("change_request", {
+      name: "change_request",
+      read_only_override: "true",
+      read_only: "true",
+    })
+
+    expect(result.sets).toEqual({ read_only: "true" })
+  })
+})
+
+describe("applyOverrides", () => {
+  test("the override nearest the queried table wins over an ancestor's", () => {
+    // Chain order: incident, task. Both override default_value; incident is nearer.
+    const merged = applyOverrides(
+      { column_label: "State", default_value: "", mandatory: "false" },
+      [
+        { table: "incident", sets: { default_value: "1" } },
+        { table: "task", sets: { default_value: "-5", mandatory: "true" } },
+      ],
+    )
+
+    expect(merged.default_value).toBe("1")
+    // An attribute only the ancestor overrides still applies.
+    expect(merged.mandatory).toBe("true")
+    // Attributes nobody overrides keep the base dictionary value.
+    expect(merged.column_label).toBe("State")
+  })
+
+  test("no overrides leaves the base dictionary attributes untouched", () => {
+    expect(applyOverrides({ mandatory: "false" }, [])).toEqual({ mandatory: "false" })
+  })
+})
+
+describe("toolDefinition", () => {
+  test("is a read tool — it must never be gated as a write, and must never write", () => {
+    expect(toolDefinition.name).toBe("snow_describe_field")
+    expect(toolDefinition.permission).toBe("read")
+    expect(toolDefinition.allowedRoles).toContain("stakeholder")
+    expect(toolDefinition.inputSchema.required).toEqual(["table", "field"])
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/snow-validate-query.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/snow-validate-query.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The clause splitter behind snow_validate_query.
+ *
+ * The tool's whole value is that it does not cry wolf: a clause it reports as
+ * an unknown field has to really be one, because the caller's next move is to
+ * edit a query that was fine. Every case below is a way of getting that wrong,
+ * and the four marked "regression" are ways the encoded-query parser private to
+ * snow_manage_flow.ts (parseEncodedQuery, ~line 3921) gets it wrong today:
+ *
+ *   - splitting on a bare /\^OR/ turns "^ORDERBYnumber" into the clause
+ *     "DERBYnumber", which reads as a misspelled field;
+ *   - scanning a longest-first operator list and taking the first hit anywhere
+ *     in the clause turns "short_description=IN PROGRESS" into field
+ *     "short_description=" with operator IN, because IN is tried before =.
+ *
+ * Nothing here needs an instance: splitting is a pure function of the string,
+ * and it runs before any dictionary lookup.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import {
+  countsContradictUnknown,
+  parseQuery,
+  toolDefinition,
+} from "../servicenow-mcp-unified/tools/validators/snow_validate_query"
+
+const fields = (query: string) => parseQuery(query).map((clause) => clause.field ?? null)
+const unchecked = (query: string) => parseQuery(query).map((clause) => Boolean(clause.unchecked))
+
+describe("parseQuery", () => {
+  test("regression: ^ORDERBY is a sort directive, not an ^OR clause", () => {
+    expect(fields("active=true^ORDERBYnumber")).toEqual(["active", null])
+    expect(fields("active=true^ORDERBYDESCsys_created_on")).toEqual(["active", null])
+    expect(unchecked("active=true^ORDERBYDESCsys_created_on")).toEqual([false, true])
+  })
+
+  test("^OR still separates a real or-clause", () => {
+    expect(fields("active=true^ORstate=2")).toEqual(["active", "state"])
+    expect(parseQuery("active=true^ORstate=2")[1]?.prefix).toBe("^OR")
+  })
+
+  test("regression: an operator word inside a value does not become the operator", () => {
+    expect(parseQuery("short_description=IN PROGRESS")[0]).toMatchObject({
+      field: "short_description",
+      operator: "=",
+      value: "IN PROGRESS",
+    })
+    expect(parseQuery("state=ON HOLD")[0]).toMatchObject({ field: "state", operator: "=", value: "ON HOLD" })
+  })
+
+  test("the longest operator wins when two start at the same position", () => {
+    expect(parseQuery("priority>=2")[0]).toMatchObject({ operator: ">=", value: "2" })
+    expect(parseQuery("sys_class_nameINSTANCEOFcmdb_ci_server")[0]).toMatchObject({
+      field: "sys_class_name",
+      operator: "INSTANCEOF",
+    })
+    expect(parseQuery("stateNOT IN1,2")[0]).toMatchObject({ field: "state", operator: "NOT IN" })
+  })
+
+  test("conditions inside a ^JOIN or RLQUERY block belong to another table and are not checked", () => {
+    expect(unchecked("JOINincident.assignment_group=sys_user_group.sys_id!active=true^ENDJOIN^active=true")).toEqual([
+      true,
+      true,
+      false,
+    ])
+    expect(unchecked("RLQUERYtask_ci.task,>0^ci_item.nameLIKEsrv^ENDRLQUERY^number=INC001")).toEqual([
+      true,
+      true,
+      true,
+      false,
+    ])
+  })
+
+  test("an unterminated block suspends checking to the end rather than guessing", () => {
+    expect(unchecked("JOINincident.caller_id=sys_user.sys_id!active=true^vip=true")).toEqual([true, true])
+  })
+
+  test("what lives outside sys_dictionary is unchecked, never unknown", () => {
+    const parsed = parseQuery("assigned_to.department=x^variables.model=y^sys_tags=z^123TEXTQUERY321=printer")
+    expect(parsed.map((clause) => clause.unchecked !== undefined)).toEqual([true, true, true, true])
+    // The dot-walk still names its entry point, so the tool can say whether
+    // `assigned_to` itself exists.
+    expect(parsed[0]?.root).toBe("assigned_to")
+    expect(parsed[1]?.root).toBeUndefined()
+  })
+
+  test("a javascript: value keeps its field checkable", () => {
+    expect(parseQuery("caller_id=javascript:gs.getUserID()")[0]).toEqual({
+      prefix: "",
+      clause: "caller_id=javascript:gs.getUserID()",
+      field: "caller_id",
+      operator: "=",
+      value: "javascript:gs.getUserID()",
+    })
+  })
+
+  test("empty and terminator-only queries produce no clauses to check", () => {
+    expect(parseQuery("")).toEqual([])
+    expect(parseQuery("^EQ")).toEqual([])
+    expect(fields("active=true^EQ")).toEqual(["active"])
+  })
+
+  test("a clause with no operator is unchecked instead of being read as a field", () => {
+    expect(parseQuery("garbage")[0]).toMatchObject({ unchecked: "no encoded-query operator found in this clause" })
+  })
+})
+
+/**
+ * The tool used to keep its "unknown" verdict even when its own two count
+ * queries had just disproved it: a clause that changes the number of matched
+ * records is a clause the instance is filtering on, so the field exists and the
+ * dictionary read missed it. That combination is unreachable under either
+ * documented behaviour for an invalid clause, which is what makes it evidence.
+ */
+describe("countsContradictUnknown", () => {
+  test("neither documented invalid-clause behaviour contradicts the verdict", () => {
+    // Ignored: with and without the clause the query matches the same rows.
+    expect(countsContradictUnknown(42, 42)).toBe(false)
+    // glide.invalid_query.returns_no_rows: the query as written matches none.
+    expect(countsContradictUnknown(0, 42)).toBe(false)
+    expect(countsContradictUnknown(0, 0)).toBe(false)
+  })
+
+  test("a clause that moved the count is a clause the instance filtered on", () => {
+    expect(countsContradictUnknown(3, 42)).toBe(true)
+    // ^OR puts the unresolved clause on the widening side, so the count can also
+    // drop when it is removed.
+    expect(countsContradictUnknown(50, 42)).toBe(true)
+  })
+
+  test("a missing count proves nothing either way", () => {
+    expect(countsContradictUnknown(null, 42)).toBe(false)
+    expect(countsContradictUnknown(3, null)).toBe(false)
+    expect(countsContradictUnknown(null, null)).toBe(false)
+  })
+})
+
+describe("toolDefinition", () => {
+  test("is read-only: it looks records up, it never selects them for change", () => {
+    expect(toolDefinition.permission).toBe("read")
+    expect(toolDefinition.allowedRoles).toContain("stakeholder")
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/call-tool.ts
@@ -7,6 +7,7 @@
  *   - regular tools go through permission check + retryable execution
  */
 
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js"
 import { toolRegistry } from "../shared/tool-registry.js"
 import { executeWithErrorHandling, SnowFlowError, classifyError } from "../shared/error-handler.js"
@@ -34,7 +35,7 @@ import {
 import { setCurrentUpdateSet } from "../shared/update-set-rebind.js"
 import { type HandlerDeps } from "./types.js"
 
-export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any) => {
+export const callTool = (deps: HandlerDeps, server: Server) => async (request: any, extra?: any) => {
   const { name, arguments: args } = request.params
 
   // Enhanced logging: show tool name AND key parameters
@@ -62,6 +63,18 @@ export const callTool = (deps: HandlerDeps) => async (request: any, extra?: any)
       // the meta path can filter stdio-only tools out of HTTP discovery.
       const contextWithSession = { ...context, sessionId, origin: ctx.origin }
       const result = await tool_search_exec(args as any, contextWithSession)
+      // Enabling a deferred tool changes what the next tools/list returns, and
+      // a client that caches the list learns that only from this notification.
+      // `enabled_tools` is what the call actually wrote to the session store
+      // (meta/index.ts applyEnablement), not what it was asked to write, so an
+      // enable=false search or a search that found nothing deferred stays
+      // silent. Only stdio can get here: http-entry registers the catalog with
+      // `deferred: false` so `enabled_tools` is always empty there, and
+      // transports/http.ts is stateless so there is no stream to notify on.
+      // A notification that cannot be delivered must not turn a successful
+      // search into a tool error — the search already happened.
+      if (ctx.origin === "stdio" && result?.enabled_tools?.length > 0)
+        await server.sendToolListChanged().catch((e) => mcpDebug(`[Server] tools/list_changed notification failed: ${e}`))
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       }

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/register.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/handlers/register.ts
@@ -22,7 +22,10 @@ import { type HandlerDeps } from "./types.js"
 
 export const registerHandlers = (server: Server, deps: HandlerDeps): void => {
   server.setRequestHandler(ListToolsRequestSchema, listTools(deps))
-  server.setRequestHandler(CallToolRequestSchema, callTool(deps))
+  // callTool gets the Server itself because one tool changes the tool list:
+  // tool_search enables deferred tools for the session, and the client only
+  // learns about it from notifications/tools/list_changed.
+  server.setRequestHandler(CallToolRequestSchema, callTool(deps, server))
   server.setRequestHandler(ListPromptsRequestSchema, listPrompts(deps))
   server.setRequestHandler(GetPromptRequestSchema, getPrompt(deps))
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/server-factory.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/server-factory.ts
@@ -10,6 +10,57 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { registerHandlers } from "../handlers/register.js"
 import { type HandlerDeps } from "../handlers/types.js"
 
+/**
+ * The `instructions` string on the initialize response (MCP lifecycle spec,
+ * 2025-06-18). Clients hand this to the model before it sees a single tool, so
+ * it is the only place to say the thing a cold session cannot work out for
+ * itself: `tools/list` shows two meta-tools, and without being told, a model
+ * reads that as "this server can barely do anything" and stops.
+ *
+ * Three constraints on anything added here.
+ *
+ * It must be true in every mode. Deferral is not a fixed property of the
+ * server: `handlers/list-tools.ts` gates on SNOW_LAZY_TOOLS (default on) AND on
+ * the `deferred` flag each transport registers in the tool index, and
+ * `transports/http-entry.ts` registers the whole catalog with `deferred: false`
+ * — so the shipped HTTP server lists everything while stdio lists two. The text
+ * therefore describes what the model can observe in its own `tools/list` rather
+ * than asserting one mode.
+ *
+ * It must be tenant-neutral. Both transports build their server from this same
+ * constant, and the HTTP transport builds a fresh one per request while serving
+ * many customers — so an instance URL, a username or an environment label put
+ * in here would be handed to whichever tenant asked next. It cannot name the
+ * credentials either: `transports/http-resolver.ts` resolves tenant and
+ * credentials per request from a downstream endpoint, so consecutive requests
+ * on one server can be different customers. Naming the instance needs a
+ * per-session string, not this one; see the test in
+ * src/__tests__/server-instructions.test.ts, which fails on an embedded URL.
+ *
+ * It must not make claims on the catalog's behalf. A model reads `instructions`
+ * as the server's own ground truth, so a universal like "every tool call is a
+ * real REST call" is not a harmless simplification — it lends credibility to
+ * the executors that fabricate. Dozens of them never construct a client at all,
+ * and a cluster of them POST a record to sys_script_execution and return the
+ * Table API's echo as if it were script output. So the claim here is scoped to
+ * the server (what a write that lands means), and verification is handed back
+ * to the model rather than promised on the tools' behalf.
+ *
+ * Failure modes are named, not re-explained: the guard messages in
+ * shared/update-set-guard.ts already spell out the exact retry at the moment of
+ * failure, and repeating them here would be one more thing to keep in sync.
+ */
+const INSTRUCTIONS = `Bridge to a live ServiceNow instance, not a sandbox: a write that reaches the instance is a real change to real data, made with the credentials this session resolves to. Not every tool reaches it — some compute locally by design, and a few report success without ever calling the instance — so a tool's own success envelope is a claim, not proof. When a write matters, read the record back.
+
+FINDING TOOLS. The catalog is large and usually deferred. If tools/list shows only tool_search and tool_execute, the rest is hidden until you ask for it: call tool_search({ query: "..." }) with words for the job ("incident", "widget deploy", "update set", "cmdb"), then read the marker on each hit — [AVAILABLE] and [ENABLED] are callable now, [DEFERRED] is not — and run tool_execute({ tool, args }). Anything listed in tools/list can also be called directly. If tools/list already shows hundreds of snow_* tools then nothing is deferred here and tool_search is only a lookup. Never conclude from a short tools/list that a capability is missing; search first.
+
+WHEN CALLS FAIL it is usually one of three things.
+- No usable credentials: tools that touch the instance return an authentication error rather than an empty result, and rephrasing the call will not help.
+- The instance answers with an HTML page or a 502/503 instead of JSON, which surfaces as a parse or auth failure. A hibernating developer instance does this — open it in a browser to wake it, then retry.
+- A guard blocked a write: configuration writes need an active update set for the session, and writes to an instance labelled production need the user's explicit approval. The error names the exact call to make next. Follow it rather than working around it with a background script.
+
+snow_session_context returns the authenticated user, their roles, the current update set and the domain in one call — ground role and ACL reasoning on it instead of guessing. snow_diagnose_setup (stdio server only) reports which credential source was used and whether the instance is answering.`
+
 export interface ServerDeps extends HandlerDeps {
   name?: string
   version?: string
@@ -23,9 +74,17 @@ export const createServer = (deps: ServerDeps): Server => {
     },
     {
       capabilities: {
-        tools: {},
+        // The tool list is not fixed for the life of a stdio session: a
+        // tool_search that enables deferred tools changes what the next
+        // tools/list returns, and a client that caches the list has no way to
+        // find out. handlers/call-tool.ts emits the matching notification, so
+        // this declaration is backed by an emitter rather than aspirational —
+        // the SDK does not check (assertNotificationCapability only asks
+        // whether `tools` is truthy), the client does.
+        tools: { listChanged: true },
         prompts: {},
       },
+      instructions: INSTRUCTIONS,
     },
   )
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/access-control/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/access-control/index.ts
@@ -1,3 +1,4 @@
+export { toolDefinition as snow_acl_explain_def, execute as snow_acl_explain_exec } from "./snow_acl_explain.js"
 export { toolDefinition as snow_create_acl_def, execute as snow_create_acl_exec } from "./snow_create_acl.js"
 export {
   toolDefinition as snow_create_acl_role_def,

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/access-control/snow_acl_explain.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/access-control/snow_acl_explain.ts
@@ -1,0 +1,435 @@
+/**
+ * snow_acl_explain - what stands between a user and a record
+ *
+ * Lists every ACL that can apply to a table (and optionally one field) for one
+ * operation, resolves the roles each of them names through the
+ * `sys_security_acl_role` m2m, and diffs those against the roles one named user
+ * actually holds.
+ *
+ * It stops there on purpose. ServiceNow's real answer also depends on each
+ * ACL's condition and advanced script, which run inside the platform against a
+ * specific record; nothing reachable over the Table API evaluates them. The
+ * output is therefore "here is what applies and here is what you hold", never a
+ * verdict. `snow_test_acl` claims to produce that verdict by POSTing to
+ * `sys_script_execution` — creating a record there executes nothing, and it
+ * ignores both its `operation` and its `user` argument.
+ */
+
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient, type ExtendedAxiosInstance } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+/**
+ * The four operations this tool covers. `sys_security_acl.operation` also carries operations belonging to
+ * the non-table ACL types (execute on a client-callable script include, for one); those are out of scope
+ * here because the name chain this builds is a table/field chain.
+ */
+const OPERATIONS = ["read", "write", "create", "delete"]
+
+/** Guard against a cyclic or pathological `super_class` chain. */
+const CHAIN_DEPTH = 10
+
+/** Page sizes. Both are reported as warnings when hit, because a silently short list here reads as "no rule". */
+const ACL_PAGE = 200
+const ROLE_PAGE = 500
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_acl_explain",
+  description:
+    "Explain which ACLs apply to a table (optionally one field) for one operation, and what a named user is missing. Walks sys_db_object.super_class so parent-table rules are included, covers the wildcard names (*, *.field, table.*, *.*), resolves each rule's required roles through the sys_security_acl_role m2m, and reports which of those roles the user actually holds (sys_user_has_role, inherited roles included). Returns the applicable rules plus the role gap — NOT an access decision: ACL conditions and advanced scripts are reported and counted but never evaluated.",
+  // Metadata for tool discovery (not sent to LLM)
+  category: "development",
+  subcategory: "access-control",
+  use_cases: ["acl", "security", "roles", "permissions", "debugging"],
+  complexity: "intermediate",
+  frequency: "medium",
+
+  // Permission enforcement
+  // Classification: READ - queries sys_security_acl, sys_security_acl_role,
+  // sys_db_object, sys_user and sys_user_has_role; writes nothing.
+  permission: "read",
+  allowedRoles: ["developer", "stakeholder", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      table: {
+        type: "string",
+        description: "Table the record lives on, e.g. 'incident'",
+      },
+      operation: {
+        type: "string",
+        enum: OPERATIONS,
+        description: "The operation being denied: read, write, create or delete",
+      },
+      field: {
+        type: "string",
+        description:
+          "Optional field name, e.g. 'priority' or 'incident.priority'. Adds the six field-level ACL names to the report; without it only the record-level names are checked.",
+      },
+      user: {
+        type: "string",
+        description:
+          "Optional sys_id or user_name of the user to diff against. Without it the report lists the rules and their roles but nothing about who holds what.",
+      },
+      include_inactive: {
+        type: "boolean",
+        description: "Include ACLs with active=false. Default: false.",
+        default: false,
+      },
+    },
+    required: ["table", "operation"],
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const table = typeof args.table === "string" ? args.table.trim() : ""
+  const operation = typeof args.operation === "string" ? args.operation.trim().toLowerCase() : ""
+  if (!table) return createErrorResult("Missing 'table' argument")
+  if (!OPERATIONS.includes(operation))
+    return createErrorResult(`'operation' must be one of: ${OPERATIONS.join(", ")} (got '${String(args.operation)}')`)
+
+  // Callers write the field either bare ("priority") or qualified
+  // ("incident.priority"); the ACL name is composed below, so drop the prefix.
+  const rawField = typeof args.field === "string" ? args.field.trim() : ""
+  const field = rawField.includes(".") ? rawField.slice(rawField.lastIndexOf(".") + 1) : rawField
+  const includeInactive = args.include_inactive === true
+  const who = typeof args.user === "string" ? args.user.trim() : ""
+
+  const client = await getAuthenticatedClient(context)
+  const warnings: string[] = []
+
+  if (rawField.includes(".") && !rawField.startsWith(`${table}.`))
+    warnings.push(
+      `Read 'field' as '${field}': the '${rawField.slice(0, rawField.lastIndexOf("."))}.' prefix was dropped, because ACL names are composed from the 'table' argument. Pass table='${rawField.slice(0, rawField.lastIndexOf("."))}' if that was the table you meant.`,
+    )
+
+  const root = await client
+    .get("/api/now/table/sys_db_object", {
+      params: { sysparm_query: `name=${table}`, sysparm_fields: "name,super_class", sysparm_limit: 1 },
+    })
+    .then((r) => ({ row: (r.data?.result ?? [])[0] as Record<string, unknown> | undefined }))
+    .catch((err: Error) => ({ error: err.message || "sys_db_object lookup failed" }))
+
+  if ("error" in root)
+    warnings.push(`Table hierarchy could not be read (${root.error}) — parent-table ACLs are NOT in this report.`)
+  const rootRow = "row" in root ? root.row : undefined
+  if ("row" in root && !rootRow)
+    warnings.push(
+      `No sys_db_object row named '${table}'. Either the table name is wrong, or this connection cannot read sys_db_object — parent-table ACLs are NOT in this report.`,
+    )
+
+  const ancestors = rootRow ? await superClassChain(client, referenceValue(rootRow.super_class), CHAIN_DEPTH) : []
+  const candidates = aclCandidateNames(table, ancestors, field)
+  const names = [...candidates.record, ...candidates.field]
+  // Record-level and field-level names are orthogonal — both levels apply to the same
+  // request — so they are not two points on one scale. Rank inside each level instead:
+  // one index across both would put the record-level `*` above `incident.priority`.
+  const order = new Map(
+    (["record", "field"] as const).flatMap((level, group) =>
+      candidates[level].map((name, index) => [name, { level, group, index }] as const),
+    ),
+  )
+
+  const acls = await client
+    .get("/api/now/table/sys_security_acl", {
+      params: {
+        // `nameIN` is exact-match per element, which is what these names need: "*" and
+        // "*.*" are literal ACL names, not patterns. Plain `name=*` equality is proven
+        // against a live instance (script/probe-sn-roles/acl-resolve.ts, and 189 rows of
+        // sn-roles.manifest.json resolved through it); a literal "*" *inside* an IN list
+        // is not, which is why the zero-match caveat below names it as a possibility.
+        sysparm_query: `nameIN${names.join(",")}^operation=${operation}${includeInactive ? "" : "^active=true"}`,
+        sysparm_fields:
+          "sys_id,name,operation,type,active,admin_overrides,condition,script,sys_updated_on,sys_updated_by",
+        sysparm_limit: ACL_PAGE,
+      },
+    })
+    .then((r) => ({ rows: (r.data?.result ?? []) as Record<string, string>[] }))
+    .catch((err: Error) => ({ error: err.message || "sys_security_acl query failed" }))
+
+  if ("error" in acls) return createErrorResult(`Could not read sys_security_acl: ${acls.error}`)
+
+  const aclRows = acls.rows.slice().sort((a, b) => {
+    const left = order.get(a.name) ?? { group: 9, index: 999 }
+    const right = order.get(b.name) ?? { group: 9, index: 999 }
+    return left.group - right.group || left.index - right.index
+  })
+  if (aclRows.length === ACL_PAGE)
+    warnings.push(`Hit the ${ACL_PAGE}-row page limit on sys_security_acl — there may be more rules than listed.`)
+
+  // Required roles live in the m2m, never on sys_security_acl itself — there is
+  // no `roles` column there, which is why tools that read one always report none.
+  const aclRoles =
+    aclRows.length === 0
+      ? { rows: [] as ReferenceRow[] }
+      : await client
+          .get("/api/now/table/sys_security_acl_role", {
+            params: {
+              sysparm_query: `sys_security_aclIN${aclRows.map((row) => row.sys_id).join(",")}`,
+              sysparm_fields: "sys_security_acl,sys_user_role",
+              sysparm_display_value: "all",
+              sysparm_limit: ROLE_PAGE,
+            },
+          })
+          .then((r) => ({ rows: (r.data?.result ?? []) as ReferenceRow[] }))
+          .catch((err: Error) => ({ error: err.message || "sys_security_acl_role query failed" }))
+
+  if ("error" in aclRoles)
+    warnings.push(
+      `Required roles could not be read (${aclRoles.error}) — every rule below reports requires_roles: null, which means unknown, not "no role needed".`,
+    )
+  const roleRows = "rows" in aclRoles ? aclRoles.rows : undefined
+  if (roleRows?.length === ROLE_PAGE)
+    warnings.push(`Hit the ${ROLE_PAGE}-row page limit on sys_security_acl_role — required roles may be incomplete.`)
+
+  const resolved = who ? await resolveUser(client, who) : undefined
+  if (resolved && !resolved.ok) return createErrorResult(resolved.error)
+  const user = resolved?.ok ? resolved : undefined
+  if (user?.warning) warnings.push(user.warning)
+  if (user?.truncated)
+    warnings.push(`The user's role list hit the ${ROLE_PAGE}-row page limit — roles_not_held may be overstated.`)
+  const held = user ? new Set(user.roles) : undefined
+
+  const rules = aclRows.map((row) => {
+    const required = roleRows === undefined ? null : rolesOf(roleRows, row.sys_id)
+    const place = order.get(row.name)
+    return {
+      sys_id: row.sys_id,
+      name: row.name,
+      level: place?.level ?? "unknown",
+      specificity_within_level: place?.index ?? null,
+      operation: row.operation,
+      type: row.type,
+      active: row.active === "true",
+      admin_overrides: row.admin_overrides === "true",
+      requires_roles: required,
+      // The roles on one rule are alternatives, so these two are a split of
+      // `requires_roles`, not a checklist: a non-empty `user_holds` already satisfies
+      // this rule's role check, and `roles_not_held` is then only the remainder — never
+      // read it as "grant these". Hence the neutral name.
+      user_holds: required && held ? required.filter((role) => held.has(role)) : null,
+      roles_not_held: required && held ? required.filter((role) => !held.has(role)) : null,
+      has_condition: Boolean(row.condition?.trim()),
+      has_script: Boolean(row.script?.trim()),
+      condition: row.condition?.trim() ? clip(row.condition.trim()) : "",
+      script_preview: row.script?.trim() ? clip(row.script.trim()) : "",
+      updated_on: row.sys_updated_on,
+      updated_by: row.sys_updated_by,
+    }
+  })
+
+  const rolesNamed = [...new Set(rules.flatMap((rule) => rule.requires_roles ?? []))].sort()
+  const withCondition = rules.filter((rule) => rule.has_condition).length
+  const withScript = rules.filter((rule) => rule.has_script).length
+  const types = [...new Set(rules.map((rule) => rule.type).filter(Boolean))].sort()
+
+  const caveats = [
+    "This is not an access decision. It lists the rules that carry the decision and the roles the user holds.",
+    "The roles on one rule are alternatives: holding any one satisfies that rule's role check, and a rule naming no roles imposes no role requirement. So 'roles_not_held' is the remainder of 'requires_roles', not a list of roles to grant — if 'user_holds' is non-empty, that rule's role check is already met.",
+    rules.length === 0
+      ? "No rule matched any of the candidate names for this operation. Either none exists, or this connection cannot see them. A third possibility: the literal wildcard names ('*', '*.*') are matched through 'nameIN', and an instance whose query parser treated them as patterns rather than literals would contribute nothing from those levels."
+      : withCondition + withScript > 0
+        ? `${withCondition} of these rules carry a condition and ${withScript} carry a script. Both run inside the platform against a specific record and are NOT evaluated here — a user holding every role listed can still be denied by them.`
+        : "None of these rules carry a condition or a script, so the role lists below are the whole of what they check.",
+    "Roles are listed exactly as each rule names them in sys_security_acl_role. Which rule ServiceNow lets decide, and how several matching rules combine, is not modelled here.",
+    "sys_security_acl is itself ACL-protected: an empty or short result can mean 'not visible to this connection' rather than 'does not exist'. Reading it needs an elevated role (admin, or a reader role such as access_control_read_admin).",
+    // sys_security_acl also holds the non-table ACL types. This tool does not filter on
+    // `type` because it could not confirm which value field-level rules carry, and a
+    // wrong filter would silently drop rules — the failure this tool exists to prevent.
+    // So it reports instead: silent on an all-`record` result, loud otherwise.
+    types.some((type) => type !== "record")
+      ? `sys_security_acl also holds rules for the non-table ACL types (ui_page, processor, rest_endpoint, client_callable_script_include), and one of those can carry a name that matched here — '*' most plausibly — without governing table access. Types matched: ${types.join(", ")}. Check each rule's 'type' before acting on it.`
+      : "",
+    rules.some((rule) => rule.admin_overrides)
+      ? "Some rules have admin_overrides set. The flag is reported per rule; its effect is not modelled."
+      : "",
+  ].filter(Boolean)
+
+  const data = {
+    table,
+    operation,
+    field: field || null,
+    table_chain: [table, ...ancestors],
+    candidate_names: candidates,
+    matched: rules.length,
+    rules,
+    roles_named_by_rules: rolesNamed,
+    user: user
+      ? {
+          // Deliberately not `sys_id`: createSuccessResult hoists a nested
+          // `sys_id` into `result.artifact`, and a read-only report has no
+          // artifact — the write-tracking post-hooks would record this user as one.
+          user_sys_id: user.sys_id,
+          user_name: user.user_name,
+          name: user.name,
+          active: user.active,
+          role_count: user.roles.length,
+          roles: user.roles,
+          // Same reason as the per-rule split: `roles_named_by_rules` is a union across
+          // rules that are alternatives to each other, so the complement of it is even
+          // less of a to-do list than the per-rule one. Named neutrally on purpose.
+          holds_of_named: rolesNamed.filter((role) => user.roles.includes(role)),
+          not_held_of_named: rolesNamed.filter((role) => !user.roles.includes(role)),
+        }
+      : null,
+    not_evaluated: { rules_with_condition: withCondition, rules_with_script: withScript },
+    caveats,
+    warnings,
+  }
+
+  const target = field ? `${table}.${field}` : table
+  const heldNamed = data.user ? data.user.holds_of_named : []
+  const summary = [
+    `ACLs applying to ${target} · ${operation}${includeInactive ? " (incl. inactive)" : ""}`,
+    `  table chain: ${data.table_chain.join(" → ")}`,
+    `  record-level names checked: ${candidates.record.join(", ")}`,
+    candidates.field.length ? `  field-level names checked:  ${candidates.field.join(", ")}` : "",
+    rules.length === 0
+      ? `  no ACL matched any of these ${names.length} names for '${operation}'`
+      : `  matched ${rules.length} rule(s): ${rules.map((rule) => rule.name).join(", ")}`,
+    rolesNamed.length ? `  roles named by these rules: ${rolesNamed.join(", ")}` : "",
+    data.user
+      ? `  ${data.user.user_name} holds ${data.user.role_count} role(s); of the roles named above ${
+          heldNamed.length ? `holds ${heldNamed.join(", ")}` : "holds none"
+        }`
+      : "  no user given — nothing is being diffed against held roles",
+    `  not evaluated: ${withCondition} condition(s), ${withScript} script(s)`,
+    warnings.length ? `  ⚠ ${warnings.length} warning(s) — see data.warnings` : "",
+    "This lists what applies and what the user holds; it is not an access decision.",
+  ]
+    .filter(Boolean)
+    .join("\n")
+
+  return createSuccessResult(data, { matched: rules.length, warnings: warnings.length }, summary)
+}
+
+/**
+ * Every ACL name that can carry a rule for this table/field, returned as two
+ * lists because the two levels are not comparable: a record-level name and a
+ * field-level name both apply to the same request, so ordering them against each
+ * other is meaningless. Within each list the names run most specific first.
+ * `ancestors` is the `sys_db_object.super_class` chain, nearest parent first.
+ *
+ * A field can be covered by its own name on this table or on any ancestor, by
+ * the same field on any table, or by a table-wide field wildcard — so a report
+ * that stops at `table.field` names the wrong blocker exactly when the inherited
+ * or wildcard rule is the one with the roles on it.
+ */
+export function aclCandidateNames(table: string, ancestors: string[], field: string) {
+  const tables = [...new Set([table, ...ancestors])]
+  const record = [...tables, "*"]
+  if (!field) return { record, field: [] as string[] }
+  return {
+    record,
+    field: [...tables.map((name) => `${name}.${field}`), `*.${field}`, ...tables.map((name) => `${name}.*`), "*.*"],
+  }
+}
+
+/** One row read with `sysparm_display_value=all`: every field is a value/display pair. */
+type ReferenceRow = Record<string, { display_value?: string; value?: string } | undefined>
+
+/**
+ * `sys_db_object.super_class` points back at `sys_db_object`, so the chain can
+ * only be walked one record at a time.
+ */
+async function superClassChain(
+  client: ExtendedAxiosInstance,
+  superClass: string | undefined,
+  depth: number,
+): Promise<string[]> {
+  if (!superClass || depth <= 0) return []
+  const row = await client
+    .get(`/api/now/table/sys_db_object/${superClass}`, { params: { sysparm_fields: "name,super_class" } })
+    .then((r) => r.data?.result as Record<string, unknown> | undefined)
+    .catch(() => undefined)
+  const name = typeof row?.name === "string" ? row.name : ""
+  if (!name) return []
+  return [name, ...(await superClassChain(client, referenceValue(row?.super_class), depth - 1))]
+}
+
+/**
+ * A reference field is `{ link, value }` on the Table API's default
+ * representation and `{ display_value, value }` with `sysparm_display_value=all`,
+ * but a bare sys_id string on some responses.
+ */
+function referenceValue(field: unknown): string | undefined {
+  if (typeof field === "string") return field || undefined
+  if (field && typeof field === "object" && "value" in field) {
+    const value = (field as { value?: unknown }).value
+    return typeof value === "string" && value ? value : undefined
+  }
+  return undefined
+}
+
+function rolesOf(rows: ReferenceRow[], aclId: string) {
+  return [
+    ...new Set(
+      rows
+        .filter((row) => referenceValue(row.sys_security_acl) === aclId)
+        .map((row) => row.sys_user_role?.display_value ?? "")
+        .filter(Boolean),
+    ),
+  ].sort()
+}
+
+/**
+ * Resolve the user and their roles. `sys_user_has_role` already materializes
+ * inherited roles (each row carries `inherited`), so there is no need to expand
+ * `sys_user_role_contains` on top of it.
+ */
+async function resolveUser(client: ExtendedAxiosInstance, who: string) {
+  const query = /^[0-9a-f]{32}$/i.test(who) ? `sys_id=${who}` : `user_name=${who}`
+  const found = await client
+    .get("/api/now/table/sys_user", {
+      params: { sysparm_query: query, sysparm_fields: "sys_id,user_name,name,active", sysparm_limit: 2 },
+    })
+    .then((r) => ({ rows: (r.data?.result ?? []) as Record<string, string>[] }))
+    .catch((err: Error) => ({
+      rows: [] as Record<string, string>[],
+      failure: `Could not read sys_user: ${err.message}`,
+    }))
+
+  if ("failure" in found) return { ok: false as const, error: found.failure }
+  if (found.rows.length === 0)
+    return {
+      ok: false as const,
+      error: `No sys_user matched ${query}. Pass a 32-character sys_id or an exact user_name.`,
+    }
+
+  const row = found.rows[0]
+  const roles = await client
+    .get("/api/now/table/sys_user_has_role", {
+      params: {
+        sysparm_query: `user=${row.sys_id}`,
+        sysparm_fields: "role.name,inherited,granted_by.name",
+        sysparm_display_value: "true",
+        sysparm_limit: ROLE_PAGE,
+      },
+    })
+    .then((r) => ({ rows: (r.data?.result ?? []) as Record<string, string>[] }))
+    .catch((err: Error) => ({
+      rows: [] as Record<string, string>[],
+      failure: `Could not read sys_user_has_role: ${err.message}`,
+    }))
+
+  if ("failure" in roles) return { ok: false as const, error: roles.failure }
+
+  return {
+    ok: true as const,
+    sys_id: row.sys_id,
+    user_name: row.user_name,
+    name: row.name,
+    active: row.active === "true",
+    roles: [...new Set(roles.rows.map((role) => role["role.name"]).filter(Boolean))].sort(),
+    truncated: roles.rows.length === ROLE_PAGE,
+    warning:
+      found.rows.length > 1 ? `More than one sys_user matched ${query}; used ${row.user_name} (${row.sys_id}).` : "",
+  }
+}
+
+function clip(value: string) {
+  return value.length > 300 ? `${value.slice(0, 300)}… [${value.length} chars]` : value
+}
+
+export const version = "1.0.0"
+export const author = "Serac SDK"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/aggregators/snow_aggregate_metrics.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/aggregators/snow_aggregate_metrics.ts
@@ -1,58 +1,318 @@
 /**
- * snow_aggregate_metrics
+ * snow_aggregate_metrics — COUNT / SUM / AVG / MIN / MAX over a table through
+ * the Aggregate API, GET /api/now/stats/{table}.
+ *
+ * This tool used to answer a different question than the one it was asked. It
+ * sent `sysparm_query: ""` on every call, so any filter the caller had in mind
+ * was silently dropped and COUNT came back for the whole table — a real,
+ * plausible number for the wrong question. And the only aggregate parameter it
+ * ever sent was sysparm_count, so SUM/AVG/MIN/MAX asked the API to aggregate
+ * nothing, got an empty stats object back, and the wrapper still reported
+ * `aggregated: true`. The `field` argument was destructured and never used.
+ *
+ * Parameter names, the `aggregate^field^operator^value` syntax of
+ * sysparm_having, and the stats / groupby_fields response shape all come from
+ * the Aggregate API reference:
+ * https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_AggregateAPI.html
  */
 
 import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
 import { getAuthenticatedClient } from "../../shared/auth.js"
 import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
 
+const AGGREGATIONS = ["COUNT", "SUM", "AVG", "MIN", "MAX"]
+
+/**
+ * The four documented field-list parameters. COUNT has no field list — it is
+ * sysparm_count, which this tool sends on every request so each row also
+ * carries how many records it covers.
+ */
+const FIELD_PARAM: Record<string, string> = {
+  SUM: "sysparm_sum_fields",
+  AVG: "sysparm_avg_fields",
+  MIN: "sysparm_min_fields",
+  MAX: "sysparm_max_fields",
+}
+
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_aggregate_metrics",
-  description: "Aggregate over a table via the /api/now/stats endpoint: COUNT, SUM, AVG, MIN, or MAX on a field, optionally grouped by another field. Returns the rolled-up result without fetching individual rows.",
+  description:
+    "Count, average, sum, min or max over a table, grouped by a field and filtered by an encoded query. Uses the Aggregate API (/api/now/stats), so it returns the rolled-up numbers per group, never the records themselves.",
   // Metadata for tool discovery (not sent to LLM)
   category: "reporting",
   subcategory: "analytics",
-  use_cases: ["aggregation", "metrics", "reporting"],
+  use_cases: ["aggregation", "count", "group by", "metrics", "reporting"],
   complexity: "intermediate",
   frequency: "high",
 
   // Permission enforcement
-  // Classification: READ - Read-only operation based on name pattern
+  // Classification: READ - a single GET against /api/now/stats, changes nothing
   permission: "read",
   allowedRoles: ["developer", "stakeholder", "admin"],
   inputSchema: {
     type: "object",
     properties: {
-      table: { type: "string", description: "Table name" },
-      field: { type: "string", description: "Field to aggregate" },
-      aggregation: { type: "string", enum: ["COUNT", "SUM", "AVG", "MIN", "MAX"], default: "COUNT" },
-      group_by: { type: "string", description: "Field to group by" },
+      table: { type: "string", description: "Table to aggregate over (e.g. incident)" },
+      aggregation: {
+        type: "string",
+        enum: ["COUNT", "SUM", "AVG", "MIN", "MAX"],
+        default: "COUNT",
+        description: "Which aggregate to compute. Everything except COUNT needs `field`.",
+      },
+      field: {
+        type: "string",
+        description:
+          "Field to aggregate, required for SUM/AVG/MIN/MAX and ignored for COUNT. Must hold a number (e.g. reassignment_count); for elapsed time use the numeric seconds fields such as business_stc rather than the duration fields. Comma-separate to aggregate several fields at once.",
+      },
+      query: {
+        type: "string",
+        description:
+          "Encoded query filtering which records are aggregated (e.g. active=true^priority=1). Omit to cover the whole table.",
+      },
+      group_by: {
+        type: "string",
+        description:
+          "Field to group by, comma-separated for several (e.g. assignment_group). One result row per distinct combination.",
+      },
+      having: {
+        type: "string",
+        description:
+          "Filter on the aggregate itself, syntax aggregate^field^operator^value (e.g. count^priority^>^3). Only meaningful together with group_by.",
+      },
+      order_by: {
+        type: "string",
+        description:
+          "Order the rows by a field or by an aggregate. The documented forms are a field (state), an aggregate over a field (AVG^state) and COUNT; append ^DESC for descending (state^DESC). Only upper-case aggregate names are documented.",
+      },
+      display_value: {
+        type: "string",
+        enum: ["true", "false", "all"],
+        default: "false",
+        description:
+          "Return display values. Set true when grouping by a reference or choice field, otherwise the groups come back as sys_ids and numeric choice values. `all` asks the API for both values and is passed through, but the row labels only change if the instance sends a display value alongside the raw one.",
+      },
+      max_groups: {
+        type: "number",
+        default: 100,
+        description:
+          "Cap on rows returned. Rows past it are dropped and the result says how many; the instance's own ordering decides which survive, so pair this with order_by. Must be a row count — anything else falls back to 100.",
+      },
     },
     required: ["table"],
   },
 }
 
 export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
-  const { table, field, aggregation = "COUNT", group_by } = args
-  try {
-    const client = await getAuthenticatedClient(context)
-    const params: any = {
-      sysparm_query: "",
-      sysparm_count: aggregation === "COUNT",
-    }
-    if (group_by) params.sysparm_group_by = group_by
-
-    const response = await client.get(`/api/now/stats/${table}`, { params })
-    return createSuccessResult({
-      aggregated: true,
-      table,
-      aggregation,
-      result: response.data.result,
-    })
-  } catch (error: any) {
-    return createErrorResult(error.message)
-  }
+  return aggregate(args, context).catch((error: any) => {
+    // The Aggregate API answers an unknown field or a malformed sysparm_having
+    // with a 400 whose body names the problem; the axios message is only the
+    // status code, which is not enough to fix the call.
+    const snow = error?.response?.data?.error
+    return createErrorResult(
+      snow?.message ? [snow.message, snow.detail].filter(Boolean).join(" — ") : (error?.message ?? String(error)),
+      // A rejected call is nearly always about the parameters, so carry the
+      // same request detail the success path carries. Arguments refused before
+      // the request went out have none, and get an empty metadata object.
+      error?.snow_request ?? {},
+    )
+  })
 }
 
-export const version = "1.0.0"
+async function aggregate(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  const table = String(args.table ?? "").trim()
+  if (!table) return createErrorResult("table is required")
+
+  const plan = buildStatsParams(args)
+  const maxGroups = resolveMaxGroups(args.max_groups ?? args.maxGroups)
+  const endpoint = `/api/now/stats/${encodeURIComponent(table)}`
+  const client = await getAuthenticatedClient(context)
+  const response = await client.get(endpoint, { params: plan.params }).catch((error: unknown) => {
+    // Not `request`: axios already puts the underlying HTTP request there.
+    throw Object.assign(error instanceof Error ? error : new Error(String(error)), {
+      snow_request: { endpoint, params: plan.params },
+    })
+  })
+
+  const all = readStats(response.data?.result, plan.aggregation, plan.fields)
+  const rows = all.slice(0, maxGroups)
+  const label = plan.aggregation === "COUNT" ? "COUNT" : `${plan.aggregation}(${plan.fields.join(",")})`
+
+  // One aggregate over one field either came back or it did not. Say which,
+  // instead of returning a success that reads like an answer of zero.
+  const warning =
+    plan.aggregation !== "COUNT" &&
+    plan.fields.length === 1 &&
+    rows.length > 0 &&
+    rows.every((row) => row.value === undefined)
+      ? `The instance answered but carried no ${label} value, so nothing was aggregated. Check that ${plan.fields[0]} exists on ${table} and holds a number.`
+      : undefined
+
+  return createSuccessResult(
+    {
+      table,
+      aggregation: plan.aggregation,
+      // COUNT takes no field list, so do not echo one back as if it had been used.
+      field: plan.aggregation === "COUNT" ? undefined : plan.fields.join(","),
+      query: plan.query || undefined,
+      group_by: plan.group_by || undefined,
+      value: plan.group_by ? undefined : rows[0]?.value,
+      rows,
+      total_rows: all.length,
+      truncated: all.length > rows.length,
+      warning,
+    },
+    { endpoint, params: plan.params },
+    summarize(label, table, plan, rows, all.length, maxGroups),
+  )
+}
+
+/**
+ * Translate the tool's arguments into Aggregate API query parameters.
+ *
+ * Exported because which sysparm_* key the field lands under, and whether the
+ * caller's filter reaches sysparm_query at all, is the whole of what this tool
+ * got wrong — and both are decidable without an instance.
+ *
+ * Throws on input the API cannot act on; `execute` turns that into an error
+ * result rather than sending a request whose answer would be meaningless.
+ */
+export function buildStatsParams(args: any) {
+  const aggregation = String(args.aggregation ?? "COUNT")
+    .trim()
+    .toUpperCase()
+  if (!AGGREGATIONS.includes(aggregation))
+    throw new Error(`aggregation must be one of ${AGGREGATIONS.join(", ")} — received "${args.aggregation}"`)
+
+  const fields = String(args.field ?? args.fields ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (aggregation !== "COUNT" && fields.length === 0)
+    throw new Error(
+      `${aggregation} needs a field to aggregate: pass field (e.g. reassignment_count), or use aggregation COUNT to count records`,
+    )
+
+  const query = expression(args.query ?? args.filter, "query", "an encoded query string, e.g. active=true^priority=1")
+  const having = expression(args.having, "having", "aggregate^field^operator^value, e.g. count^priority^>^3")
+  // group_by and order_by stay lenient: both are documented as comma-separated
+  // lists, so an array of field names stringifies to exactly the right value,
+  // and neither can change which records are counted — a mangled one is either
+  // rejected by the instance or ignored.
+  const group_by = String(args.group_by ?? args.groupBy ?? "").trim()
+  const order_by = String(args.order_by ?? args.orderBy ?? "").trim()
+  // sysparm_display_value takes true/false/all. A caller sending the boolean
+  // true means "true"; anything else keeps the API default of database values.
+  const display = args.display_value ?? args.displayValue
+
+  const params: Record<string, string> = { sysparm_count: "true" }
+  if (query) params.sysparm_query = query
+  if (aggregation !== "COUNT") params[FIELD_PARAM[aggregation]] = fields.join(",")
+  if (group_by) params.sysparm_group_by = group_by
+  if (having) params.sysparm_having = having
+  if (order_by) params.sysparm_order_by = order_by
+  if (display === true || display === "true") params.sysparm_display_value = "true"
+  if (display === "all") params.sysparm_display_value = "all"
+
+  return { aggregation, fields, query, group_by, params }
+}
+
+/**
+ * The two parameters that decide which records are counted. Both reach the
+ * instance verbatim, so a non-string would arrive as "[object Object]", and an
+ * encoded query the instance cannot parse is the case where the condition may
+ * be dropped and the whole table aggregated instead — a confident number for a
+ * filter that was never applied. Refuse the value rather than send it.
+ */
+function expression(value: unknown, name: string, shape: string) {
+  if (value === undefined || value === null) return ""
+  if (typeof value !== "string") throw new Error(`${name} must be ${shape}`)
+  return value.trim()
+}
+
+/**
+ * How many rows to keep, exported for the same reason as the helpers around it:
+ * a cap that quietly becomes NaN slices the result to nothing, and `summarize`
+ * would then report that the instance returned no value — a false statement
+ * about what the instance answered. Anything that is not a usable row count
+ * (`"all"`, `""`, an object, a negative number) falls back to the schema's
+ * default of 100, and the summary names the cap it actually applied.
+ */
+export function resolveMaxGroups(raw: unknown) {
+  const parsed = Math.floor(Number(raw))
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 100
+}
+
+/**
+ * Normalise the Aggregate API payload into one row per group.
+ *
+ * Grouped requests answer with an array of `{ stats, groupby_fields }`; an
+ * ungrouped request answers with a single object, so both are flattened to a
+ * list. Every documented aggregate but count nests one level deeper —
+ * `stats.avg.<field>` — and a value the instance did not return stays
+ * undefined rather than becoming 0, because "no aggregate came back" and "the
+ * aggregate is zero" are opposite answers for whoever asked.
+ *
+ * Group labels prefer a display value when one arrives. The documented sample
+ * response carries only `field` and `value`, so under sysparm_display_value=all
+ * this is a fallback that costs nothing rather than a shape being relied on.
+ */
+export function readStats(result: unknown, aggregation: string, fields: string[]) {
+  const entries: StatsEntry[] = Array.isArray(result) ? result : result ? [result as StatsEntry] : []
+  return entries.map((entry) => {
+    const stats: Stats = entry?.stats ?? {}
+    const nested = stats[aggregation.toLowerCase()]
+    return {
+      group: Array.isArray(entry?.groupby_fields)
+        ? Object.fromEntries(
+            entry.groupby_fields.map((pair) => [pair?.field ?? "", pair?.display_value ?? pair?.value ?? ""]),
+          )
+        : undefined,
+      count: stats.count,
+      value:
+        aggregation === "COUNT"
+          ? stats.count
+          : fields.length === 1 && nested && typeof nested === "object"
+            ? nested[fields[0]]
+            : undefined,
+      stats,
+    }
+  })
+}
+
+/** COUNT sits directly on `stats`; every other aggregate nests one level, `stats.avg.<field>`. */
+type Stats = { count?: string | number } & Record<string, string | number | Record<string, string | number> | undefined>
+
+type StatsEntry = {
+  stats?: Stats
+  groupby_fields?: { field?: string; value?: string; display_value?: string }[]
+}
+
+function summarize(
+  label: string,
+  table: string,
+  plan: ReturnType<typeof buildStatsParams>,
+  rows: ReturnType<typeof readStats>,
+  total: number,
+  maxGroups: number,
+) {
+  const header = `${label} over ${table}${plan.query ? ` where ${plan.query}` : ""}${plan.group_by ? ` grouped by ${plan.group_by}` : ""}`
+  if (total === 0) return `${header}: no records matched`
+  if (!plan.group_by) return `${header} = ${rows[0]?.value ?? "(no value returned)"}`
+
+  const preview = rows
+    .slice(0, 10)
+    .map((row) => `  ${Object.values(row.group ?? {}).join(" / ") || "(empty)"}: ${row.value ?? "(none)"}`)
+  return [
+    `${header}: ${total} row(s)`,
+    ...preview,
+    ...(rows.length > preview.length ? [`  ... and ${rows.length - preview.length} more in the result`] : []),
+    ...(total > rows.length
+      ? [
+          `  ${total - rows.length} further row(s) dropped by max_groups=${maxGroups}; the instance's own ordering decided which were kept`,
+        ]
+      : []),
+  ].join("\n")
+}
+
+export const version = "1.1.0"
 export const author = "Serac SDK Migration"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/index.ts
@@ -18,3 +18,7 @@ export {
   toolDefinition as snow_list_applications_def,
   execute as snow_list_applications_exec,
 } from "./snow_list_applications.js"
+export {
+  toolDefinition as snow_app_repo_manage_def,
+  execute as snow_app_repo_manage_exec,
+} from "./snow_app_repo_manage.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/snow_app_repo_manage.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/snow_app_repo_manage.ts
@@ -1,0 +1,467 @@
+/**
+ * snow_app_repo_manage
+ *
+ * Publishes a scoped application to the Application Repository and installs a
+ * published version onto the instance, through ServiceNow's CI/CD API.
+ *
+ * Endpoint paths, parameter names, the "scope or sys_id" rule, the required
+ * role and the numeric progress statuses used below are all taken from
+ * ServiceNow's CI/CD API reference:
+ * https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/concept/cicd-api.html
+ * The same page in the Yokohama bundle carries identical parameter and status
+ * tables; the HTTP status hints in execute() quote that table and nothing else.
+ *
+ * Both app_repo endpoints are asynchronous. Their 200 means "the job is
+ * queued", not "the app is published/installed": the body carries a progress
+ * record whose status starts at Pending. So nothing here calls a publish or an
+ * install done unless a progress record said Successful. A Failed or Canceled
+ * job comes back as an error carrying ServiceNow's own message, and a job that
+ * is still running when the wait budget runs out comes back as an error too —
+ * with the progress_id, because "I don't know yet" is the truthful answer.
+ *
+ * There is no pipeline and no cross-instance target in this API: every endpoint
+ * acts on the instance the call authenticated to ("installs the specified
+ * application from the application repository onto the instance making the
+ * endpoint call"). Publishing from dev and installing on test are therefore two
+ * calls over two different connections, not one deployment.
+ */
+
+import type { AxiosInstance } from "axios"
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+const PUBLISH_PATH = "/api/sn_cicd/app_repo/publish"
+const INSTALL_PATH = "/api/sn_cicd/app_repo/install"
+const PROGRESS_PATH = "/api/sn_cicd/progress"
+
+// The progress status codes the CI/CD API documents.
+const STATE_BY_STATUS: Record<string, string> = {
+  "0": "pending",
+  "1": "running",
+  "2": "successful",
+  "3": "failed",
+  "4": "canceled",
+}
+// Derived from the table above rather than kept as a second list of codes: two
+// lists drift, and the one that drifts silently is the one that decides whether
+// a caller is told a job finished. An unrecognised code is never final, so the
+// caller polls instead of being handed a result the API did not give.
+function isFinal(status: unknown) {
+  return ["successful", "failed", "canceled"].includes(STATE_BY_STATUS[String(status)] ?? "")
+}
+
+const POLL_INTERVAL_MS = 5000
+// Deliberately short. A blocking tool call that outlives the MCP client's own
+// timeout loses the progress_id with it, which is worse than returning early
+// and telling the caller to poll.
+const DEFAULT_TIMEOUT_MS = 120000
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_app_repo_manage",
+  description: `Publish a scoped application to the Application Repository and install a published version, via ServiceNow's CI/CD API (/api/sn_cicd/app_repo). Requires the sn_cicd.sys_ci_automation or admin role.
+
+Actions:
+- publish — POST /api/sn_cicd/app_repo/publish. Stores the application and its artifacts in the Application Repository under a version. Identify the app by scope or app_sys_id. Without an explicit version the publish uses the app's current local version and fails if that version is already in the repository.
+- install — POST /api/sn_cicd/app_repo/install. Installs a repository version onto the instance this call is authenticated to.
+- progress — GET /api/sn_cicd/progress/{progress_id}. Reports the real state of a job started earlier.
+
+This API has no pipeline and no target-instance parameter: both endpoints act on the instance you are connected to. To move an app from dev to test you publish while connected to dev, then install while connected to test.
+
+Publish and install are asynchronous — they return a queued progress record, not a finished deployment. By default this tool polls that record until it is final and reports what it says: Successful returns success; Failed or Canceled returns an error with ServiceNow's own message; a job still running when timeout_ms elapses returns an error saying the outcome is unknown, with the progress_id. Pass wait=false to get the progress_id back immediately and poll it yourself with action=progress. Returns progress_id, state, status_label, percent_complete and ServiceNow's status/error text.
+
+Examples:
+- { action: "publish", scope: "x_acme_myapp", version: "1.2.0", dev_notes: "sprint 14" }
+- { action: "install", scope: "x_acme_myapp", version: "1.2.0", timeout_ms: 600000 }
+- { action: "install", app_sys_id: "b7e...", version: "1.2.0", wait: false }
+- { action: "progress", progress_id: "d174f8e11bd800103d374087bc4bcbd9" }`,
+  // Metadata for tool discovery (not sent to LLM)
+  category: "development",
+  subcategory: "applications",
+  use_cases: ["app-repo", "deployment", "cicd", "devops", "scoped-apps"],
+  complexity: "advanced",
+  frequency: "medium",
+
+  // Permission enforcement
+  // Classification: WRITE — publish stores an application version on the
+  // instance, install changes what is installed on it.
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "Operation to perform",
+        enum: ["publish", "install", "progress"],
+      },
+      scope: {
+        type: "string",
+        description:
+          '[publish/install] Application scope, e.g. "x_acme_myapp". Found in the scope field of Custom Application [sys_app]; for install it may also come from Store Application [sys_store_app]. Pass this or app_sys_id.',
+      },
+      app_sys_id: {
+        type: "string",
+        description:
+          "[publish/install] sys_id of the application, from Custom Application [sys_app] (install also accepts a Store Application [sys_store_app] sys_id). Sent as the API's sys_id parameter. Takes precedence over scope — the API wants one identifier, not both.",
+      },
+      version: {
+        type: "string",
+        description:
+          '[publish] Version to store the application under, e.g. "1.2.0"; the local application version is updated to match. Omit and the publish uses the app\'s current version, failing if that version is already in the repository. [install] Version to install; omitting it lets ServiceNow pick per its auto_upgrade_base_app / base_app_version rules.',
+      },
+      dev_notes: {
+        type: "string",
+        description: "[publish] Developer notes stored with the published version.",
+      },
+      auto_upgrade_base_app: {
+        type: "boolean",
+        description:
+          "[install] Only relevant when installing customizations of a base application: whether the associated base application may be upgraded to a later version. Left to ServiceNow's default (false) when omitted.",
+      },
+      base_app_version: {
+        type: "string",
+        description:
+          "[install] Version of the base application (a third-party Store application) to install. When set, only the base application is installed.",
+      },
+      progress_id: {
+        type: "string",
+        description: "[progress] Progress record id returned by an earlier publish or install.",
+      },
+      wait: {
+        type: "boolean",
+        description:
+          "[publish/install] Poll the progress record until it is final (default true). false returns the progress_id straight away, before the job has done anything — the app is not published or installed at that point.",
+        default: true,
+      },
+      timeout_ms: {
+        type: "number",
+        description:
+          "[publish/install when wait=true] How long to keep polling, in milliseconds. Default 120000 (2 min); installs of large applications routinely need more. Running out returns an error with the progress_id, not a success — recover with action=progress on that id. Do not re-issue the publish/install with a larger timeout_ms: the first job is still running and a second one would be a duplicate.",
+        default: DEFAULT_TIMEOUT_MS,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+export const ACTIONS = {
+  publish: publishApp,
+  install: installApp,
+  progress: readProgress,
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = str(args.action)
+  const handler = action ? ACTIONS[action as keyof typeof ACTIONS] : undefined
+  // Checked before authenticating: a typo shouldn't cost a round trip, and it
+  // makes the dispatch table testable without an instance.
+  if (!handler) {
+    return createErrorResult(
+      `Unknown action: ${action ?? "(none)"}. Valid actions: ${Object.keys(ACTIONS).join(", ")}.`,
+    )
+  }
+
+  try {
+    return await handler(await getAuthenticatedClient(context), args)
+  } catch (error: unknown) {
+    const message = messageOf(error)
+    const status = statusOf(error)
+    // Each branch below repeats what the CI/CD API reference assigns to that
+    // code, and nothing else — a hint that sends the caller to the wrong fix is
+    // worse than the bare status. 400 is documented on publish only.
+    if (status === 400) {
+      return createErrorResult(
+        `Bad request (400) on ${action}. Original error: ${message}. ServiceNow documents 400 on app_repo/publish for two causes: the application version "isn't correct or is a downgrade" — a publish without an explicit version uses the app's current version and fails if that version is already in the repository, so pass a higher version — or "the application is connected to source control and contains uncommitted changes that must be resolved", which means committing them first.`,
+      )
+    }
+    if (status === 401) {
+      return createErrorResult(
+        `Authentication failed (401) on ${action}: ServiceNow reports the user credentials are incorrect. This is about the credentials, not about roles. Original error: ${message}`,
+      )
+    }
+    if (status === 403) {
+      return createErrorResult(
+        `Forbidden (403) on ${action}: the user is not an admin and does not have the sn_cicd.sys_ci_automation role. Original error: ${message}`,
+      )
+    }
+    if (status === 404) {
+      return createErrorResult(
+        `Not found (404) on ${action}. ServiceNow documents this only as "the requested item wasn't found" — check that the scope/app_sys_id names an application on this instance, and for install that the version is in the Application Repository. Original error: ${message}`,
+      )
+    }
+    if (status === 405) {
+      return createErrorResult(
+        `Invalid method (405) on ${action}. ServiceNow documents this as "the functionality is inactive", i.e. this instance is not serving /api/sn_cicd. Original error: ${message}`,
+      )
+    }
+    if (status === 409) {
+      return createErrorResult(
+        `Conflict (409) on ${action}. ServiceNow documents this as "the requested item isn't unique". Original error: ${message}`,
+      )
+    }
+    return createErrorResult(message)
+  }
+}
+
+async function publishApp(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const target = identify(args)
+  if (!target) return createErrorResult(MISSING_APP)
+
+  // Documented as query parameters; the endpoint takes no request body.
+  const response = await client.post(PUBLISH_PATH, undefined, {
+    params: { ...target, version: str(args.version), dev_notes: str(args.dev_notes) },
+  })
+  return await settle(client, "publish", response.data?.result, args)
+}
+
+async function installApp(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const target = identify(args)
+  if (!target) return createErrorResult(MISSING_APP)
+
+  const response = await client.post(INSTALL_PATH, undefined, {
+    params: {
+      ...target,
+      version: str(args.version),
+      auto_upgrade_base_app: optionalBool(args.auto_upgrade_base_app),
+      base_app_version: str(args.base_app_version),
+    },
+  })
+  return await settle(client, "install", response.data?.result, args)
+}
+
+async function readProgress(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const progressId = str(args.progress_id)
+  if (!progressId) {
+    return createErrorResult("progress needs progress_id — the id an earlier publish or install returned.")
+  }
+  const progress = await fetchProgress(client, `${PROGRESS_PATH}/${encodeURIComponent(progressId)}`)
+  return reportProgress(`CI/CD job ${progressId}`, "progress", progress, progressId)
+}
+
+/**
+ * Turn the queued record an app_repo POST returns into an honest answer:
+ * either the id the caller has to poll, or whatever the progress record ends
+ * up saying once it stops moving.
+ */
+async function settle(
+  client: AxiosInstance,
+  action: "publish" | "install",
+  started: unknown,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const queued = rec(started)
+  const link = rec(rec(queued.links).progress)
+  const progressId = str(link.id)
+  const path = progressPath(link)
+  const label =
+    action === "publish"
+      ? `Publish of ${describeApp(args)} to the Application Repository`
+      : `Install of ${describeApp(args)} onto this instance`
+
+  // A job that has already reached a final state is reported as that state
+  // whatever `wait` says — including a publish that failed on the spot, which
+  // must not come back as "requested, poll it later".
+  if (isFinal(queued.status)) return reportProgress(label, action, queued, progressId)
+
+  if (!path) {
+    return createErrorResult(
+      `${label} was accepted by ServiceNow, but the response carried no progress link, so this tool cannot confirm what happened. Check the application's version history on the instance. Raw result: ${JSON.stringify(queued)}`,
+      { progress_id: progressId },
+    )
+  }
+
+  // The documented response always carries links.progress.id, but the caller
+  // gets a usable instruction either way rather than the string "undefined".
+  const pollHint = progressId
+    ? `Poll { action: "progress", progress_id: "${progressId}" }`
+    : `Follow the progress record at ${str(link.url) ?? path}`
+
+  if (!bool(args.wait, true)) {
+    return createSuccessResult(
+      {
+        action,
+        state: STATE_BY_STATUS[String(queued.status)] ?? "pending",
+        finished: false,
+        progress_id: progressId,
+        progress_url: str(link.url),
+        status: queued.status,
+        status_label: str(queued.status_label),
+        // Documented on the app_repo/install response only ("if available, the
+        // previously installed version") — not on publish and not on the
+        // progress record, so it is read here and nowhere else on purpose.
+        rollback_version: str(queued.rollback_version),
+      },
+      { progress_id: progressId },
+      `${label} was REQUESTED and has NOT finished — ServiceNow reports "${str(queued.status_label) ?? "Pending"}". ${pollHint} until it is final before treating the application as ${action === "publish" ? "published" : "installed"}.`,
+    )
+  }
+
+  const budget = num(args.timeout_ms) ?? DEFAULT_TIMEOUT_MS
+  const polled = await pollUntilFinal(client, path, Date.now() + budget)
+  if (!polled.final) {
+    // Every poll can have failed, in which case there is no status to quote —
+    // saying so beats printing the word "undefined" as a ServiceNow status.
+    const seen =
+      str(polled.progress.status_label) ??
+      (polled.progress.status === undefined ? undefined : `status ${String(polled.progress.status)}`)
+    // No "retry with a larger timeout_ms" here: re-issuing the publish or
+    // install would start a second job while the first one is still running.
+    // The only recovery is the progress record.
+    return createErrorResult(
+      `${label} had not finished after ${budget}ms — ${seen ? `ServiceNow last reported "${seen}"${percentSuffix(polled.progress)}` : "this tool never got a readable progress record for it"}${pollErrorSuffix(polled.progress)}. The job may still be running; this tool does not know the outcome. ${pollHint} — do NOT re-issue this ${action}, it is already running. Pass a larger timeout_ms on a future ${action} if this keeps happening.`,
+      { progress_id: progressId, finished: false, timed_out: true, status: polled.progress.status },
+    )
+  }
+  return reportProgress(label, action, polled.progress, progressId)
+}
+
+// Bounded by the deadline the caller paid for: every iteration is one GET, and
+// the loop stops rather than starting a sleep it cannot finish in budget.
+export async function pollUntilFinal(
+  client: AxiosInstance,
+  path: string,
+  deadline: number,
+  last: Record<string, unknown> = {},
+): Promise<{ progress: Record<string, unknown>; final: boolean }> {
+  // A poll that fails is not a job that failed. Installing an application can
+  // take the node out for a moment, and auth.ts turns any 502/503 into a thrown
+  // "instance is hibernating or starting up" error — letting that escape would
+  // report a healthy install as a dead instance and lose the progress_id with
+  // it, leaving the job unpollable. So a failed GET is carried forward and
+  // retried until the deadline, with the last status this loop did read.
+  // Annotated because spreading `last` widens the union away from the index
+  // signature, and every reader below wants the record, not the two shapes.
+  const progress: Record<string, unknown> = await fetchProgress(client, path).catch((error: unknown) => ({
+    ...last,
+    poll_error: messageOf(error),
+  }))
+  if (isFinal(progress.status)) return { progress, final: true }
+  if (Date.now() + POLL_INTERVAL_MS >= deadline) return { progress, final: false }
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+  return await pollUntilFinal(client, path, deadline, progress)
+}
+
+async function fetchProgress(client: AxiosInstance, path: string) {
+  // The auth interceptor rewrites a body that has no `result` into `result: []`,
+  // so an unreadable answer arrives here as an empty record instead of throwing.
+  // Without a status there is nothing to report, and inventing one is the whole
+  // failure mode this tool exists to avoid.
+  const progress = rec((await client.get(path)).data?.result)
+  if (progress.status === undefined) {
+    throw new Error(`ServiceNow returned no readable CI/CD progress record from ${path}.`)
+  }
+  return progress
+}
+
+/**
+ * One place decides what a progress record means, so a publish, an install and
+ * a bare status query can never disagree about whether a job succeeded.
+ */
+export function reportProgress(
+  label: string,
+  action: string,
+  progress: Record<string, unknown>,
+  progressId: string | undefined,
+): ToolResult {
+  const status = String(progress.status)
+  const statusLabel = str(progress.status_label) ?? status
+  const detail = str(progress.error) ?? str(progress.status_message) ?? str(progress.status_detail)
+  const data = {
+    action,
+    progress_id: progressId,
+    state: STATE_BY_STATUS[status] ?? "unknown",
+    finished: isFinal(status),
+    status: progress.status,
+    status_label: statusLabel,
+    percent_complete: progress.percent_complete,
+    error: str(progress.error),
+    status_message: str(progress.status_message),
+    status_detail: str(progress.status_detail),
+  }
+
+  if (status === "3" || status === "4") {
+    return createErrorResult(
+      `${label} finished as ${statusLabel}. ServiceNow says: ${detail ?? "(no detail returned)"}`,
+      data,
+    )
+  }
+  if (status === "2") {
+    return createSuccessResult(data, {}, `${label} finished: ${statusLabel}.${detail ? ` ${detail}` : ""}`)
+  }
+  return createSuccessResult(
+    data,
+    {},
+    `${label} has NOT finished — ServiceNow reports "${statusLabel}"${percentSuffix(progress)}. Poll again before acting on it.`,
+  )
+}
+
+/**
+ * Where to poll for a queued job.
+ *
+ * ServiceNow hands back an absolute progress URL and its own GitHub Actions
+ * follow that link rather than rebuilding the path, so this prefers it — but
+ * takes only the path and query, resolved against the authenticated client's
+ * own baseURL. That client attaches the instance's Authorization header to
+ * every request it makes, so following a host that arrived inside a response
+ * body would be a way to post that token somewhere else.
+ */
+export function progressPath(link: Record<string, unknown>) {
+  const url = str(link.url)
+  if (url && URL.canParse(url)) {
+    const parsed = new URL(url)
+    return `${parsed.pathname}${parsed.search}`
+  }
+  const id = str(link.id)
+  return id ? `${PROGRESS_PATH}/${encodeURIComponent(id)}` : undefined
+}
+
+const MISSING_APP =
+  'Pass scope (e.g. "x_acme_myapp") or app_sys_id to say which application. Both are on the application record: the scope and Sys ID fields of Custom Application [sys_app], or Store Application [sys_store_app] for an installed store app.'
+
+// The API accepts scope or sys_id, not both.
+function identify(args: Record<string, unknown>) {
+  const sys_id = str(args.app_sys_id)
+  if (sys_id) return { sys_id }
+  const scope = str(args.scope)
+  if (scope) return { scope }
+  return undefined
+}
+
+const describeApp = (args: Record<string, unknown>) =>
+  `${str(args.app_sys_id) ?? str(args.scope)}${str(args.version) ? ` ${str(args.version)}` : ""}`
+
+const percentSuffix = (progress: Record<string, unknown>) =>
+  progress.percent_complete === undefined ? "" : ` at ${String(progress.percent_complete)}%`
+
+// Set by pollUntilFinal when the last GET never landed, so the timeout message
+// says "I stopped being able to look" rather than implying ServiceNow went quiet.
+const pollErrorSuffix = (progress: Record<string, unknown>) =>
+  str(progress.poll_error) ? `; the last progress read failed with: ${str(progress.poll_error)}` : ""
+
+const str = (value: unknown) => (typeof value === "string" && value.length > 0 ? value : undefined)
+const num = (value: unknown) => (typeof value === "number" ? value : undefined)
+// Agents routinely stringify booleans, so "true"/"false" are accepted alongside
+// the real thing — same reasoning as confirmationFlag() in update-set-guard.ts.
+const bool = (value: unknown, fallback: boolean) => {
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  return fallback
+}
+// Only forwarded when the caller actually set it; axios drops undefined params,
+// which leaves ServiceNow's own default in charge.
+const optionalBool = (value: unknown) => {
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  return undefined
+}
+const rec = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : {}
+const statusOf = (error: unknown) => {
+  const status = rec(rec(error).response).status
+  return typeof status === "number" ? status : undefined
+}
+const messageOf = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/snow_install_application.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/applications/snow_install_application.ts
@@ -1,47 +1,75 @@
 /**
- * snow_install_application
+ * snow_install_application — retired in place, kept only as a signpost.
+ *
+ * What this tool used to do: POST { sys_id, version } to
+ * /api/now/table/sys_store_app and return
+ * createSuccessResult({ installed: true, application: <the row the Table API
+ * echoed back> }). Inserting a row into sys_store_app does not install an
+ * application; it creates a record. So every "installed: true" this tool ever
+ * returned was fabricated, and each call left a junk row on the instance.
+ *
+ * ServiceNow's documented way to install an application from the Application
+ * Repository is the CI/CD API — POST /api/sn_cicd/app_repo/install, which is
+ * asynchronous and reports through a progress record:
+ * https://www.servicenow.com/docs/bundle/yokohama-api-reference/page/integrate/inbound-rest/concept/cicd-api.html
+ * snow_app_repo_manage speaks it. Answering here with a different API's
+ * semantics under this tool's name would repeat the original mistake, so this
+ * executor makes no request at all and says where to go instead.
+ *
+ * The name is kept rather than deleted so callers that already reference it get
+ * the redirect instead of "unknown tool", and so its sn-roles.manifest.json
+ * entry does not go stale (that manifest is produced by a live-instance probe
+ * and cannot be regenerated in CI).
  */
 
-import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
-import { getAuthenticatedClient } from "../../shared/auth.js"
-import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+import { type MCPToolDefinition, type ToolResult } from "../../shared/types.js"
+import { createErrorResult } from "../../shared/error-handler.js"
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_install_application",
-  description: "Install application from store",
+  description:
+    '[DEPRECATED - use snow_app_repo_manage] Performs no operation and returns an error. It used to insert a row into sys_store_app and report that as an install; a row insert installs nothing. Install through the documented CI/CD Application Repository API instead: snow_app_repo_manage({ action: "install", scope: "x_acme_myapp", version: "1.2.0" }).',
   // Metadata for tool discovery (not sent to LLM)
   category: "development",
   subcategory: "applications",
-  use_cases: ["app-install", "store", "deployment"],
+  // Deliberately not "app-install" / "deployment" any more: discovery by use
+  // case must land on the tool that actually installs, not on this signpost.
+  use_cases: ["deprecated"],
   complexity: "beginner",
   frequency: "low",
 
   // Permission enforcement
-  // Classification: WRITE - Write operation based on name pattern
-  permission: "write",
+  // Classification: READ — this executor issues no request to the instance and
+  // cannot change anything. Left as "write" it would sit behind the prod-write
+  // and update-set guards (shared/update-set-guard.ts), so a caller would be
+  // told to open an update set before they could be told the tool is retired.
+  permission: "read",
   allowedRoles: ["developer", "admin"],
   inputSchema: {
     type: "object",
     properties: {
-      app_id: { type: "string", description: "Application ID from store" },
-      version: { type: "string", description: "Version to install" },
+      app_id: {
+        type: "string",
+        description: "Ignored. Pass it as app_sys_id to snow_app_repo_manage instead.",
+      },
+      version: {
+        type: "string",
+        description: "Ignored. Pass it as version to snow_app_repo_manage instead.",
+      },
     },
-    required: ["app_id"],
+    required: [],
   },
 }
 
-export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
-  const { app_id, version } = args
-  try {
-    const client = await getAuthenticatedClient(context)
-    const installData: any = { sys_id: app_id }
-    if (version) installData.version = version
-    const response = await client.post("/api/now/table/sys_store_app", installData)
-    return createSuccessResult({ installed: true, application: response.data.result })
-  } catch (error: any) {
-    return createErrorResult(error.message)
-  }
+export async function execute(args: Record<string, unknown>): Promise<ToolResult> {
+  const identifier = typeof args?.app_id === "string" && args.app_id.length > 0 ? args.app_id : "<app sys_id>"
+  const wanted = typeof args?.version === "string" && args.version.length > 0 ? args.version : undefined
+  return createErrorResult(
+    `snow_install_application is retired and did not install anything. It wrote a row to sys_store_app and called that an install, which it is not. ` +
+      `Use the CI/CD Application Repository API instead: snow_app_repo_manage({ action: "install", app_sys_id: "${identifier}"${wanted ? `, version: "${wanted}"` : ""} }) — ` +
+      `or pass scope instead of app_sys_id. That endpoint installs onto the instance you are authenticated to, and the application must already be published to the Application Repository (snow_app_repo_manage action "publish", run against the instance that owns the app).`,
+  )
 }
 
-export const version = "1.0.0"
-export const author = "Serac SDK Migration"
+export const version = "2.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/index.ts
@@ -16,6 +16,10 @@ export { toolDefinition as snow_run_discovery_def, execute as snow_run_discovery
 export { toolDefinition as snow_get_ci_impact_def, execute as snow_get_ci_impact_exec } from "./snow_get_ci_impact.js"
 export { toolDefinition as snow_reconcile_ci_def, execute as snow_reconcile_ci_exec } from "./snow_reconcile_ci.js"
 export {
+  toolDefinition as snow_cmdb_identify_reconcile_def,
+  execute as snow_cmdb_identify_reconcile_exec,
+} from "./snow_cmdb_identify_reconcile.js"
+export {
   toolDefinition as snow_ci_health_check_def,
   execute as snow_ci_health_check_exec,
 } from "./snow_ci_health_check.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/snow_cmdb_identify_reconcile.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/snow_cmdb_identify_reconcile.ts
@@ -1,0 +1,362 @@
+/**
+ * snow_cmdb_identify_reconcile - insert/update CIs through the Identification
+ * and Reconciliation Engine (IRE).
+ *
+ * Every other CI writer in this package aims straight at a class table:
+ * snow_create_ci POSTs /api/now/table/<ci_class>, snow_update_ci PUTs it,
+ * snow_reconcile_ci PUTs base cmdb_ci. That skips identification entirely — a
+ * host that already exists comes back as a second row, no identifier rule runs,
+ * no reconciliation rule decides whether the calling source is even allowed to
+ * overwrite the attribute, and no Source [sys_object_source] row is written.
+ * IRE is the documented way in: "Use this API instead of updating the CMDB
+ * directly."
+ *
+ * Request and response shapes below are taken from ServiceNow's own reference,
+ * "Identification and Reconciliation API":
+ *   https://www.servicenow.com/docs/r/api-reference/rest-apis/c_IdentifyReconcileAPI.html
+ * read from ServiceNow's published documentation source (the docs site renders
+ * client-side and cannot be fetched as text):
+ *   https://github.com/ServiceNow/ServiceNowDocs
+ *   markdown/api-reference/rest-apis/c_IdentifyReconcileAPI.md — release
+ *   "australia", last_updated 2026-03-12.
+ */
+
+import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_cmdb_identify_reconcile",
+  description: `Insert or update CIs through the CMDB Identification and Reconciliation Engine: POST /api/now/identifyreconcile. IRE runs each class's identifier rules against the payload, so a CI that already exists is matched and updated instead of duplicated, reconciliation rules decide whether this data source may overwrite each attribute, and the source is recorded in Source [sys_object_source].
+
+Returns the engine's verdict per payload item: operation (INSERT, UPDATE, NO_CHANGE, UPDATE_WITH_UPGRADE, UPDATE_WITH_DOWNGRADE, UPDATE_WITH_SWITCH, DELETE), sysId, identifierEntrySysId, each identification attempt with its attemptResult (MATCHED, MULTI_MATCH, NO_MATCH, SKIPPED) and the identifier rule it used, plus per-item errors and warnings. IRE answers HTTP 200 even when individual items fail identification, so this tool reports success only when no returned item, relation or additionally committed item carries an error or a non-zero errorCount.
+
+dry_run: true posts the same payload to /api/now/identifyreconcile/query instead, which returns the same insert/update decision without committing anything. Run that first before pushing a large payload — it is the only way to see what IRE would do without doing it.
+
+data_source is required and must be an existing choice on cmdb_ci.discovery_source; this tool checks it against sys_choice before posting. Without sysparm_data_source the documented behaviour is to store the payload in the incomplete-payloads table rather than commit it, which looks like success and changes nothing.
+
+Use this instead of snow_create_ci and snow_update_ci, which write to a class table and never run identification. Do not reach for snow_reconcile_ci: despite the name it does not reconcile — it PUTs the caller's object onto base cmdb_ci and echoes its reconciliation_rule argument back untouched.
+
+The ServiceNow account needs the itil or asset role.`,
+  // Metadata for tool discovery (not sent to LLM)
+  category: "cmdb",
+  subcategory: "reconciliation",
+  use_cases: ["cmdb", "identification", "reconciliation", "deduplication", "discovery-integration"],
+  complexity: "advanced",
+  frequency: "medium",
+
+  // Permission enforcement
+  // Classification: WRITE - the default path commits inserts/updates to the CMDB.
+  // dry_run routes to /identifyreconcile/query and changes nothing, but permission
+  // is per tool, not per argument, so the whole tool is classified by its writing path.
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        description: "CIs to identify and then insert or update. At least one entry.",
+        items: {
+          type: "object",
+          properties: {
+            className: {
+              type: "string",
+              description:
+                "Required. CMDB class/table of the CI, e.g. cmdb_ci_linux_server or cmdb_ci_win_server. Camel-cased key, snake_case table name.",
+            },
+            values: {
+              type: "object",
+              description:
+                "Field name/value pairs to create or update on the CI. Reference fields take the referenced sys_id. The reference marks only className required, so this may be omitted when the CI is identified through lookup or sys_object_source_info instead — but an item with neither carries nothing for IRE to identify or write.",
+            },
+            internal_id: {
+              type: "string",
+              description:
+                "Identifier for this item within this payload only. Any value, unique in the payload. Referenced by relations.parent_id/child_id and referenceItems.",
+            },
+            lookup: {
+              type: "array",
+              description:
+                "Lookup-based identification records (e.g. cmdb_serial_number rows) used to identify the CI. Each entry takes className, values, and optionally internal_id and sys_object_source_info.",
+              items: { type: "object" },
+            },
+            related: {
+              type: "array",
+              description:
+                "Records on a table that references this CI, created or updated alongside it. Not used for identification; allowed types come from the Related Entry [cmdb_related_entry] table.",
+              items: { type: "object" },
+            },
+            settings: {
+              type: "object",
+              description:
+                "Per-item update restrictions: updateWithoutUpgrade, updateWithoutDowngrade, updateWithoutSwitch, skipReclassificationRestrictionRules. All booleans, all default false.",
+            },
+            sys_object_source_info: {
+              type: "object",
+              description:
+                "Unique CI identifier for this data source: source_name (a cmdb_ci.discovery_source choice), source_native_key, optional source_feed, optional source_recency_timestamp as 'YYYY-MM-DD hh:mm:ss' UTC. Lets IRE match on the Source [sys_object_source] table instead of running identifier rules.",
+            },
+          },
+          required: ["className"],
+        },
+      },
+      relations: {
+        type: "array",
+        description:
+          "Relationships between payload items. Each entry needs type (a name from CI Relationship Type [cmdb_rel_type], e.g. 'Runs on::Runs') plus either parent/child as integer indexes into items, or parent_id/child_id as internal_id values (the only form that can point at a related or lookup item). Optional sys_rel_source_info { source_name, source_feed }.",
+        items: { type: "object" },
+      },
+      referenceItems: {
+        type: "array",
+        description:
+          "References between two payload items, resolved before identification: { referenced, referencedBy, referenceField } where referenced/referencedBy are internal_id values and referenceField is the reference column on the referencedBy class.",
+        items: { type: "object" },
+      },
+      data_source: {
+        type: "string",
+        description:
+          "Required. Sent as sysparm_data_source. Must be a choice value of cmdb_ci.discovery_source on this instance, e.g. 'ServiceNow'. Checked against sys_choice before the payload is posted.",
+      },
+      dry_run: {
+        type: "boolean",
+        description:
+          "Post to /api/now/identifyreconcile/query instead: same identification, same per-item verdict, nothing committed.",
+        default: false,
+      },
+    },
+    required: ["items", "data_source"],
+  },
+}
+
+export async function execute(args: Record<string, any>, context: ServiceNowContext): Promise<ToolResult> {
+  const items = Array.isArray(args.items) ? args.items : []
+  if (items.length === 0)
+    return createErrorResult(
+      "items must be a non-empty array. Each entry needs className (a CMDB table such as cmdb_ci_linux_server), plus the data to identify and write the CI — usually values, otherwise lookup or sys_object_source_info.",
+    )
+
+  // The reference marks className "Required." and marks nothing else on an item,
+  // so an item identified purely through lookup or sys_object_source_info is not
+  // documented as invalid. className is enforced; values is only type-checked
+  // when present, because refusing a payload the API would accept is this tool
+  // inventing a rule and claiming it came from the API.
+  const malformed = items.findIndex((item) => typeof item?.className !== "string" || item.className.length === 0)
+  if (malformed !== -1)
+    return createErrorResult(
+      `items[${malformed}] needs a className string — the CMDB class/table of the CI, such as cmdb_ci_linux_server. It is the only field the reference marks required on an item.`,
+    )
+
+  const badValues = items.findIndex(
+    (item) =>
+      item.values !== undefined &&
+      (typeof item.values !== "object" || item.values === null || Array.isArray(item.values)),
+  )
+  if (badValues !== -1)
+    return createErrorResult(
+      `items[${badValues}].values must be an object of field name/value pairs. Omit it only when the CI is identified through lookup or sys_object_source_info instead.`,
+    )
+
+  // Sent as a query parameter, not in the body. Omitting it does not fail loudly:
+  // the documented default is to store the payload in the incomplete-payloads
+  // table, so the call returns 200 and the CMDB is unchanged.
+  const source: string | undefined = args.data_source ?? args.sysparm_data_source ?? args.discovery_source
+  if (typeof source !== "string" || source.length === 0)
+    return createErrorResult(
+      "data_source is required. Without sysparm_data_source, IRE stores the payload in the incomplete-payloads table instead of committing it — the call succeeds and nothing changes.",
+    )
+
+  const relations = Array.isArray(args.relations) ? args.relations : []
+  const badRelation = relations.findIndex(
+    (relation) =>
+      typeof relation?.type !== "string" ||
+      relation.type.length === 0 ||
+      !(
+        (Number.isInteger(relation.parent) && Number.isInteger(relation.child)) ||
+        (typeof relation.parent_id === "string" && typeof relation.child_id === "string")
+      ),
+  )
+  if (badRelation !== -1)
+    return createErrorResult(
+      `relations[${badRelation}] needs type (a name from cmdb_rel_type, e.g. "Runs on::Runs") plus either parent/child as integer indexes into items, or parent_id/child_id as internal_id values.`,
+    )
+
+  const outOfRange = relations.findIndex(
+    (relation) =>
+      Number.isInteger(relation.parent) &&
+      (relation.parent < 0 || relation.parent >= items.length || relation.child < 0 || relation.child >= items.length),
+  )
+  if (outOfRange !== -1)
+    return createErrorResult(
+      `relations[${outOfRange}] points outside the items array (${items.length} item(s)). parent and child are zero-based indexes into items; use parent_id/child_id if you meant an internal_id.`,
+    )
+
+  const dryRun: boolean = args.dry_run ?? false
+  const client = await getAuthenticatedClient(context)
+
+  // The reference states sysparm_data_source "must be one of the choice values
+  // defined for the discovery_source field of the Configuration Item [cmdb_ci]
+  // table". The instance's rejection of an unknown value does not name the valid
+  // ones, so read them first. A failed or empty read is not treated as proof the
+  // value is wrong — the call goes ahead and the check is reported as skipped.
+  // sys_choice rows are per language, so an instance with language packs holds
+  // the same value once per language; without the language filter a real choice
+  // can fall outside the row limit and this check then rejects a valid write.
+  const choices: string[] = await client
+    .get("/api/now/table/sys_choice", {
+      params: {
+        sysparm_query: "name=cmdb_ci^element=discovery_source^language=en",
+        sysparm_fields: "value",
+        sysparm_limit: 500,
+      },
+    })
+    .then((response) =>
+      (response.data.result ?? [])
+        .map((row: Record<string, any>) => row.value)
+        .filter((value: unknown): value is string => typeof value === "string" && value.length > 0),
+    )
+    .catch(() => [])
+
+  if (choices.length > 0 && !choices.includes(source))
+    return createErrorResult(
+      `data_source '${source}' is not a choice on cmdb_ci.discovery_source. Values read from sys_choice on this instance (language en): ${[...new Set(choices)].sort().join(", ")}`,
+      { data_source: source, valid_data_sources: [...new Set(choices)].sort() },
+    )
+
+  const endpoint = dryRun ? "/api/now/identifyreconcile/query" : "/api/now/identifyreconcile"
+  const referenceItems = Array.isArray(args.referenceItems) ? args.referenceItems : []
+  const response = await client.post(
+    endpoint,
+    {
+      items,
+      ...(relations.length > 0 ? { relations } : {}),
+      ...(referenceItems.length > 0 ? { referenceItems } : {}),
+    },
+    { params: { sysparm_data_source: source } },
+  )
+
+  // The worked example in the reference returns `result` as an object; only its
+  // schema table prints array brackets around the same named keys. The object is
+  // the real shape — the array read stays because reading the wrong one would
+  // report zero items for a payload that was in fact processed.
+  const result = Array.isArray(response.data.result) ? response.data.result[0] : response.data.result
+  const resultItems: Record<string, any>[] = Array.isArray(result?.items) ? result.items : []
+  const resultRelations: Record<string, any>[] = Array.isArray(result?.relations) ? result.relations : []
+  const additionalItems: Record<string, any>[] = Array.isArray(result?.additionalCommittedItems)
+    ? result.additionalCommittedItems
+    : []
+
+  // result.items is documented as "List of CIs included in the request body
+  // items array", so an empty one for a non-empty payload means the verdict was
+  // not returned in the shape read here. Report that rather than a clean run of
+  // zero items, which would read as success.
+  if (resultItems.length === 0)
+    return createErrorResult(
+      `${endpoint} returned no per-item result for a ${items.length}-item payload, so what IRE did with it cannot be confirmed from the response. The raw body is in metadata.`,
+      { endpoint, data_source: source, dry_run: dryRun, response: response.data },
+    )
+
+  const failures = [
+    ...collectErrors(resultItems, "items"),
+    ...collectErrors(resultRelations, "relations"),
+    ...collectErrors(additionalItems, "additionalCommittedItems"),
+  ]
+
+  const summary = [
+    dryRun
+      ? `IRE dry run against ${endpoint} — nothing committed, ${resultItems.length} item verdict(s):`
+      : `IRE processed ${resultItems.length} item(s) as data source '${source}':`,
+    ...resultItems.slice(0, 10).map((item, index) => {
+      const sysId = typeof item?.sysId === "string" && item.sysId !== "Unknown" ? ` sys_id: ${item.sysId}` : ""
+      return `  ${index + 1}. ${item?.className ?? "?"} ${item?.operation ?? "?"}${sysId}`
+    }),
+    ...(resultItems.length > 10 ? [`  ... and ${resultItems.length - 10} more`] : []),
+    ...failures.slice(0, 5).map((failure) => `  ✗ ${failure.where}: ${failure.message ?? failure.error}`),
+    ...(failures.length > 5 ? [`  ✗ ... and ${failures.length - 5} more error(s)`] : []),
+  ].join("\n")
+
+  const data = {
+    dry_run: dryRun,
+    endpoint,
+    data_source: source,
+    data_source_checked: choices.length > 0,
+    operations: resultItems.reduce<Record<string, number>>((counts, item) => {
+      const operation = typeof item?.operation === "string" ? item.operation : "UNKNOWN"
+      counts[operation] = (counts[operation] ?? 0) + 1
+      return counts
+    }, {}),
+    items: resultItems,
+    relations: resultRelations,
+    additional_committed_items: additionalItems,
+    errors: failures,
+  }
+
+  if (failures.length > 0)
+    return {
+      success: false,
+      error:
+        `IRE returned ${failures.length} error(s) for this payload: ` +
+        failures
+          .slice(0, 3)
+          .map((failure) => `${failure.where} ${failure.message ?? failure.error}`)
+          .join("; ") +
+        (failures.length > 3 ? ` (+${failures.length - 3} more)` : "") +
+        (dryRun
+          ? ""
+          : " — partial commits are an Enhanced-IRE feature and this endpoint is not the enhanced one, so do not assume the error-free items committed; re-read the CIs to confirm. Per-item verdicts are in data.items."),
+      data,
+      summary,
+      metadata: { endpoint, data_source: source, dry_run: dryRun },
+    }
+
+  // Only a single-item payload has one unambiguous artifact, and "Unknown" is
+  // the documented sysId for an item whose identification failed.
+  const single = resultItems.length === 1 ? resultItems[0] : undefined
+  const artifact =
+    !dryRun && typeof single?.sysId === "string" && single.sysId.length > 0 && single.sysId !== "Unknown"
+      ? {
+          sys_id: single.sysId,
+          type: "cmdb_ci",
+          table: typeof single.className === "string" ? single.className : undefined,
+        }
+      : undefined
+
+  return createSuccessResult(data, { endpoint, data_source: source, dry_run: dryRun }, summary, artifact)
+}
+
+/**
+ * IRE reports per-item failure inside a 200 response, one `errors` array per
+ * result row, so the caller only learns a CI was rejected by reading them. The
+ * reference documents errorCount beside errors on items, relations and
+ * additionalCommittedItems, and its inline shape sample for
+ * additionalCommittedItems prints errorCount without the errors array. A count
+ * with no detail is still a failure, so it is reported rather than dropped.
+ */
+function collectErrors(rows: Record<string, any>[], label: string) {
+  return rows.flatMap((row, index) => {
+    const className = typeof row?.className === "string" ? row.className : undefined
+    const errors: Record<string, any>[] = Array.isArray(row?.errors) ? row.errors : []
+    if (errors.length > 0)
+      return errors.map((entry) => ({
+        where: `${label}[${index}]`,
+        className,
+        error: entry?.error,
+        message: entry?.message,
+      }))
+    // Number() rather than a typeof check: the reference types errorCount as a
+    // Number, but a count that arrives as "2" is still two errors.
+    if (Number(row?.errorCount) > 0)
+      return [
+        {
+          where: `${label}[${index}]`,
+          className,
+          error: "errorCount",
+          message: `${row.errorCount} error(s) reported, with no errors[] detail in the response`,
+        },
+      ]
+    return []
+  })
+}
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/snow_reconcile_ci.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/cmdb/snow_reconcile_ci.ts
@@ -1,5 +1,14 @@
 /**
  * snow_reconcile_ci - CMDB reconciliation
+ *
+ * DEPRECATED: this does not run reconciliation. The executor below PUTs the
+ * caller's source_data onto base cmdb_ci for one sys_id and echoes the
+ * reconciliation_rule argument straight back as `rule` — no identifier rule, no
+ * reconciliation rule, no Source [sys_object_source] row, and class-specific
+ * columns are dropped because the write targets cmdb_ci rather than the CI's
+ * own class table. Use snow_cmdb_identify_reconcile, which posts to
+ * /api/now/identifyreconcile and lets the Identification and Reconciliation
+ * Engine decide the operation.
  */
 
 import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
@@ -8,7 +17,8 @@ import { createSuccessResult, createErrorResult } from "../../shared/error-handl
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_reconcile_ci",
-  description: "Reconcile CI data from multiple sources",
+  description:
+    "[DEPRECATED - use snow_cmdb_identify_reconcile] Does not reconcile. PUTs the given fields onto base cmdb_ci for one sys_id and echoes reconciliation_rule back untouched — no identifier or reconciliation rule runs, no Source [sys_object_source] row is written, and class-specific fields are dropped. Use snow_cmdb_identify_reconcile instead, which posts the payload to the Identification and Reconciliation Engine. Kept only for callers that already depend on this plain cmdb_ci update.",
   // Metadata for tool discovery (not sent to LLM)
   category: "cmdb",
   subcategory: "reconciliation",

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/extensions/snow_scripted_rest_api.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/extensions/snow_scripted_rest_api.ts
@@ -8,7 +8,7 @@ import { createSuccessResult, createErrorResult } from "../../shared/error-handl
 
 export const toolDefinition: MCPToolDefinition = {
   name: "snow_scripted_rest_api",
-  description: "Invoke a Scripted REST API resource at /api/<namespace>/<path> with chosen method (GET/POST/PUT/PATCH/DELETE) and optional JSON body. Use for instance-defined REST endpoints; for stock table API use snow_custom_api.",
+  description: "Invoke an EXISTING Scripted REST API resource at /api/<namespace>/<path> with chosen method (GET/POST/PUT/PATCH/DELETE) and optional JSON body. This is a client: it calls endpoints, it does not create them — to author a Scripted REST API (sys_ws_definition + sys_ws_operation) use snow_scripted_rest_api_manage. For the stock table API use snow_custom_api.",
   // Metadata for tool discovery (not sent to LLM)
   category: "integration",
   subcategory: "rest-api",

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/integration/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/integration/index.ts
@@ -16,6 +16,10 @@ export {
   execute as snow_rest_message_manage_exec,
 } from "./snow_rest_message_manage.js"
 export {
+  toolDefinition as snow_scripted_rest_api_manage_def,
+  execute as snow_scripted_rest_api_manage_exec,
+} from "./snow_scripted_rest_api_manage.js"
+export {
   toolDefinition as snow_test_rest_connection_def,
   execute as snow_test_rest_connection_exec,
 } from "./snow_test_rest_connection.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/integration/snow_scripted_rest_api_manage.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/integration/snow_scripted_rest_api_manage.ts
@@ -1,0 +1,822 @@
+/**
+ * snow_scripted_rest_api_manage
+ *
+ * Authors inbound Scripted REST APIs: the sys_ws_definition record and the
+ * sys_ws_operation resources hanging off it. This is the build side; calling a
+ * finished endpoint is snow_scripted_rest_api's job.
+ *
+ * Field names and payload shapes are copied from shared/scripted-exec.ts, which
+ * deploys Serac's own executor endpoint through exactly these two tables against
+ * live instances — with one exception. `requires_acl_authorization` is a column
+ * scripted-exec names in a comment and deliberately never sends, and ServiceNow's
+ * published docs do not enumerate sys_ws_operation's fields, so that one name is
+ * carried from a comment and unverified against a live instance. Which is why the
+ * tool reports the value the instance returned rather than the value it sent: if
+ * the column is wrong, protected or absent on this version, the caller is told so
+ * instead of being reassured that ACL enforcement is on. Every other column here
+ * (name, service_id, short_description, active on the definition; name,
+ * web_service_definition, http_method, relative_path, operation_script, active,
+ * requires_authentication on the resource) is one scripted-exec really writes.
+ *
+ * The one thing this tool refuses to fake: a created resource is not necessarily
+ * a reachable URL. ServiceNow computes `operation_uri` itself, and the route
+ * takes a moment to appear — scripted-exec pings up to five times at 1.5s before
+ * it believes its own deployment. So a create returns the URI ServiceNow
+ * assigned plus an explicit routing verdict, never a bare `created: true`.
+ */
+
+import type { AxiosInstance } from "axios"
+import type { MCPToolDefinition, ServiceNowContext, ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+const DEFINITION_TABLE = "/api/now/table/sys_ws_definition"
+const OPERATION_TABLE = "/api/now/table/sys_ws_operation"
+const DEFINITION_FIELDS = "sys_id,name,service_id,namespace,base_uri,short_description,active"
+// requires_acl_authorization is requested here so the tool can report what the
+// instance stores rather than what the caller asked for. Asking for a column the
+// table does not have is safe: "Invalid fields are ignored" per the Table API
+// reference, so it simply comes back absent — which this tool reports as
+// unconfirmed, not as off.
+const OPERATION_FIELDS =
+  "sys_id,name,http_method,relative_path,operation_uri,active,requires_authentication,requires_acl_authorization,web_service_definition"
+// One page of resources. A definition with more than this many is not something
+// this tool will delete, because it cannot see the rest to delete them first.
+const OPERATION_PAGE_LIMIT = 200
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_scripted_rest_api_manage",
+  description:
+    "Build and maintain inbound Scripted REST APIs on the instance: the sys_ws_definition record (list/get/create/update/delete) and its sys_ws_operation resources (add_operation/update_operation/delete_operation). " +
+    "Returns the operation_uri ServiceNow assigned to each resource, and — with verify_routing=true, or action=verify afterwards — whether that URL actually answers yet; a freshly created resource is routable only after a short delay, so it reports 'created but not yet routable' rather than claiming success it did not observe. Probing calls the resource for real, which runs whatever its script does. " +
+    "This tool AUTHORS endpoints. To CALL an endpoint that already exists, use snow_scripted_rest_api instead.",
+  // Metadata for tool discovery (not sent to LLM)
+  category: "integration",
+  subcategory: "scripted-rest-api",
+  use_cases: ["scripted-rest-api", "inbound-api", "custom-endpoint", "web-service"],
+  complexity: "advanced",
+  frequency: "medium",
+
+  // Permission enforcement
+  // Classification: WRITE — creates and edits sys_ws_definition / sys_ws_operation
+  // records, which are configuration and belong in an update set.
+  permission: "write",
+  allowedRoles: ["developer", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: [
+          "list", // List Scripted REST API definitions
+          "get", // One definition plus all of its resources
+          "create", // Create a definition (optionally its first resource)
+          "update", // Update a definition
+          "delete", // Delete a definition and its resources
+          "add_operation", // Add a resource to a definition
+          "update_operation", // Update a resource
+          "delete_operation", // Delete a resource
+          "verify", // Probe an existing resource's URL to see whether it routes
+        ],
+        description:
+          "Action to perform. list/get/create/update/delete act on the API definition (sys_ws_definition); add_operation/update_operation/delete_operation act on its resources (sys_ws_operation); verify probes an existing resource's URL, which calls the resource.",
+      },
+      sys_id: {
+        type: "string",
+        description:
+          "sys_id of the Scripted REST API definition (get/update/delete/add_operation). Alias: definition_sys_id. " +
+          "update_operation/delete_operation/verify also accept it when operation_sys_id is missing, but those actions need the RESOURCE's sys_id — passing the definition's there just 404s.",
+      },
+      name: {
+        type: "string",
+        description:
+          "[create/update] Name of the API. ServiceNow derives the API ID from it when api_id is omitted. Also usable instead of sys_id to look a definition up.",
+      },
+      api_id: {
+        type: "string",
+        description:
+          "[create] Explicit API ID (service_id column), the segment that appears in the URL. Leave empty to let ServiceNow derive it from the name.",
+      },
+      short_description: { type: "string", description: "[create/update] Short description of the API" },
+      // No field that update/update_operation can write declares a JSON-schema
+      // `default`. Models routinely echo defaults back while meaning to change
+      // one other field, and here that is not a no-op: an echoed http_method or
+      // relative_path silently re-routes a live endpoint, and an echoed
+      // requires_acl_authorization=false silently disarms it. The create-side
+      // defaults live in the executor instead, where nothing can mistake them
+      // for an instruction. Every update action writes only what it was passed.
+      active: {
+        type: "boolean",
+        description:
+          "Whether the record is active. Applies to the definition on create/update, and to the resource on add_operation/update_operation. Defaults to true when creating; on the update actions it is left alone unless passed.",
+      },
+      filter: {
+        type: "string",
+        description: '[list] Encoded query against sys_ws_definition (e.g. "nameLIKEorder" or "active=true")',
+      },
+      limit: { type: "number", description: "[list] Maximum definitions to return", default: 50 },
+      operation_sys_id: {
+        type: "string",
+        description: "sys_id of the resource record (update_operation/delete_operation/verify)",
+      },
+      operation_name: { type: "string", description: "[create/add_operation/update_operation] Name of the resource" },
+      http_method: {
+        type: "string",
+        enum: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+        description:
+          "[create/add_operation/update_operation] HTTP method the resource implements. Creating without it gets GET. On update_operation, pass it only to change the method — it moves the endpoint.",
+      },
+      relative_path: {
+        type: "string",
+        description:
+          '[create/add_operation/update_operation] Path relative to the API base, e.g. "/orders" or "/orders/{id}". Creating without it gets "/". On update_operation, pass it only to move the resource — every caller of the old path breaks.',
+      },
+      operation_script: {
+        type: "string",
+        description:
+          "[create/add_operation/update_operation] The resource script, shaped as (function process(request, response) { ... })(request, response). Runs server-side on Rhino, so ES5 only — ES6+ syntax is reported back as a warning.",
+      },
+      requires_authentication: {
+        type: "boolean",
+        description:
+          "[create/add_operation/update_operation] Require an authenticated caller. Creating without it requires authentication.",
+      },
+      requires_acl_authorization: {
+        type: "boolean",
+        description:
+          "[create/add_operation/update_operation] Enforce rest_endpoint ACLs on the resource. Creating without it leaves the column unset — see the tool's response notes for why. Authentication alone authorises EVERY authenticated user, so put a gs.hasRole() check in the script if you leave this off. Passing false on update_operation actively turns enforcement off; the response always reports the value the instance stored, not the one you sent.",
+      },
+      verify_routing: {
+        type: "boolean",
+        description:
+          "[create/add_operation/update_operation/verify] After writing, call the resource URL to see whether it routes yet. WARNING: this invokes your resource script for real, with whatever side effects it has.",
+        default: false,
+      },
+    },
+    required: ["action"],
+  },
+}
+
+/**
+ * Action → handler. Exported so the schema's `action` enum can be checked
+ * against what the executor really dispatches, instead of the two drifting.
+ */
+export const ACTIONS = {
+  list: listDefinitions,
+  get: getDefinition,
+  create: createDefinition,
+  update: updateDefinition,
+  delete: deleteDefinition,
+  add_operation: addOperation,
+  update_operation: updateOperation,
+  delete_operation: deleteOperation,
+  verify: verifyOperation,
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const action = str(args.action)
+  const handler = action ? ACTIONS[action as keyof typeof ACTIONS] : undefined
+  // Checked before authenticating: a typo shouldn't cost a round trip, and it
+  // makes the dispatch table testable without an instance.
+  if (!handler) {
+    return createErrorResult(
+      `Unknown action: ${action ?? "(none)"}. Valid actions: ${Object.keys(ACTIONS).join(", ")}.`,
+    )
+  }
+
+  try {
+    return await handler(await getAuthenticatedClient(context), args)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    const status = statusOf(error)
+    if (status === 403) {
+      return createErrorResult(
+        `Permission denied (403) on ${action}. Creating or editing a Scripted REST API needs the web_service_admin role (per ServiceNow's "Create a scripted REST service" procedure) or admin. Original error: ${message}`,
+      )
+    }
+    return createErrorResult(message)
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Definition (sys_ws_definition)
+// ───────────────────────────────────────────────────────────────────────────
+
+async function listDefinitions(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const response = await client.get(DEFINITION_TABLE, {
+    params: {
+      sysparm_query: str(args.filter),
+      sysparm_fields: DEFINITION_FIELDS,
+      sysparm_limit: num(args.limit) ?? 50,
+    },
+  })
+  const definitions = asArray(rec(response.data).result).map(rec)
+
+  return createSuccessResult(
+    {
+      action: "list",
+      count: definitions.length,
+      definitions: definitions.map(summariseDefinition),
+    },
+    { operation: "list_scripted_rest_apis" },
+    `Found ${definitions.length} Scripted REST API definition(s)`,
+  )
+}
+
+async function getDefinition(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const definition = await resolveDefinition(client, args)
+  const operations = await fetchOperations(client, str(definition.sys_id) ?? "")
+
+  return createSuccessResult(
+    {
+      action: "get",
+      definition: summariseDefinition(definition),
+      operations: operations.map(summariseOperation),
+      operation_count: operations.length,
+      ...(operations.length === 0
+        ? { warning: "This API has no resources, so it serves nothing. Add one with action=add_operation." }
+        : operations.length === OPERATION_PAGE_LIMIT
+          ? {
+              warning: `Only the first ${OPERATION_PAGE_LIMIT} resources were read, so this list is probably incomplete.`,
+            }
+          : {}),
+    },
+    { operation: "get_scripted_rest_api" },
+    `${str(definition.name) ?? "(unnamed)"} — ${operations.length} resource(s), base_uri ${str(definition.base_uri) ?? "(unknown)"}`,
+  )
+}
+
+async function createDefinition(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const name = str(args.name)
+  if (!name) return createErrorResult("name is required for action=create")
+
+  const response = await client.post(DEFINITION_TABLE, {
+    name,
+    // Omitted service_id is set by ServiceNow from the name (the form calls it
+    // "API ID" and fills it automatically), so only send it when asked for.
+    ...(str(args.api_id) ? { service_id: str(args.api_id) } : {}),
+    ...(str(args.short_description) ? { short_description: str(args.short_description) } : {}),
+    active: bool(args.active, true),
+  })
+  const definition = rec(rec(response.data).result)
+  const definitionId = str(definition.sys_id)
+  if (!definitionId) {
+    return createErrorResult("ServiceNow accepted the sys_ws_definition insert but returned no sys_id.")
+  }
+
+  // A definition on its own serves nothing, so create the first resource in the
+  // same call when the caller supplied a script for it. A failure there must not
+  // surface as a plain error: the definition already exists on the instance and
+  // the caller has to know its sys_id to finish or clean up.
+  const operation = str(args.operation_script)
+    ? await createOperation(client, definition, args).catch((error: unknown) => messageOf(error))
+    : undefined
+  if (typeof operation === "string") {
+    return createErrorResult(
+      `The sys_ws_definition was created (sys_id ${definitionId}, name "${name}") but its first resource was rejected: ${operation}. ` +
+        `The API exists and currently serves nothing — retry the resource with action="add_operation", sys_id="${definitionId}", or delete the definition with action="delete".`,
+    )
+  }
+
+  return createSuccessResult(
+    {
+      action: "create",
+      created: true,
+      definition: summariseDefinition(definition),
+      ...(operation ? { operation: operation.data } : {}),
+      ...(operation?.warnings?.length ? { warnings: operation.warnings } : {}),
+      next_steps: operation
+        ? [
+            operation.data.routing.routable === true
+              ? `Call it with snow_scripted_rest_api, or from outside: ${operation.data.url ?? "(unknown URL)"}`
+              : `Re-check routing later with action=verify, operation_sys_id="${operation.data.sys_id}"`,
+          ]
+        : [
+            `Add a resource: action="add_operation", sys_id="${definitionId}", relative_path="/...", operation_script="(function process(request, response) { ... })(request, response);"`,
+            "Until then this API has no resources and answers nothing.",
+          ],
+    },
+    { operation: "create_scripted_rest_api" },
+    `Created Scripted REST API "${name}"\n  sys_id: ${definitionId}\n  base_uri: ${str(definition.base_uri) ?? "(not returned)"}` +
+      (operation ? `\n  resource: ${operation.data.url ?? "(unknown URL)"} — ${operation.data.routing.verdict}` : ""),
+  )
+}
+
+async function updateDefinition(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const definition = await resolveDefinition(client, args)
+  const payload = {
+    ...(str(args.name) ? { name: str(args.name) } : {}),
+    ...(str(args.short_description) ? { short_description: str(args.short_description) } : {}),
+    ...(args.active === undefined ? {} : { active: bool(args.active, true) }),
+  }
+  if (Object.keys(payload).length === 0) {
+    return createErrorResult("Nothing to update. Provide at least one of: name, short_description, active.")
+  }
+
+  const response = await client.patch(`${DEFINITION_TABLE}/${str(definition.sys_id)}`, payload)
+
+  return createSuccessResult(
+    {
+      action: "update",
+      updated: true,
+      definition: summariseDefinition(rec(rec(response.data).result)),
+      fields_updated: Object.keys(payload),
+    },
+    { operation: "update_scripted_rest_api" },
+  )
+}
+
+async function deleteDefinition(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const definition = await resolveDefinition(client, args)
+  const definitionId = str(definition.sys_id) ?? ""
+  const operations = await fetchOperations(client, definitionId)
+  // fetchOperations reads a single page. A full page means there may be resources
+  // this tool cannot see, and deleting the definition anyway would orphan them
+  // while reporting operations_deleted as if the delete had been clean.
+  if (operations.length === OPERATION_PAGE_LIMIT) {
+    return createErrorResult(
+      `This API has at least ${OPERATION_PAGE_LIMIT} resources, which is one full page — the most this tool reads at a time — so it will not delete the definition and orphan the ones it cannot see. ` +
+        `Remove resources with action="delete_operation" until fewer than ${OPERATION_PAGE_LIMIT} remain, or delete the API from System Web Services > Scripted REST APIs in the UI.`,
+    )
+  }
+
+  // Resources first: a sys_ws_operation left behind points at a definition that
+  // no longer exists.
+  const deleted: Array<{ sys_id?: string; deleted: boolean; error?: string }> = await Promise.all(
+    operations.map((operation) =>
+      client
+        .delete(`${OPERATION_TABLE}/${str(operation.sys_id)}`)
+        .then(() => ({ sys_id: str(operation.sys_id), deleted: true }))
+        .catch((error: unknown) => ({
+          sys_id: str(operation.sys_id),
+          deleted: false,
+          error: messageOf(error),
+        })),
+    ),
+  )
+  const failed = deleted.filter((entry) => !entry.deleted)
+  if (failed.length > 0) {
+    return createErrorResult(
+      `Could not delete ${failed.length} of ${operations.length} resource(s), so the definition was left in place: ` +
+        failed.map((entry) => `${entry.sys_id}: ${entry.error}`).join("; "),
+    )
+  }
+
+  await client.delete(`${DEFINITION_TABLE}/${definitionId}`)
+
+  return createSuccessResult(
+    {
+      action: "delete",
+      deleted: true,
+      sys_id: definitionId,
+      operations_deleted: deleted.length,
+    },
+    { operation: "delete_scripted_rest_api" },
+    `Deleted Scripted REST API ${str(definition.name) ?? definitionId} and ${deleted.length} resource(s)`,
+  )
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Resources (sys_ws_operation)
+// ───────────────────────────────────────────────────────────────────────────
+
+async function addOperation(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  if (!str(args.operation_script)) return createErrorResult("operation_script is required for action=add_operation")
+
+  const definition = await resolveDefinition(client, args)
+  const operation = await createOperation(client, definition, args)
+
+  return createSuccessResult(
+    {
+      action: "add_operation",
+      created: true,
+      definition: summariseDefinition(definition),
+      operation: operation.data,
+      ...(operation.warnings.length > 0 ? { warnings: operation.warnings } : {}),
+    },
+    { operation: "add_scripted_rest_operation" },
+    `Added ${operation.data.http_method} resource to ${str(definition.name) ?? "(unnamed API)"}\n  url: ${operation.data.url ?? "(unknown)"}\n  ${operation.data.routing.verdict}`,
+  )
+}
+
+async function updateOperation(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const operationId = str(args.operation_sys_id) ?? str(args.sys_id)
+  if (!operationId) return createErrorResult("operation_sys_id is required for action=update_operation")
+
+  const script = str(args.operation_script)
+  const payload = {
+    ...(str(args.operation_name) ? { name: str(args.operation_name) } : {}),
+    ...(str(args.http_method) ? { http_method: str(args.http_method) } : {}),
+    ...(str(args.relative_path) ? { relative_path: normalisePath(str(args.relative_path)) } : {}),
+    ...(script ? { operation_script: script } : {}),
+    ...(args.active === undefined ? {} : { active: bool(args.active, true) }),
+    ...(args.requires_authentication === undefined
+      ? {}
+      : { requires_authentication: bool(args.requires_authentication, true) }),
+    ...(args.requires_acl_authorization === undefined
+      ? {}
+      : { requires_acl_authorization: bool(args.requires_acl_authorization, false) }),
+  }
+  if (Object.keys(payload).length === 0) {
+    return createErrorResult(
+      "Nothing to update. Provide at least one of: operation_name, http_method, relative_path, operation_script, active, requires_authentication, requires_acl_authorization.",
+    )
+  }
+
+  const response = await client.patch(`${OPERATION_TABLE}/${operationId}`, payload)
+  const operation = rec(rec(response.data).result)
+  // Only decoration here: the definition supplies fallback URLs if ServiceNow
+  // returned no operation_uri. A failed read is not worth failing the update over.
+  const definition = await fetchDefinitionById(client, refValue(operation.web_service_definition)).catch(() => ({}))
+
+  // relative_path changes move the URL, so re-read what ServiceNow now says it is
+  // rather than reporting the one the caller remembered.
+  const routing = await routeReport(client, definition, operation, args)
+  const warnings = [
+    ...(script ? es5Warnings(script) : []),
+    // Only when this call touched the flag — an unrelated script edit should not
+    // start lecturing about a security posture the caller did not change.
+    ...("requires_acl_authorization" in payload
+      ? aclWarnings(bool(args.requires_acl_authorization, false), flag(operation.requires_acl_authorization))
+      : []),
+  ]
+
+  return createSuccessResult(
+    {
+      action: "update_operation",
+      updated: true,
+      operation: { ...summariseOperation(operation), url: routing.url, routing },
+      fields_updated: Object.keys(payload),
+      ...(warnings.length > 0 ? { warnings } : {}),
+    },
+    { operation: "update_scripted_rest_operation" },
+  )
+}
+
+async function deleteOperation(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const operationId = str(args.operation_sys_id) ?? str(args.sys_id)
+  if (!operationId) return createErrorResult("operation_sys_id is required for action=delete_operation")
+
+  await client.delete(`${OPERATION_TABLE}/${operationId}`)
+
+  return createSuccessResult(
+    { action: "delete_operation", deleted: true, operation_sys_id: operationId },
+    { operation: "delete_scripted_rest_operation" },
+  )
+}
+
+async function verifyOperation(client: AxiosInstance, args: Record<string, unknown>): Promise<ToolResult> {
+  const operationId = str(args.operation_sys_id) ?? str(args.sys_id)
+  if (!operationId) return createErrorResult("operation_sys_id is required for action=verify")
+
+  const response = await client.get(`${OPERATION_TABLE}/${operationId}`, {
+    params: { sysparm_fields: OPERATION_FIELDS },
+  })
+  const operation = rec(rec(response.data).result)
+  if (!str(operation.sys_id)) return createErrorResult(`No sys_ws_operation found with sys_id ${operationId}`)
+
+  // Decoration again: the probe runs off the operation's own operation_uri, and
+  // the definition only supplies fallback URLs, so a failed read costs detail in
+  // the report rather than the verdict.
+  const definition = await fetchDefinitionById(client, refValue(operation.web_service_definition)).catch(() => ({}))
+  const routing = await routeReport(client, definition, operation, { ...args, verify_routing: true })
+
+  return createSuccessResult(
+    {
+      action: "verify",
+      operation: { ...summariseOperation(operation), url: routing.url, routing },
+      definition: summariseDefinition(definition),
+    },
+    { operation: "verify_scripted_rest_operation" },
+    `${routing.verdict}${routing.url ? `\n  url: ${routing.url}` : ""}`,
+  )
+}
+
+/**
+ * Create one sys_ws_operation under `definition`, then report where it lives
+ * and whether that URL answers. Shared by create and add_operation.
+ *
+ * The payload mirrors shared/scripted-exec.ts, which deploys Serac's own
+ * executor through this table.
+ */
+async function createOperation(
+  client: AxiosInstance,
+  definition: Record<string, unknown>,
+  args: Record<string, unknown>,
+) {
+  const script = str(args.operation_script) ?? ""
+  const response = await client.post(OPERATION_TABLE, {
+    name: str(args.operation_name) ?? `${str(args.http_method) ?? "GET"} ${normalisePath(str(args.relative_path))}`,
+    web_service_definition: str(definition.sys_id),
+    http_method: str(args.http_method) ?? "GET",
+    relative_path: normalisePath(str(args.relative_path)),
+    operation_script: script,
+    active: bool(args.active, true),
+    requires_authentication: bool(args.requires_authentication, true),
+    // requires_acl_authorization is only sent when the caller asks for it.
+    // Carried forward from shared/scripted-exec.ts, which learned this the hard
+    // way: with it on and no rest_endpoint ACL defined for the resource,
+    // ServiceNow's behaviour is version-dependent and can deny every caller —
+    // including the admin integration user the endpoint exists to serve. The
+    // cost of leaving it off is that authentication alone authorises every
+    // authenticated user, which is why the response says so and why
+    // scripted-exec puts a gs.hasRole() check inside its own script.
+    ...(bool(args.requires_acl_authorization, false) ? { requires_acl_authorization: true } : {}),
+  })
+  // The Table API returns the inserted record, so what the instance actually
+  // stored is already in hand — no extra read to find out whether the security
+  // flag survived the insert.
+  const operation = rec(rec(response.data).result)
+  const routing = await routeReport(client, definition, operation, args)
+
+  return {
+    data: {
+      ...summariseOperation(operation),
+      url: routing.url,
+      routing,
+    },
+    warnings: [
+      ...es5Warnings(script),
+      ...aclWarnings(bool(args.requires_acl_authorization, false), flag(operation.requires_acl_authorization)),
+    ],
+  }
+}
+
+/**
+ * What the instance stored for requires_acl_authorization, said plainly.
+ *
+ * Driven by the response body, never by the argument. This is the one column the
+ * tool writes that no other code in the repo has proven, so "the caller asked for
+ * true" is not evidence that enforcement is on: a wrong column name, a read-only
+ * or protected field, or a scoped-app restriction all end with the flag dropped
+ * and the caller believing an endpoint is guarded when every authenticated user
+ * can call it. An absent column is reported as unconfirmed rather than collapsed
+ * into either state — the Table API ignores invalid sysparm_fields entries, so
+ * absence means "this instance did not give us the value", not "it is off".
+ */
+export function aclWarnings(requested: boolean, stored: boolean | undefined): string[] {
+  if (stored === true) return []
+  if (stored === undefined)
+    return [
+      `The instance returned no requires_acl_authorization value for this resource, so ACL enforcement is unconfirmed${requested ? " even though you asked for it" : ""}. ` +
+        "Treat the resource as callable by every authenticated user until you have checked the Security section of its form, and keep a gs.hasRole() check at the top of the script.",
+    ]
+  return [
+    requested
+      ? "You asked for requires_acl_authorization=true but the record ServiceNow returned has it off, so any authenticated user can call this resource. Set it on the resource form, define a rest_endpoint ACL for it, and until then gate the script with gs.hasRole()."
+      : "requires_acl_authorization is off on this resource, so any authenticated user can call it. Add a gs.hasRole() check at the top of the script, or set requires_acl_authorization=true and define a rest_endpoint ACL for it.",
+  ]
+}
+
+async function fetchOperations(client: AxiosInstance, definitionId: string) {
+  const response = await client.get(OPERATION_TABLE, {
+    params: {
+      sysparm_query: `web_service_definition=${definitionId}`,
+      sysparm_fields: OPERATION_FIELDS,
+      sysparm_limit: OPERATION_PAGE_LIMIT,
+    },
+  })
+  return asArray(rec(response.data).result).map(rec)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Routing
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Where a resource lives, and — only when asked — whether that URL answers.
+ *
+ * `operation_uri` is computed by ServiceNow, not by us, so it is read back from
+ * the record rather than assembled from the arguments. The probe is opt-in
+ * because calling a user's resource runs the user's script, side effects and
+ * all; without it the verdict is honestly "unverified".
+ */
+async function routeReport(
+  client: AxiosInstance,
+  definition: Record<string, unknown>,
+  operation: Record<string, unknown>,
+  args: Record<string, unknown>,
+) {
+  const candidates = buildResourceUrlCandidates({
+    operationUri: str(operation.operation_uri),
+    baseUri: str(definition.base_uri),
+    namespace: str(definition.namespace),
+    serviceId: str(definition.service_id),
+    relativePath: str(operation.relative_path),
+  })
+  const url = candidates[0]
+  if (candidates.length === 0) {
+    return {
+      url,
+      candidate_urls: candidates,
+      routable: null,
+      verdict:
+        "the record was written but its URL is unknown — ServiceNow returned no operation_uri and the definition's base_uri/namespace/api_id were not available to reconstruct one. Read it back with action=get.",
+    }
+  }
+
+  if (!bool(args.verify_routing, false)) {
+    return {
+      url,
+      candidate_urls: candidates,
+      routable: null,
+      verdict:
+        "created/updated, routing unverified — pass verify_routing=true to probe it (that invokes the resource script for real), or call it yourself with snow_scripted_rest_api",
+    }
+  }
+
+  const method = str(operation.http_method) ?? "GET"
+  const probes: Array<{ url: string; status: number | null; attempt: number }> = []
+  // A freshly created route is not live immediately — scripted-exec pings up to
+  // five times at 1.5s before it trusts its own deployment. Every candidate is
+  // tried within each round, so a wrong first candidate costs one request rather
+  // than the whole retry budget.
+  for (const attempt of [1, 2, 3, 4, 5]) {
+    for (const candidate of candidates) {
+      const status = await probe(client, candidate, method)
+      probes.push({ url: candidate, status, attempt })
+      if (status !== null && status !== 404) {
+        return {
+          url: candidate,
+          candidate_urls: candidates,
+          routable: true,
+          probe_status: status,
+          verdict: `routable — ${method} ${candidate} answered HTTP ${status} on attempt ${attempt} (any status other than 404 means the route resolved; the status itself comes from your script or from ServiceNow's auth layer)`,
+        }
+      }
+    }
+    if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, 1500))
+  }
+
+  return {
+    url,
+    candidate_urls: candidates,
+    routable: false,
+    // The last round only, named for what it is: every round probes the same
+    // candidates, so repeating all of them is noise, but calling the tail
+    // "probes" would read as the whole record of what was tried.
+    probes_last_attempt: probes.slice(-candidates.length),
+    probes_total: probes.length,
+    verdict:
+      "created but not yet routable — every candidate URL returned 404 (or was unreachable) across five attempts at 1.5s. The route can still appear a little later, so re-check with action=verify; other explanations are an inactive resource or a script that answers 404 itself.",
+  }
+}
+
+async function probe(client: AxiosInstance, url: string, method: string) {
+  const response = await client
+    .request({ url, method })
+    .catch((error: unknown) => (statusOf(error) === undefined ? null : { status: statusOf(error) as number }))
+  return response ? response.status : null
+}
+
+/**
+ * URLs a resource may answer on, most authoritative first.
+ *
+ * Generalised from buildCandidateUrls() in shared/scripted-exec.ts, which needs
+ * the fallbacks because operation_uri is occasionally absent from the insert
+ * response and because base_uri/namespace are computed server-side.
+ */
+export function buildResourceUrlCandidates(input: {
+  operationUri?: string
+  baseUri?: string
+  namespace?: string
+  serviceId?: string
+  relativePath?: string
+}): string[] {
+  const path = input.relativePath ? normalisePath(input.relativePath).replace(/\/+$/, "") : ""
+  return [
+    input.operationUri,
+    input.baseUri ? input.baseUri.replace(/\/+$/, "") + path : undefined,
+    input.namespace && input.serviceId ? `/api/${input.namespace}/${input.serviceId}${path}` : undefined,
+    input.serviceId ? `/api/${input.serviceId}${path}` : undefined,
+  ]
+    .filter((candidate): candidate is string => typeof candidate === "string" && candidate.length > 0)
+    .map((candidate) => (candidate.startsWith("/") ? candidate : `/${candidate}`))
+    .filter((candidate, index, all) => all.indexOf(candidate) === index)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+async function resolveDefinition(client: AxiosInstance, args: Record<string, unknown>) {
+  const sysId = str(args.sys_id) ?? str(args.definition_sys_id)
+  if (sysId) {
+    const definition = await fetchDefinitionById(client, sysId)
+    if (!str(definition.sys_id)) throw new Error(`No sys_ws_definition found with sys_id ${sysId}`)
+    return definition
+  }
+
+  const name = str(args.name)
+  if (!name) throw new Error("sys_id or name is required to identify the Scripted REST API")
+
+  const response = await client.get(DEFINITION_TABLE, {
+    params: { sysparm_query: `name=${name}`, sysparm_fields: DEFINITION_FIELDS, sysparm_limit: 1 },
+  })
+  const definition = rec(asArray(rec(response.data).result)[0])
+  if (!str(definition.sys_id)) throw new Error(`No Scripted REST API named "${name}"`)
+  return definition
+}
+
+/**
+ * A 404 is an answer — "there is no such definition" — and the caller gets that
+ * verbatim. A 401, 403, 500 or timeout is not an answer, and swallowing one here
+ * would make resolveDefinition report "No sys_ws_definition found with sys_id X"
+ * for a record that exists, which sends an agent off to create a duplicate. So
+ * everything else propagates to execute, which knows what a 403 means.
+ */
+async function fetchDefinitionById(client: AxiosInstance, sysId: string | undefined) {
+  if (!sysId) return {}
+  const response = await client
+    .get(`${DEFINITION_TABLE}/${sysId}`, { params: { sysparm_fields: DEFINITION_FIELDS } })
+    .catch((error: unknown) => {
+      if (statusOf(error) === 404) return null
+      throw error
+    })
+  return rec(rec(response?.data).result)
+}
+
+const summariseDefinition = (definition: Record<string, unknown>) => ({
+  sys_id: str(definition.sys_id),
+  name: str(definition.name),
+  api_id: str(definition.service_id),
+  namespace: str(definition.namespace),
+  base_uri: str(definition.base_uri),
+  short_description: str(definition.short_description),
+  active: definition.active === "true" || definition.active === true,
+})
+
+const summariseOperation = (operation: Record<string, unknown>) => ({
+  sys_id: str(operation.sys_id),
+  name: str(operation.name),
+  http_method: str(operation.http_method),
+  relative_path: str(operation.relative_path),
+  operation_uri: str(operation.operation_uri),
+  active: operation.active === "true" || operation.active === true,
+  requires_authentication: operation.requires_authentication === "true" || operation.requires_authentication === true,
+  // Tri-state on purpose, unlike the two above: those are columns scripted-exec
+  // proves exist, this one is not, so `undefined` ("the instance did not return
+  // it") has to stay distinguishable from `false` ("the instance says it is off").
+  requires_acl_authorization: flag(operation.requires_acl_authorization),
+})
+
+/**
+ * Resource scripts run on ServiceNow's server-side engine, which is ES5 (Rhino).
+ * Reported, not enforced: the record saves either way, and mis-flagging a
+ * caller's valid script into a hard failure would be worse than a warning.
+ */
+const ES5_PATTERNS = [
+  { type: "const", regex: /\bconst\s+/g },
+  { type: "let", regex: /\blet\s+/g },
+  { type: "arrow_function", regex: /=>\s*[{(]/g },
+  { type: "template_literal", regex: /`[^`]*`/g },
+  { type: "class", regex: /\bclass\s+\w+/g },
+]
+
+function es5Warnings(script: string): string[] {
+  const violations = ES5_PATTERNS.flatMap((pattern) =>
+    Array.from(script.matchAll(pattern.regex), (match) => ({
+      type: pattern.type,
+      line: script.slice(0, match.index ?? 0).split("\n").length,
+    })),
+  )
+  if (violations.length === 0) return []
+  return [
+    `operation_script contains ES6+ syntax (${violations.map((violation) => `${violation.type} at line ${violation.line}`).join(", ")}). ServiceNow's server-side engine is ES5 — use var and function() instead. The record was saved as given.`,
+  ]
+}
+
+const normalisePath = (path: string | undefined) => {
+  if (!path || path === "/") return "/"
+  return path.startsWith("/") ? path : `/${path}`
+}
+
+const str = (value: unknown) => (typeof value === "string" && value.length > 0 ? value : undefined)
+const num = (value: unknown) => (typeof value === "number" ? value : undefined)
+// Agents routinely stringify booleans, so "true"/"false" are accepted alongside
+// the real thing — same reasoning as confirmationFlag() in update-set-guard.ts.
+const bool = (value: unknown, fallback: boolean) => {
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  return fallback
+}
+// Same coercion for a value read back off a record, except that "the field was
+// not in the response" stays undefined instead of becoming a claim about it.
+const flag = (value: unknown) => {
+  if (value === true || value === "true") return true
+  if (value === false || value === "false") return false
+  return undefined
+}
+const rec = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" ? (value as Record<string, unknown>) : {}
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : [])
+// Reference fields come back as { link, value } unless sysparm_fields flattened them.
+const refValue = (value: unknown) => str(value) ?? str(rec(value).value)
+const statusOf = (error: unknown) => {
+  const status = rec(rec(error).response).status
+  return typeof status === "number" ? status : undefined
+}
+const messageOf = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/meta/index.ts
@@ -71,7 +71,7 @@ export const tool_search_def: MCPToolDefinition = {
   name: "tool_search",
   description: `Search for available ServiceNow tools when you need specialized functionality.
 
-This tool searches through ALL 235+ available tools including:
+It searches every tool this server registered — several hundred of them — including:
 - Core operations (queries, CRUD, bulk operations)
 - Deployment (widgets, UI pages, script includes)
 - CMDB and asset management
@@ -419,8 +419,8 @@ export const tool_execute_def: MCPToolDefinition = {
   name: "tool_execute",
   description: `Execute any ServiceNow tool by name. Use this after tool_search to call the tools you found.
 
-This is the gateway to ALL 235+ ServiceNow tools. After searching with tool_search,
-use this tool to execute the found tools.
+This is the gateway to every ServiceNow tool this server registered. After searching
+with tool_search, use this tool to execute the found tools.
 
 Example:
 1. tool_search({query: "query incidents"})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/index.ts
@@ -21,6 +21,10 @@ export {
   toolDefinition as snow_discover_table_fields_def,
   execute as snow_discover_table_fields_exec,
 } from "./snow_discover_table_fields.js"
+export {
+  toolDefinition as snow_describe_field_def,
+  execute as snow_describe_field_exec,
+} from "./snow_describe_field.js"
 export { toolDefinition as snow_get_by_sysid_def, execute as snow_get_by_sysid_exec } from "./snow_get_by_sysid.js"
 export {
   toolDefinition as snow_search_artifacts_def,

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/snow_describe_field.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/snow_describe_field.ts
@@ -1,0 +1,544 @@
+/**
+ * snow_describe_field - describe one field, resolved through the class hierarchy
+ *
+ * A sys_dictionary row lives on the table that *declares* the column, so
+ * `name=incident^element=short_description` returns nothing: short_description
+ * is declared on task. snow_discover_table_fields and snow_table_schema_discovery
+ * both query sys_dictionary by table name alone, which is why they report an
+ * incident schema with no number, state, priority or assigned_to, and neither
+ * reads a choice list at all. This tool walks sys_db_object.super_class to the
+ * root class first, then applies the sys_dictionary_override rows found on that
+ * chain, then resolves the field's sys_choice list.
+ *
+ * Everything it returns comes from a Table API read of sys_db_object,
+ * sys_dictionary, sys_dictionary_override and sys_choice. Where a value is a
+ * computation rather than a column (the merged `effective` block, the selected
+ * choice set) the inputs are returned alongside it so the caller can check the
+ * work.
+ */
+
+import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient, type ExtendedAxiosInstance } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+/**
+ * Only a cycle guard, not a real ceiling. cmdb_ci_win_server -> cmdb_ci_server ->
+ * cmdb_ci_computer -> cmdb_ci_hardware -> cmdb_ci is already five levels, so the
+ * maxDepth = 3 used by snow_blast_radius_field_references drops exactly the
+ * fields defined on cmdb_ci itself.
+ */
+const MAX_CHAIN_DEPTH = 20
+
+/**
+ * Columns copied out of the sys_dictionary row. Absent columns are dropped
+ * rather than reported empty, so this list can stay generous without the
+ * output claiming a column exists on an instance where it does not.
+ *
+ * A field's hint and help text are not here because they are not on
+ * sys_dictionary at all — they live on sys_documentation, which is also where the
+ * per-table, per-language field label lives. `column_label` below is the base
+ * label and is not language-resolved, so it is not necessarily the label a user
+ * sees on a translated instance.
+ */
+const DICTIONARY_KEYS = [
+  "name",
+  "element",
+  "column_label",
+  "internal_type",
+  "reference",
+  "max_length",
+  "mandatory",
+  "read_only",
+  "active",
+  "display",
+  "default_value",
+  "choice",
+  "choice_table",
+  "choice_field",
+  "dependent",
+  "dependent_on_field",
+  "use_dependent_field",
+  "attributes",
+  "reference_qual",
+  "calculation",
+  "virtual",
+  "unique",
+  "comments",
+  "sys_scope",
+]
+
+const CHOICE_KEYS = ["value", "label", "sequence", "inactive", "language", "dependent_value", "hint", "sys_id"]
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_describe_field",
+  description: `Describe one field on one table, resolved through table inheritance. Walks sys_db_object.super_class to the root class, so fields declared on a parent are found (incident.short_description is declared on task, incident.state on task, cmdb_ci_win_server.name on cmdb_ci). Applies the sys_dictionary_override rows found anywhere on that chain, nearest table wins.
+
+Returns: the declaring table, the full parent-class chain, the effective column_label / internal_type / max_length / mandatory / read_only / default_value / reference target / reference qualifier / attributes after overrides, the raw dictionary row and the override rows it merged, and the field's sys_choice values.
+
+Choice handling: the nearest table on the chain that defines any sys_choice rows for the field supplies the list — a child's choices replace the parent's, they are not merged — and the count for every other table on the chain is reported too. Inactive choices are filtered out (opt in with include_inactive_choices), rows are matched on language, and each choice keeps its own dependent_value instead of being flattened. sys_dictionary.choice is returned as choice_mode with the instance's own label for it, so an empty choices array is distinguishable from a field that has no choice list.
+
+Use this instead of snow_discover_table_fields or snow_table_schema_discovery when you need one field's real definition: those two query sys_dictionary by table name only and therefore miss every inherited field.`,
+  // Metadata for tool discovery (not sent to LLM)
+  category: "core-operations",
+  subcategory: "discovery",
+  use_cases: ["schema", "field-definition", "choice-list", "discovery"],
+  complexity: "intermediate",
+  frequency: "high",
+
+  // Permission enforcement
+  // Classification: READ - reads sys_db_object, sys_dictionary, sys_dictionary_override, sys_choice
+  permission: "read",
+  allowedRoles: ["developer", "stakeholder", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      table: {
+        type: "string",
+        description: "Table the field is used on, e.g. 'incident'. The field may be declared on a parent table.",
+      },
+      field: {
+        type: "string",
+        description: "Column name (sys_dictionary element), e.g. 'state'. Not the column label.",
+      },
+      language: {
+        type: "string",
+        description: "Language code for choice labels. Choices with no language set are always included.",
+        default: "en",
+      },
+      include_inactive_choices: {
+        type: "boolean",
+        description: "Include sys_choice rows marked inactive (default: false)",
+        default: false,
+      },
+      max_choices: {
+        type: "number",
+        description: "Maximum sys_choice rows to read across the whole chain (default: 500)",
+        default: 500,
+        minimum: 1,
+        maximum: 5000,
+      },
+    },
+    required: ["table", "field"],
+  },
+}
+
+export async function execute(args: Record<string, any>, context: ServiceNowContext): Promise<ToolResult> {
+  // The sibling schema tools take `table_name`, and the blast-radius tools take
+  // `table_name`/`field_name`, so models reach for those names here too. Accept
+  // the synonyms rather than failing on one.
+  const table: string | undefined = args.table ?? args.table_name
+  const field: string | undefined = args.field ?? args.field_name ?? args.element
+  const language: string = args.language ?? "en"
+  const includeInactive: boolean = args.include_inactive_choices ?? false
+  const maxChoices: number = args.max_choices ?? 500
+
+  if (!table || !field) return createErrorResult("table and field are required")
+
+  try {
+    const client = await getAuthenticatedClient(context)
+
+    const walk = await resolveTableChain(client, table)
+    if (walk.chain.length === 0) {
+      return createErrorResult(`Table not found in sys_db_object: ${table}`, { table, field })
+    }
+
+    const names = walk.chain.map((entry) => entry.name)
+    const scope = `nameIN${names.join(",")}^element=${field}`
+
+    // sys_dictionary_override and sys_choice are allowed to fail independently:
+    // a locked-down instance can refuse them while the dictionary read succeeds,
+    // and a partial answer with a note beats no answer at all.
+    const [dictionaryResult, overrideResult, choiceResult] = await Promise.allSettled([
+      client.get("/api/now/table/sys_dictionary", {
+        params: { sysparm_query: scope, sysparm_display_value: "all", sysparm_limit: names.length },
+      }),
+      client.get("/api/now/table/sys_dictionary_override", {
+        params: { sysparm_query: scope, sysparm_display_value: "all", sysparm_limit: names.length },
+      }),
+      client.get("/api/now/table/sys_choice", {
+        params: { sysparm_query: scope, sysparm_limit: maxChoices },
+      }),
+    ])
+
+    if (dictionaryResult.status === "rejected") {
+      return createErrorResult(reasonOf(dictionaryResult.reason), { table, field, table_chain: names })
+    }
+
+    const dictionaryRows: Record<string, unknown>[] = dictionaryResult.value.data.result ?? []
+    // Chain order is most-derived first, so the first hit is the nearest declaration.
+    // `element` is re-checked client-side because ServiceNow drops query conditions it
+    // considers invalid instead of erroring: a degraded query returns every field's
+    // rows, and merging those into `effective` would be a confident wrong answer
+    // rather than a visible failure.
+    const definitions = names.flatMap((name) =>
+      dictionaryRows.filter((row) => cell(row.name) === name && cell(row.element) === field),
+    )
+    const dictionary = definitions[0]
+
+    if (!dictionary) {
+      const suggestions = await client
+        .get("/api/now/table/sys_dictionary", {
+          params: {
+            sysparm_query: `nameIN${names.join(",")}^elementLIKE${field}`,
+            sysparm_fields: "name,element,column_label",
+            sysparm_limit: 10,
+          },
+        })
+        .then((response) => response.data.result ?? [])
+        .catch(() => [])
+      return createErrorResult(
+        `Field '${field}' is not defined on ${table} or any of its parent classes (${names.join(" -> ")}). ` +
+          `Note that a field defined only on a child table is not visible from ${table}.`,
+        { table, field, table_chain: names, similar_fields: suggestions },
+      )
+    }
+
+    const overrideRows: Record<string, unknown>[] =
+      overrideResult.status === "fulfilled" ? (overrideResult.value.data.result ?? []) : []
+    const overrides = names.flatMap((name) =>
+      overrideRows
+        .filter((row) => cell(row.name) === name && cell(row.element) === field)
+        .map((row) => readOverride(name, row)),
+    )
+
+    const attributes = project(dictionary, DICTIONARY_KEYS)
+    const merged = applyOverrides(attributes, overrides)
+
+    const choiceRows: Record<string, unknown>[] =
+      choiceResult.status === "fulfilled" ? (choiceResult.value.data.result ?? []) : []
+    const choices = selectChoiceSet(
+      names,
+      choiceRows.filter((row) => cell(row.element) === field),
+      { language, includeInactive },
+    )
+
+    const declaredOn = cell(dictionary.name)
+    // Both columns are references that store a *name*, not a sys_id — a real row has
+    // <internal_type display_value="Reference">reference</internal_type> and
+    // <reference display_value="" name="sys_user">sys_user</reference>, against a
+    // genuine sys_id reference like <sys_scope display_value="NeedIt">6ead...</sys_scope>
+    // in the same row. So `value` is already what the caller needs, and display_value
+    // is only a label — empty on `reference`, which is what makes a `value || display`
+    // read of that column fall through to the raw cell object.
+    const internalType = cell(dictionary.internal_type)
+    const referenceTable = cell(dictionary.reference)
+
+    const effective = compact({
+      column_label: merged.column_label,
+      internal_type: internalType,
+      internal_type_label: label(dictionary.internal_type),
+      reference_table: referenceTable,
+      reference_label: label(dictionary.reference),
+      max_length: merged.max_length,
+      mandatory: merged.mandatory === "true",
+      read_only: merged.read_only === "true",
+      active: merged.active === "true",
+      display: merged.display === "true",
+      default_value: merged.default_value,
+      reference_qual: merged.reference_qual,
+      calculation: merged.calculation,
+      attributes: merged.attributes,
+      dependent: merged.dependent,
+    })
+
+    const notes = [
+      overrideResult.status === "rejected"
+        ? `sys_dictionary_override could not be read (${reasonOf(overrideResult.reason)}); the effective values are the base dictionary row only.`
+        : undefined,
+      choiceResult.status === "rejected"
+        ? `sys_choice could not be read (${reasonOf(choiceResult.reason)}); no choice list is reported for this field.`
+        : undefined,
+      choiceRows.length >= maxChoices
+        ? `sys_choice returned the full ${maxChoices}-row limit, so the list may be cut off. Raise max_choices.`
+        : undefined,
+      choices.counts_by_table.length > 1
+        ? `${choices.source_table} defines its own choices for this field; the other tables on the chain (${choices.counts_by_table
+            .slice(1)
+            .map((entry) => `${entry.table}: ${entry.count}`)
+            .join(
+              ", ",
+            )}) are reported for reference only. This tool treats the nearest table's choice list as replacing its parents' rather than merging them.`
+        : undefined,
+      overrides.some((entry) => entry.sets && entry.table !== table)
+        ? `Dictionary overrides declared on ancestor tables (${overrides
+            .filter((entry) => entry.sets && entry.table !== table)
+            .map((entry) => entry.table)
+            .join(
+              ", ",
+            )}) were merged into the effective values, nearest table last. Every entry in 'overrides' names the table it came from, so an override you consider irrelevant to ${table} can be discounted.`
+        : undefined,
+      overrides.some((entry) => entry.unpaired)
+        ? `An override row flags ${overrides.flatMap((entry) => entry.unpaired ?? []).join(", ")} as overridden but carries no column holding the new value, so those attributes are reported unchanged from the base dictionary row. display is normally one of these: sys_dictionary_override has display_override without a 'display' column beside it.`
+        : undefined,
+      merged.choice_table || merged.choice_field
+        ? `The dictionary row points the choice list elsewhere (choice_table='${merged.choice_table ?? ""}', choice_field='${merged.choice_field ?? ""}'). The choices below were read from the class hierarchy of ${table} and may not be the list this field renders.`
+        : undefined,
+      choices.skipped_for_language.length > 0
+        ? `${choices.skipped_for_language.join(", ")} define sys_choice rows for this field but none in language '${language}' and none with no language set, so they were skipped — and each of them sits nearer ${table} than ${choices.source_table ?? "any table that did match"}. Re-run with the instance's own language before trusting the list below.`
+        : undefined,
+      walk.chain.length >= MAX_CHAIN_DEPTH
+        ? `Parent-class walk stopped at ${MAX_CHAIN_DEPTH} tables; the chain may continue past ${names[names.length - 1]}.`
+        : undefined,
+    ].filter((note): note is string => typeof note === "string")
+
+    const data = {
+      table,
+      field,
+      declared_on: declaredOn,
+      inherited: declaredOn !== table,
+      table_chain: walk.chain,
+      dictionary_sys_id: cell(dictionary.sys_id),
+      effective,
+      choice_mode:
+        dictionary.choice === undefined
+          ? undefined
+          : { value: cell(dictionary.choice), label: label(dictionary.choice) },
+      choices: choices.choices,
+      choices_source_table: choices.source_table,
+      choice_counts_by_table: choices.counts_by_table,
+      choices_language: language,
+      choices_skipped_for_language: choices.skipped_for_language,
+      // Counted across every table on the chain, not just the one that supplied the
+      // returned list — the name says so because the number is otherwise read as
+      // "this many choices were dropped from `choices`".
+      inactive_choices_excluded_on_chain: choices.inactive_excluded,
+      overrides,
+      dictionary: attributes,
+      other_definitions: definitions.slice(1).map((row) => cell(row.name)),
+      notes,
+    }
+
+    const summary = [
+      `${table}.${field} — ${internalType || "unknown type"}` +
+        (merged.max_length ? `(${merged.max_length})` : "") +
+        (referenceTable ? ` -> ${referenceTable}` : ""),
+      `  declared on ${declaredOn}${declaredOn === table ? "" : ` (inherited by ${table} via ${names.join(" -> ")})`}`,
+      `  label: ${merged.column_label ?? "(none)"} | mandatory: ${effective.mandatory} | read only: ${effective.read_only}`,
+      // Counted on `sets`, not on row count: most override rows carry all eight flags
+      // and set none of them, and "3 overrides applied" for three inert rows is a
+      // claim about work that did not happen.
+      overrides.length > 0
+        ? `  ${overrides.filter((entry) => entry.sets).length} of ${overrides.length} dictionary override row(s) changed a value (rows on ${overrides.map((entry) => entry.table).join(", ")})`
+        : undefined,
+      choices.choices.length > 0
+        ? `  ${choices.choices.length} choice(s) from ${choices.source_table}: ${choices.choices
+            .slice(0, 8)
+            .map((choice) => `${choice.value}=${choice.label}`)
+            .join(", ")}${choices.choices.length > 8 ? ", ..." : ""}`
+        : `  no sys_choice rows on the chain (sys_dictionary.choice = ${cell(dictionary.choice) || "unset"})`,
+      ...notes.map((note) => `  note: ${note}`),
+    ]
+      .filter((line): line is string => typeof line === "string")
+      .join("\n")
+
+    return createSuccessResult(data, { table, field, apiCalls: walk.calls + 3 }, summary)
+  } catch (error: any) {
+    return createErrorResult(error.message)
+  }
+}
+
+/**
+ * Walk sys_db_object.super_class from `table` up to the root class.
+ * Returns [table, parent, grandparent, ...]; empty if `table` has no
+ * sys_db_object row at all, plus the number of GETs it took.
+ *
+ * Dot-walking inside sysparm_fields is undocumented — the Table API reference
+ * says only that invalid fields are ignored — so `super_class.name` can in
+ * principle come back absent rather than empty. That failure is silent and
+ * expensive: the chain would stop at one table and the tool would answer
+ * `inherited: false` for incident.short_description, the exact wrong answer it
+ * exists to prevent. Plain `super_class` is requested alongside it as the
+ * ground truth (it is a real sys_id reference), and the parent is resolved by
+ * sys_id whenever the dotted column did not arrive.
+ */
+async function resolveTableChain(
+  client: ExtendedAxiosInstance,
+  table: string,
+  chain: { name: string; label: string }[] = [],
+  calls = 0,
+): Promise<{ chain: { name: string; label: string }[]; calls: number }> {
+  // A super_class cycle is corrupt data, not a hierarchy — stop rather than loop.
+  if (chain.length >= MAX_CHAIN_DEPTH || chain.some((entry) => entry.name === table)) return { chain, calls }
+
+  const response = await client.get("/api/now/table/sys_db_object", {
+    params: {
+      sysparm_query: `name=${table}`,
+      sysparm_fields: "name,label,super_class,super_class.name",
+      sysparm_limit: 1,
+    },
+  })
+  const row = response.data.result?.[0]
+  if (!row) return { chain, calls: calls + 1 }
+
+  const next = [...chain, { name: table, label: cell(row.label) }]
+  const dotted = cell(row["super_class.name"])
+  const parentId = dotted ? "" : cell(row.super_class)
+  const parent = dotted || (await resolveParentName(client, parentId))
+  const spent = calls + (parentId ? 2 : 1)
+  return parent ? resolveTableChain(client, parent, next, spent) : { chain: next, calls: spent }
+}
+
+/** Name of the sys_db_object row with this sys_id, or "" — never throws. */
+async function resolveParentName(client: ExtendedAxiosInstance, sysId: string): Promise<string> {
+  if (!sysId) return ""
+  return client
+    .get("/api/now/table/sys_db_object", {
+      params: { sysparm_query: `sys_id=${sysId}`, sysparm_fields: "name", sysparm_limit: 1 },
+    })
+    .then((response) => cell(response.data.result?.[0]?.name))
+    .catch(() => "")
+}
+
+/**
+ * Read one sys_dictionary_override row into the set of attributes it actually
+ * changes. Derived from the row's own `<attribute>_override` flags rather than a
+ * hardcoded list, so an instance whose override columns differ from the ones
+ * this file expects still produces a correct answer instead of a confident wrong
+ * one. A flag set true with no matching column is reported in `unpaired` rather
+ * than dropped silently.
+ *
+ * The flag columns are suffixed, not prefixed: a real row carries
+ * mandatory_override, read_only_override, default_value_override,
+ * reference_qual_override, attributes_override, calculation_override,
+ * dependent_override and display_override. Every one of those pairs with a
+ * same-named sys_dictionary_override column except display_override, which has no
+ * `display` column beside it — so `unpaired: ["display"]` is expected output on a
+ * row that sets it, not a sign of bad data.
+ *
+ * Exported for the test beside this file — the merge rule is the thing worth
+ * pinning, and it cannot be exercised through `execute` without an instance.
+ */
+export function readOverride(table: string, row: Record<string, unknown>) {
+  const flagged = Object.keys(row)
+    .filter((key) => key.endsWith("_override") && cell(row[key]) === "true")
+    .map((key) => key.slice(0, -"_override".length))
+
+  return compact({
+    table,
+    base_table: cell(row.base_table),
+    sys_id: cell(row.sys_id),
+    sets: Object.fromEntries(
+      flagged.filter((attribute) => row[attribute] !== undefined).map((attribute) => [attribute, cell(row[attribute])]),
+    ) as Record<string, string>,
+    unpaired: flagged.filter((attribute) => row[attribute] === undefined),
+  })
+}
+
+/**
+ * Merge dictionary overrides onto the base dictionary attributes. `overrides` is
+ * in chain order (nearest table first), so it is applied in reverse: the
+ * override closest to the queried table is the one that survives.
+ *
+ * Exported for the test beside this file.
+ */
+export function applyOverrides(
+  attributes: Record<string, string>,
+  overrides: { table?: string; sets?: Record<string, string> }[],
+) {
+  return [...overrides]
+    .reverse()
+    .reduce<
+      Record<string, string>
+    >((accumulator, override) => ({ ...accumulator, ...(override.sets ?? {}) }), attributes)
+}
+
+/**
+ * Pick the choice list that actually applies to the queried table.
+ *
+ * A child table's sys_choice rows replace its parent's for that element, they do
+ * not add to them — so the first table on the chain with any rows wins outright
+ * and the rest are reported as counts only. Rows are filtered by language (rows
+ * with no language set always count, since that is how choices created through
+ * the API arrive) and by `inactive`, and each row keeps its own dependent_value
+ * rather than being flattened into one list.
+ *
+ * The language filter can hand the win to the wrong table: on a non-English
+ * instance a child whose rows exist only in `nl` drops out and the parent's list
+ * is returned as if the child defined none. Those tables come back in
+ * `skipped_for_language` so the caller sees it happened instead of trusting a
+ * list the field cannot actually hold.
+ *
+ * Exported for the test beside this file.
+ */
+export function selectChoiceSet(
+  chain: string[],
+  rows: Record<string, unknown>[],
+  options: { language: string; includeInactive: boolean },
+) {
+  const inLanguage = rows.filter((row) => {
+    const value = cell(row.language)
+    return value === "" || value === options.language
+  })
+  const active = options.includeInactive ? inLanguage : inLanguage.filter((row) => cell(row.inactive) !== "true")
+
+  const grouped = chain
+    .map((table) => ({ table, rows: active.filter((row) => cell(row.name) === table) }))
+    .filter((group) => group.rows.length > 0)
+
+  const winner = grouped[0]
+  const choices = (winner?.rows ?? [])
+    .slice()
+    .sort((left, right) => sequenceOf(left) - sequenceOf(right))
+    .map((row) => project(row, CHOICE_KEYS))
+
+  return {
+    source_table: winner?.table,
+    choices,
+    counts_by_table: grouped.map((group) => ({ table: group.table, count: group.rows.length })),
+    inactive_excluded: inLanguage.length - active.length,
+    // Only the tables nearer than the winner matter: those are the ones whose list
+    // would have been returned had the language matched.
+    skipped_for_language: chain
+      .slice(0, winner ? chain.indexOf(winner.table) : chain.length)
+      .filter((table) => rows.some((row) => cell(row.name) === table))
+      .filter((table) => !inLanguage.some((row) => cell(row.name) === table)),
+  }
+}
+
+function sequenceOf(row: Record<string, unknown>): number {
+  const parsed = Number(cell(row.sequence))
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * Read a Table API cell. With sysparm_display_value=all every column arrives as
+ * `{ display_value, value }`; without it, as a plain string.
+ */
+function cell(raw: unknown): string {
+  if (raw === null || raw === undefined) return ""
+  if (typeof raw === "object") {
+    const value = (raw as Record<string, unknown>).value
+    return typeof value === "string" ? value : ""
+  }
+  return String(raw)
+}
+
+/** The instance's own display value for a cell, or "" when it did not send one. */
+function label(raw: unknown): string {
+  if (!raw || typeof raw !== "object") return ""
+  const display = (raw as Record<string, unknown>).display_value
+  return typeof display === "string" ? display : ""
+}
+
+/** Copy the requested columns that the row actually has. Absent stays absent. */
+function project(row: Record<string, unknown>, keys: string[]): Record<string, string> {
+  return Object.fromEntries(keys.filter((key) => row[key] !== undefined).map((key) => [key, cell(row[key])]))
+}
+
+function compact<T extends Record<string, unknown>>(object: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => {
+      if (value === undefined || value === "") return false
+      if (Array.isArray(value)) return value.length > 0
+      if (value && typeof value === "object") return Object.keys(value).length > 0
+      return true
+    }),
+  ) as Partial<T>
+}
+
+function reasonOf(reason: any): string {
+  return reason?.message ?? String(reason)
+}
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/validators/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/validators/index.ts
@@ -7,6 +7,10 @@ export {
   execute as snow_validate_field_exec,
 } from "./snow_validate_field.js"
 export {
+  toolDefinition as snow_validate_query_def,
+  execute as snow_validate_query_exec,
+} from "./snow_validate_query.js"
+export {
   toolDefinition as snow_validate_sysid_def,
   execute as snow_validate_sysid_exec,
 } from "./snow_validate_sysid.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/validators/snow_validate_query.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/validators/snow_validate_query.ts
@@ -1,0 +1,559 @@
+/**
+ * snow_validate_query - check an encoded query against the table's real schema
+ *
+ * ServiceNow does not reject a query that names a field the table does not
+ * have. From the Table API reference for sysparm_query: "By default, if part of
+ * a query is invalid, such as an invalid field name, the instance ignores the
+ * invalid part."
+ * https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html
+ *
+ * So `active=true^assigment_group=abc` does not fail — it silently becomes
+ * `active=true` and selects every active record. A caller that hands that query
+ * to snow_bulk_update or snow_data_export then acts on a record set far wider
+ * than the one it described. (The `glide.invalid_query.returns_no_rows`
+ * property flips the behaviour to "return nothing" instead; this tool reports
+ * which of the two the instance actually did rather than assuming either.)
+ *
+ * Everything here is read-only: sys_db_object, sys_dictionary, and — only when
+ * count_matches is on — the caller's own query with sysparm_limit=1.
+ */
+
+import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient, type ExtendedAxiosInstance } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_validate_query",
+  description:
+    "Check every field named in an encoded query against the table's sys_dictionary, walking the sys_db_object.super_class chain so inherited fields (incident.priority lives on task) resolve. ServiceNow does not error on a misspelled field in sysparm_query — by default it drops that condition and returns a WIDER result set — so run this before snow_bulk_update, snow_record_manage or snow_data_export act on the matched records. Returns one entry per clause marked known / unknown / unchecked (dot-walks, ^JOIN and RLQUERY blocks, ORDERBY, full-text search and task variables are reported as unchecked, never as errors), spelling suggestions for unknown fields, and how many records the query really matches.",
+  // Metadata for tool discovery (not sent to LLM)
+  category: "development",
+  subcategory: "validation",
+  use_cases: ["query-validation", "encoded-query", "bulk-update-safety", "schema"],
+  complexity: "intermediate",
+  frequency: "medium",
+
+  // Permission enforcement
+  // Classification: READ - reads sys_db_object / sys_dictionary and optionally
+  // runs the caller's own query with sysparm_limit=1. Changes nothing.
+  permission: "read",
+  allowedRoles: ["developer", "stakeholder", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      table: {
+        type: "string",
+        description: "Table the query will run against (e.g. incident, cmdb_ci_server)",
+      },
+      query: {
+        type: "string",
+        description:
+          "Encoded query to check, e.g. active=true^priority=1. An empty string is accepted and reported as 'matches every record'.",
+      },
+      count_matches: {
+        type: "boolean",
+        description:
+          "Also run the query read-only (sysparm_limit=1) and report how many records it matches, taken from the X-Total-Count response header. Default true.",
+        default: true,
+      },
+    },
+    required: ["table", "query"],
+  },
+}
+
+export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  return validateQuery(args, context).catch((error: any) => createErrorResult(error?.message ?? String(error)))
+}
+
+async function validateQuery(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  const table = String(args.table ?? "").trim()
+  if (!table) return createErrorResult("table is required")
+  const query = String(args.query ?? "").trim()
+  const countMatches = (args.count_matches ?? args.countMatches ?? true) !== false
+
+  const client = await getAuthenticatedClient(context)
+  const walk = await tableChain(client, table)
+  const parsed = parseQuery(query)
+
+  // Only the fields this tool claims to check: plain columns, plus the first
+  // segment of every dot-walk so the reader learns whether the entry point
+  // itself is real.
+  const candidates = [
+    ...new Set(parsed.flatMap((clause) => [clause.root, clause.unchecked ? undefined : clause.field]).filter(isName)),
+  ]
+  const dictionary =
+    candidates.length > 0 && walk.chain.length > 0 ? await readDictionary(client, walk.chain, candidates) : []
+  const defined = new Map(
+    candidates.flatMap((field) => {
+      // A field redefined on a child table wins over the parent's row, so take
+      // the match nearest the queried table.
+      const row = dictionary
+        .filter((entry: any) => entry.element === field)
+        .sort((a: any, b: any) => walk.chain.indexOf(a.name) - walk.chain.indexOf(b.name))[0]
+      return row ? [[field, row] as const] : []
+    }),
+  )
+
+  const missing = parsed.filter((clause) => !clause.unchecked && clause.field && !defined.has(clause.field))
+  // Fetched for the spelling suggestions, but it doubles as the honesty guard
+  // below: a table with no readable dictionary rows at all cannot be the basis
+  // for calling anything unknown.
+  const columns = missing.length > 0 && walk.chain.length > 0 ? await readColumns(client, walk.chain) : []
+  const unavailable =
+    walk.chain.length === 0
+      ? `${table} has no sys_db_object record, so no schema could be loaded — check the table name`
+      : !walk.complete
+        ? `the super_class chain above ${walk.chain[walk.chain.length - 1]} could not be resolved, so a field inherited from higher up cannot be told apart from a typo`
+        : // A truncated read is the one remaining way to produce a false
+          // "unknown": the row that would have resolved the field exists and was
+          // simply not returned.
+          dictionary.length >= DICTIONARY_LIMIT
+          ? `the sys_dictionary read for ${walk.chain.join(" → ")} came back at its ${DICTIONARY_LIMIT}-row limit, so a field that does exist may not be among the rows this tool saw`
+          : missing.length > 0 && columns.length === 0
+            ? `no sys_dictionary rows are readable for ${walk.chain.join(" → ")} — a database view, or this account cannot read the dictionary`
+            : undefined
+
+  const clauses: {
+    prefix: string
+    clause: string
+    field?: string
+    operator?: string
+    status: "known" | "unknown" | "unchecked"
+    reason?: string
+    defined_on?: string
+    type?: string
+    references?: string
+    dictionary_active?: boolean
+    did_you_mean?: string[]
+  }[] = parsed.map((clause) => {
+    const base = { prefix: clause.prefix, clause: clause.clause, field: clause.field, operator: clause.operator }
+    if (clause.unchecked) return { ...base, status: "unchecked" as const, reason: reasonFor(clause, defined) }
+    const row = defined.get(clause.field!)
+    if (row)
+      return {
+        ...base,
+        status: "known" as const,
+        defined_on: row.name,
+        type: typeOf(row),
+        references: referenceOf(row),
+        ...(row.active === "false" ? { dictionary_active: false } : {}),
+      }
+    if (unavailable) return { ...base, status: "unchecked" as const, reason: unavailable }
+    const closest = suggest(clause.field!, columns)
+    return { ...base, status: "unknown" as const, ...(closest.length > 0 ? { did_you_mean: closest } : {}) }
+  })
+
+  const unknown = clauses.filter((clause) => clause.status === "unknown")
+  const matches = countMatches ? await countRecords(client, table, query) : null
+  // Rebuilding the query without the unresolved clauses is what the instance is
+  // documented to do by itself. Running both tells us which behaviour this
+  // instance is configured for instead of assuming the default.
+  const withoutUnknown =
+    unknown.length === 0
+      ? undefined
+      : clauses
+          .filter((clause) => clause.status !== "unknown")
+          .map((clause) => clause.prefix + clause.clause)
+          .join("")
+          .replace(/^\^(OR|NQ)?/, "")
+  const matchesWithoutUnknown =
+    countMatches && withoutUnknown !== undefined ? await countRecords(client, table, withoutUnknown) : null
+
+  const contradicted = countsContradictUnknown(matches, matchesWithoutUnknown)
+  // Both of the sentences below describe a count, not a setting. Equal counts
+  // are also what a real clause that excludes nothing produces, and a zero is
+  // also what a real clause nothing matches produces, so neither may be stated
+  // as a fact about how the instance is configured.
+  const observed =
+    matches === null || matchesWithoutUnknown === null
+      ? null
+      : contradicted
+        ? `The unresolved clause(s) ${matches < matchesWithoutUnknown ? `narrowed the result set by ${matchesWithoutUnknown - matches}` : `widened the result set by ${matches - matchesWithoutUnknown}`} record(s): ${matches} as written, ${matchesWithoutUnknown} without them. An invalid clause cannot do that — ignored it leaves both counts equal, and under glide.invalid_query.returns_no_rows the query as written matches none — so at least one of the fields this tool could not resolve is real and it did not see it. Check whether this account can read every sys_dictionary row for ${walk.chain.join(" → ")}. (Records written to ${table} between the two counts would look the same way.)`
+        : matches === matchesWithoutUnknown && matches > 1
+          ? `With and without the unresolved clause(s) the query matches the same ${matches} records — consistent with the instance ignoring them, if they are indeed invalid, and equally with their being real clauses that exclude nothing.`
+          : matches === 0 && matchesWithoutUnknown > 0
+            ? `The query as written returned no rows; without the unresolved clause(s) it matches ${matchesWithoutUnknown} records. That is consistent with glide.invalid_query.returns_no_rows being switched on — or with one of the unresolved clauses being a real field that nothing on this table matches.`
+            : null
+
+  const counts = {
+    known: clauses.filter((clause) => clause.status === "known").length,
+    unknown: unknown.length,
+    unchecked: clauses.filter((clause) => clause.status === "unchecked").length,
+  }
+  // Five outcomes, not two. "Nothing was checked" is its own answer: a ✓ on a
+  // query where no field could be resolved is the lie this tool exists to stop,
+  // and so is a ✓ on one where four of five clauses were skipped.
+  const verdict = contradicted
+    ? "unresolved-fields-contradicted"
+    : counts.unknown > 0
+      ? "unresolved-fields"
+      : counts.known === 0
+        ? "nothing-was-checked"
+        : counts.unchecked > 0
+          ? "some-clauses-unchecked"
+          : "all-fields-resolved"
+  const warnings = [
+    query === "" ? `The query is empty, which selects every record in ${table}.` : undefined,
+    // Worth saying when it cost the reader an answer — either nothing could be
+    // loaded at all, or a clause landed in "unchecked" because of it.
+    unavailable && (walk.chain.length === 0 || missing.length > 0) ? `${unavailable}.` : undefined,
+    // Withheld once the counts show these clauses moving the result set: they
+    // are being applied, whatever this tool made of the field names.
+    unknown.length > 0 && !contradicted
+      ? "ServiceNow does not raise an error for these clauses. Its Table API reference states that by default the instance ignores the invalid part of a query, so they do not narrow the result set — they widen it."
+      : undefined,
+    contradicted
+      ? "Do not treat the unresolved field(s) as typos on this evidence: removing them changed how many records match, which is what a clause the instance is applying does."
+      : undefined,
+    query.includes("javascript:")
+      ? "One or more values are javascript: expressions. This tool checks field names only, it does not evaluate them — and a ^ inside such a value would split the clause list wrongly."
+      : undefined,
+  ].filter(isName)
+
+  return createSuccessResult(
+    {
+      table,
+      hierarchy: walk.chain,
+      query,
+      verdict,
+      counts,
+      clauses,
+      unknown_fields: unknown.map((clause) => clause.field),
+      matches,
+      matches_without_unresolved_clauses: matchesWithoutUnknown,
+      query_without_unresolved_clauses: withoutUnknown,
+      observed_behaviour: observed,
+      warnings,
+    },
+    {
+      table,
+      hierarchy_depth: walk.chain.length,
+      count_source: !countMatches
+        ? "not requested"
+        : matches === null
+          ? "unavailable — the count query returned no X-Total-Count header"
+          : "X-Total-Count header",
+    },
+    [
+      `${
+        {
+          "unresolved-fields-contradicted": "!",
+          "unresolved-fields": "✗",
+          "some-clauses-unchecked": "~",
+          "all-fields-resolved": "✓",
+          "nothing-was-checked": "?",
+        }[verdict]
+      } ${table}: ${counts.known} field(s) resolved, ${counts.unknown} unresolved, ${counts.unchecked} not checked`,
+      walk.chain.length > 1 ? `  hierarchy: ${walk.chain.join(" → ")}` : undefined,
+      // The suggestions are held back once the counts contradict the verdict —
+      // offering a spelling for a field that just filtered records is the
+      // wrong-way-round advice this tool must not give.
+      ...unknown.map(
+        (clause) =>
+          `  unresolved: ${clause.field}${!contradicted && clause.did_you_mean?.length ? ` — did you mean ${clause.did_you_mean.join(", ")}?` : ""}`,
+      ),
+      matches === null ? undefined : `  matches ${matches} record(s) as written`,
+      observed ?? undefined,
+      ...warnings.map((warning) => `  ! ${warning}`),
+    ]
+      .filter(isName)
+      .join("\n"),
+  )
+}
+
+/**
+ * Whether the two counts rule out this tool's own "unknown" verdict. Neither
+ * documented behaviour for an invalid clause can move the count: ignored, both
+ * queries return the same rows; under glide.invalid_query.returns_no_rows the
+ * query as written returns none. So a non-zero count that differs from the count
+ * without those clauses means at least one of them really filters, and the tool
+ * simply could not see the field. That evidence outranks the field lookup —
+ * calling a valid clause invalid is the one failure worse than not checking.
+ *
+ * Exported for the tests: it is a pure function of two numbers, and getting it
+ * wrong is invisible from the tool's output shape.
+ */
+export function countsContradictUnknown(matches: number | null, matchesWithoutUnknown: number | null) {
+  return matches !== null && matchesWithoutUnknown !== null && matches > 0 && matches !== matchesWithoutUnknown
+}
+
+/**
+ * Segments that are not field conditions. Longest first where one is a prefix
+ * of another (ORDERBYDESC before ORDERBY), and all uppercase — dictionary
+ * column names are lower case, so none of these can shadow a real field.
+ */
+const STRUCTURAL: ReadonlyArray<readonly [string, string]> = [
+  ["ORDERBYDESC", "sort directive, not a filter condition"],
+  ["ORDERBY", "sort directive, not a filter condition"],
+  ["GROUPBY", "grouping directive, not a filter condition"],
+  ["GOTO", "list 'go to' directive"],
+  ["ENDJOIN", "end of a ^JOIN block"],
+  ["JOIN", "^JOIN block — the conditions inside it apply to the joined table"],
+  ["ENDRLQUERY", "end of a related-list query"],
+  ["RLQUERY", "related-list query — the conditions inside it apply to the related table"],
+  ["123TEXTQUERY321", "full-text search, not a field condition"],
+  ["EQ", "clause terminator"],
+  ["NQ", "new-query separator"],
+]
+
+/**
+ * Encoded-query operators, as ServiceNow's "Available operators for filters and
+ * queries" reference lists them.
+ * https://www.servicenow.com/docs/bundle/zurich-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+ */
+const OPERATORS = [
+  "IN_HIERARCHY_DYNAMIC",
+  "GT_OR_EQUALS_FIELD",
+  "LT_OR_EQUALS_FIELD",
+  "IN_HIERARCHY",
+  "DOESNOTHAVE",
+  "EMPTYSTRING",
+  "INSTANCEOF",
+  "ISNOTEMPTY",
+  "CHANGESFROM",
+  "VALCHANGES",
+  "CHANGESTO",
+  "STARTSWITH",
+  "RELATIVEGT",
+  "RELATIVELT",
+  "RELATIVEGE",
+  "RELATIVELE",
+  "EXCLUDING",
+  "GT_FIELD",
+  "LT_FIELD",
+  "MORETHAN",
+  "LESSTHAN",
+  "DATEPART",
+  "ANYTHING",
+  "ENDSWITH",
+  "ISEMPTY",
+  "BETWEEN",
+  "NOT LIKE",
+  "NSAMEAS",
+  "DYNAMIC",
+  "SAMEAS",
+  "NOT IN",
+  "NOTON",
+  "LIKE",
+  "ON",
+  "IN",
+  "!=",
+  "<=",
+  ">=",
+  "=",
+  "<",
+  ">",
+]
+
+/**
+ * Split an encoded query into clauses and say, for each, whether its field can
+ * be looked up at all. Exported for the tests: every rule below is a pure
+ * function of the string, and both of the parsing bugs it exists to avoid are
+ * invisible from the tool's output shape.
+ */
+export function parseQuery(query: string) {
+  // `^OR` must not eat `^ORDERBY`. Splitting on a bare /\^OR/ leaves the clause
+  // "DERBYnumber", which then reads as a misspelled field — a false positive,
+  // which is the one failure this tool cannot afford.
+  const parts = query.replace(/\^EQ$/, "").split(/(\^OR(?!DERBY)|\^NQ|\^)/)
+  const segments = parts.flatMap((part, i) =>
+    i % 2 === 1 || part.length === 0 ? [] : [{ prefix: i === 0 ? "" : parts[i - 1], clause: part }],
+  )
+  // A ^JOIN or RLQUERY block re-points everything inside it at another table.
+  // An unterminated block suspends checking to the end of the query on purpose:
+  // over-reporting "unchecked" is safe, calling a valid clause invalid is not.
+  const inBlock = segments.reduce<boolean[]>(
+    (acc, segment) => [
+      ...acc,
+      /^(ENDJOIN|ENDRLQUERY)/.test(segment.clause)
+        ? false
+        : /^(JOIN|RLQUERY)/.test(segment.clause)
+          ? true
+          : (acc[acc.length - 1] ?? false),
+    ],
+    [],
+  )
+  return segments.map((segment, i) => ({ ...segment, ...describe(segment.clause, inBlock[i]) }))
+}
+
+// The shape is spelled out because every branch below returns a different
+// subset of it, and the caller reads `root` and `field` across all of them.
+function describe(
+  clause: string,
+  inBlock: boolean,
+): { field?: string; operator?: string; value?: string; root?: string; unchecked?: string } {
+  // Structural first, so the segment that opens a block is named as the opener
+  // rather than as something inside it.
+  const structural = STRUCTURAL.find(([keyword]) => clause.startsWith(keyword))
+  if (structural) return { unchecked: structural[1] }
+  if (inBlock) return { unchecked: "inside a ^JOIN / RLQUERY block — the condition applies to another table" }
+
+  // Take the operator that starts earliest, and the longest one at that
+  // position. Taking the first hit from a longest-first list instead reads
+  // "short_description=IN PROGRESS" as field "short_description=" operator "IN".
+  const hit = OPERATORS.flatMap((op) => {
+    const at = clause.indexOf(op)
+    return at > 0 ? [{ op, at }] : []
+  }).sort((a, b) => a.at - b.at || b.op.length - a.op.length)[0]
+  if (!hit) return { unchecked: "no encoded-query operator found in this clause" }
+
+  const field = clause.slice(0, hit.at)
+  const rest = { field, operator: hit.op, value: clause.slice(hit.at + hit.op.length) }
+  if (field === "sys_tags")
+    return { ...rest, unchecked: "tag filter — this tool does not resolve sys_tags, so the clause is left unchecked" }
+  if (field === "variables" || field.startsWith("variables."))
+    return { ...rest, unchecked: "task variable — held in the variable tables, not in this table's dictionary" }
+  if (field.includes("."))
+    return {
+      ...rest,
+      root: field.split(".")[0],
+      unchecked: "dot-walk — only the first segment is looked up, the fields beyond it live on other tables",
+    }
+  return rest
+}
+
+function reasonFor(clause: ReturnType<typeof parseQuery>[number], defined: Map<string, any>) {
+  if (!clause.root) return clause.unchecked
+  const row = defined.get(clause.root)
+  if (row)
+    return `${clause.unchecked}. First segment "${clause.root}" is a ${typeOf(row) ?? "field"} on ${row.name}${referenceOf(row) ? ` referencing ${referenceOf(row)}` : ""}.`
+  // Deliberately not called a typo: variable prefixes and related-list syntax
+  // are legitimate here and are not dictionary columns either.
+  return `${clause.unchecked}. First segment "${clause.root}" is not a field on this table or its ancestors — worth re-reading, though some prefixes are legitimately not dictionary columns.`
+}
+
+/**
+ * table → super_class → … to the root. Nothing is capped at three levels:
+ * cmdb_ci_win_server → cmdb_ci_server → cmdb_ci_computer → cmdb_ci_hardware →
+ * cmdb_ci is five, and stopping early reports every field on the root class as
+ * unknown. `complete` is false when the walk stopped somewhere other than a
+ * table with no parent, and the caller then declines to call anything unknown.
+ */
+async function tableChain(
+  client: ExtendedAxiosInstance,
+  table: string,
+  seen: string[] = [],
+): Promise<{ chain: string[]; complete: boolean }> {
+  if (!table || seen.includes(table) || seen.length >= 20) return { chain: seen, complete: !table }
+  const response = await client.get("/api/now/table/sys_db_object", {
+    params: {
+      sysparm_query: `name=${table}`,
+      sysparm_fields: "name,super_class,super_class.name",
+      sysparm_limit: 1,
+    },
+  })
+  const row = response.data.result?.[0]
+  if (!row) return { chain: seen, complete: false }
+  const walked = row["super_class.name"]
+  const parent = typeof walked === "string" && walked ? walked : await parentName(client, row.super_class)
+  if (!parent && referenceValue(row.super_class)) return { chain: [...seen, table], complete: false }
+  return tableChain(client, parent, [...seen, table])
+}
+
+// sysparm_fields normally returns the dot-walked super_class.name directly. If
+// an instance answers with only the reference cell, resolve it by sys_id rather
+// than truncating the chain.
+async function parentName(client: ExtendedAxiosInstance, superClass: any) {
+  const sysId = referenceValue(superClass)
+  if (!sysId) return ""
+  const response = await client
+    .get(`/api/now/table/sys_db_object/${encodeURIComponent(sysId)}`, { params: { sysparm_fields: "name" } })
+    .catch(() => undefined)
+  const name = response?.data?.result?.name
+  return typeof name === "string" ? name : ""
+}
+
+// One row per (table in the chain × field named in the query), so reaching the
+// limit takes a query naming ~100 distinct fields against a five-deep chain. The
+// caller checks for it anyway because a silently short read is the only path
+// left to a field being called unknown when it is not.
+const DICTIONARY_LIMIT = 500
+
+async function readDictionary(client: ExtendedAxiosInstance, chain: string[], elements: string[]) {
+  const response = await client.get("/api/now/table/sys_dictionary", {
+    params: {
+      sysparm_query: `nameIN${chain.join(",")}^elementIN${elements.join(",")}`,
+      sysparm_fields: "name,element,internal_type,internal_type.name,reference,reference.name,active",
+      sysparm_limit: DICTIONARY_LIMIT,
+    },
+  })
+  return (response.data.result ?? []) as any[]
+}
+
+async function readColumns(client: ExtendedAxiosInstance, chain: string[]) {
+  const response = await client.get("/api/now/table/sys_dictionary", {
+    params: {
+      sysparm_query: `nameIN${chain.join(",")}^elementISNOTEMPTY`,
+      sysparm_fields: "element",
+      sysparm_limit: 5000,
+    },
+  })
+  const elements = ((response.data.result ?? []) as any[]).map((row) => String(row.element ?? "")).filter(isName)
+  return [...new Set(elements)]
+}
+
+/**
+ * How many records the query really matches. Null rather than 0 when the count
+ * is unavailable — a query that could not be counted and a query that matches
+ * nothing are opposite answers for a caller deciding whether to run an update.
+ */
+async function countRecords(client: ExtendedAxiosInstance, table: string, query: string) {
+  const response = await client
+    .get(`/api/now/table/${encodeURIComponent(table)}`, {
+      params: { sysparm_query: query, sysparm_limit: 1, sysparm_fields: "sys_id" },
+    })
+    .catch(() => undefined)
+  const total = response?.headers?.["x-total-count"]
+  return typeof total === "string" && /^\d+$/.test(total) ? Number(total) : null
+}
+
+/**
+ * Trigram overlap, used only to offer a spelling suggestion beside an unknown
+ * field. It never decides a status.
+ */
+function suggest(field: string, columns: string[]) {
+  return columns
+    .map((column) => ({ column, score: overlap(field, column) }))
+    .filter((scored) => scored.score >= 0.5)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((scored) => scored.column)
+}
+
+function overlap(a: string, b: string) {
+  const left = trigrams(a)
+  const right = trigrams(b)
+  const shared = [...left].filter((gram) => right.has(gram)).length
+  return shared / (left.size + right.size - shared)
+}
+
+function trigrams(value: string) {
+  const padded = `  ${value} `
+  return new Set(Array.from({ length: padded.length - 2 }, (_, i) => padded.slice(i, i + 3)))
+}
+
+function typeOf(row: any) {
+  const walked = row["internal_type.name"]
+  if (typeof walked === "string" && walked) return walked
+  return typeof row.internal_type === "string" && row.internal_type ? row.internal_type : undefined
+}
+
+function referenceOf(row: any) {
+  const walked = row["reference.name"]
+  if (typeof walked === "string" && walked) return walked
+  return typeof row.reference === "string" && row.reference ? row.reference : undefined
+}
+
+// Reference cells come back as { link, value } unless the instance flattens
+// them to the sys_id string.
+function referenceValue(cell: any) {
+  const value = typeof cell === "string" ? cell : cell?.value
+  return typeof value === "string" && value ? value : ""
+}
+
+function isName(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/tools.json
+++ b/packages/servicenow-mcp/tools.json
@@ -1,11 +1,66 @@
 {
-  "generatedAt": "2026-08-16T21:13:18.874Z",
-  "count": 438,
+  "generatedAt": "2026-08-17T23:43:09.683Z",
+  "count": 444,
   "groups": [
     {
       "name": "access-control",
       "displayName": "Access Control",
       "tools": [
+        {
+          "name": "snow_acl_explain",
+          "description": "Explain which ACLs apply to a table (optionally one field) for one operation, and what a named user is missing. Walks sys_db_object.super_class so parent-table rules are included, covers the wildcard names (*, *.field, table.*, *.*), resolves each rule's required roles through the sys_security_acl_role m2m, and reports which of those roles the user actually holds (sys_user_has_role, inherited roles included). Returns the applicable rules plus the role gap — NOT an access decision: ACL conditions and advanced scripts are reported and counted but never evaluated.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "acl",
+            "security",
+            "roles",
+            "permissions",
+            "debugging"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table the record lives on, e.g. 'incident'"
+              },
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "read",
+                  "write",
+                  "create",
+                  "delete"
+                ],
+                "description": "The operation being denied: read, write, create or delete"
+              },
+              "field": {
+                "type": "string",
+                "description": "Optional field name, e.g. 'priority' or 'incident.priority'. Adds the six field-level ACL names to the report; without it only the record-level names are checked."
+              },
+              "user": {
+                "type": "string",
+                "description": "Optional sys_id or user_name of the user to diff against. Without it the report lists the rules and their roles but nothing about who holds what."
+              },
+              "include_inactive": {
+                "type": "boolean",
+                "description": "Include ACLs with active=false. Default: false.",
+                "default": false
+              }
+            },
+            "required": [
+              "table",
+              "operation"
+            ]
+          }
+        },
         {
           "name": "snow_create_access_control",
           "description": "Create an Access Control List (ACL) entry on a table: grants a role permission to perform an operation (read/write/create/delete) on records, optionally gated by a condition or advanced script. Writes to sys_security_acl.",
@@ -1251,7 +1306,7 @@
       "tools": [
         {
           "name": "snow_aggregate_metrics",
-          "description": "Aggregate over a table via the /api/now/stats endpoint: COUNT, SUM, AVG, MIN, or MAX on a field, optionally grouped by another field. Returns the rolled-up result without fetching individual rows.",
+          "description": "Count, average, sum, min or max over a table, grouped by a field and filtered by an encoded query. Uses the Aggregate API (/api/now/stats), so it returns the rolled-up numbers per group, never the records themselves.",
           "permission": "read",
           "allowedRoles": [
             "developer",
@@ -1260,6 +1315,8 @@
           ],
           "useCases": [
             "aggregation",
+            "count",
+            "group by",
             "metrics",
             "reporting"
           ],
@@ -1270,11 +1327,7 @@
             "properties": {
               "table": {
                 "type": "string",
-                "description": "Table name"
-              },
-              "field": {
-                "type": "string",
-                "description": "Field to aggregate"
+                "description": "Table to aggregate over (e.g. incident)"
               },
               "aggregation": {
                 "type": "string",
@@ -1285,11 +1338,43 @@
                   "MIN",
                   "MAX"
                 ],
-                "default": "COUNT"
+                "default": "COUNT",
+                "description": "Which aggregate to compute. Everything except COUNT needs `field`."
+              },
+              "field": {
+                "type": "string",
+                "description": "Field to aggregate, required for SUM/AVG/MIN/MAX and ignored for COUNT. Must hold a number (e.g. reassignment_count); for elapsed time use the numeric seconds fields such as business_stc rather than the duration fields. Comma-separate to aggregate several fields at once."
+              },
+              "query": {
+                "type": "string",
+                "description": "Encoded query filtering which records are aggregated (e.g. active=true^priority=1). Omit to cover the whole table."
               },
               "group_by": {
                 "type": "string",
-                "description": "Field to group by"
+                "description": "Field to group by, comma-separated for several (e.g. assignment_group). One result row per distinct combination."
+              },
+              "having": {
+                "type": "string",
+                "description": "Filter on the aggregate itself, syntax aggregate^field^operator^value (e.g. count^priority^>^3). Only meaningful together with group_by."
+              },
+              "order_by": {
+                "type": "string",
+                "description": "Order the rows by a field or by an aggregate. The documented forms are a field (state), an aggregate over a field (AVG^state) and COUNT; append ^DESC for descending (state^DESC). Only upper-case aggregate names are documented."
+              },
+              "display_value": {
+                "type": "string",
+                "enum": [
+                  "true",
+                  "false",
+                  "all"
+                ],
+                "default": "false",
+                "description": "Return display values. Set true when grouping by a reference or choice field, otherwise the groups come back as sys_ids and numeric choice values. `all` asks the API for both values and is passed through, but the row labels only change if the instance sends a display value alongside the raw one."
+              },
+              "max_groups": {
+                "type": "number",
+                "default": 100,
+                "description": "Cap on rows returned. Rows past it are dropped and the result says how many; the instance's own ordering decides which survive, so pair this with order_by. Must be a row count — anything else falls back to 100."
               }
             },
             "required": [
@@ -1562,6 +1647,79 @@
       "displayName": "Applications",
       "tools": [
         {
+          "name": "snow_app_repo_manage",
+          "description": "Publish a scoped application to the Application Repository and install a published version, via ServiceNow's CI/CD API (/api/sn_cicd/app_repo). Requires the sn_cicd.sys_ci_automation or admin role.\n\nActions:\n- publish — POST /api/sn_cicd/app_repo/publish. Stores the application and its artifacts in the Application Repository under a version. Identify the app by scope or app_sys_id. Without an explicit version the publish uses the app's current local version and fails if that version is already in the repository.\n- install — POST /api/sn_cicd/app_repo/install. Installs a repository version onto the instance this call is authenticated to.\n- progress — GET /api/sn_cicd/progress/{progress_id}. Reports the real state of a job started earlier.\n\nThis API has no pipeline and no target-instance parameter: both endpoints act on the instance you are connected to. To move an app from dev to test you publish while connected to dev, then install while connected to test.\n\nPublish and install are asynchronous — they return a queued progress record, not a finished deployment. By default this tool polls that record until it is final and reports what it says: Successful returns success; Failed or Canceled returns an error with ServiceNow's own message; a job still running when timeout_ms elapses returns an error saying the outcome is unknown, with the progress_id. Pass wait=false to get the progress_id back immediately and poll it yourself with action=progress. Returns progress_id, state, status_label, percent_complete and ServiceNow's status/error text.\n\nExamples:\n- { action: \"publish\", scope: \"x_acme_myapp\", version: \"1.2.0\", dev_notes: \"sprint 14\" }\n- { action: \"install\", scope: \"x_acme_myapp\", version: \"1.2.0\", timeout_ms: 600000 }\n- { action: \"install\", app_sys_id: \"b7e...\", version: \"1.2.0\", wait: false }\n- { action: \"progress\", progress_id: \"d174f8e11bd800103d374087bc4bcbd9\" }",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "app-repo",
+            "deployment",
+            "cicd",
+            "devops",
+            "scoped-apps"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Operation to perform",
+                "enum": [
+                  "publish",
+                  "install",
+                  "progress"
+                ]
+              },
+              "scope": {
+                "type": "string",
+                "description": "[publish/install] Application scope, e.g. \"x_acme_myapp\". Found in the scope field of Custom Application [sys_app]; for install it may also come from Store Application [sys_store_app]. Pass this or app_sys_id."
+              },
+              "app_sys_id": {
+                "type": "string",
+                "description": "[publish/install] sys_id of the application, from Custom Application [sys_app] (install also accepts a Store Application [sys_store_app] sys_id). Sent as the API's sys_id parameter. Takes precedence over scope — the API wants one identifier, not both."
+              },
+              "version": {
+                "type": "string",
+                "description": "[publish] Version to store the application under, e.g. \"1.2.0\"; the local application version is updated to match. Omit and the publish uses the app's current version, failing if that version is already in the repository. [install] Version to install; omitting it lets ServiceNow pick per its auto_upgrade_base_app / base_app_version rules."
+              },
+              "dev_notes": {
+                "type": "string",
+                "description": "[publish] Developer notes stored with the published version."
+              },
+              "auto_upgrade_base_app": {
+                "type": "boolean",
+                "description": "[install] Only relevant when installing customizations of a base application: whether the associated base application may be upgraded to a later version. Left to ServiceNow's default (false) when omitted."
+              },
+              "base_app_version": {
+                "type": "string",
+                "description": "[install] Version of the base application (a third-party Store application) to install. When set, only the base application is installed."
+              },
+              "progress_id": {
+                "type": "string",
+                "description": "[progress] Progress record id returned by an earlier publish or install."
+              },
+              "wait": {
+                "type": "boolean",
+                "description": "[publish/install] Poll the progress record until it is final (default true). false returns the progress_id straight away, before the job has done anything — the app is not published or installed at that point.",
+                "default": true
+              },
+              "timeout_ms": {
+                "type": "number",
+                "description": "[publish/install when wait=true] How long to keep polling, in milliseconds. Default 120000 (2 min); installs of large applications routinely need more. Running out returns an error with the progress_id, not a success — recover with action=progress on that id. Do not re-issue the publish/install with a larger timeout_ms: the first job is still running and a second one would be a duplicate.",
+                "default": 120000
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        },
+        {
           "name": "snow_create_application",
           "description": "Create a scoped application (sys_app), optionally bootstrapping an Update Set and switching the OAuth service account into the new scope so subsequent artifacts are tracked there.\n\nUse when: building a complete feature set (HR Portal, Customer Onboarding), bundling functionality for single-unit deployment, building external integrations, or developing for multiple instances. Prefer global scope for small fixes, shared utilities, quick POCs, or cross-application work.\n\nDefaults:\n- auto_create_update_set=true — creates a fresh Update Set in the new app scope\n- auto_switch_scope=true — switches the OAuth service account to the new scope so subsequent artifacts track there\n\nSet either to false for manual control.",
           "permission": "write",
@@ -1677,16 +1835,14 @@
         },
         {
           "name": "snow_install_application",
-          "description": "Install application from store",
-          "permission": "write",
+          "description": "[DEPRECATED - use snow_app_repo_manage] Performs no operation and returns an error. It used to insert a row into sys_store_app and report that as an install; a row insert installs nothing. Install through the documented CI/CD Application Repository API instead: snow_app_repo_manage({ action: \"install\", scope: \"x_acme_myapp\", version: \"1.2.0\" }).",
+          "permission": "read",
           "allowedRoles": [
             "developer",
             "admin"
           ],
           "useCases": [
-            "app-install",
-            "store",
-            "deployment"
+            "deprecated"
           ],
           "complexity": "beginner",
           "frequency": "low",
@@ -1695,17 +1851,16 @@
             "properties": {
               "app_id": {
                 "type": "string",
-                "description": "Application ID from store"
+                "description": "Ignored. Pass it as app_sys_id to snow_app_repo_manage instead."
               },
               "version": {
                 "type": "string",
-                "description": "Version to install"
+                "description": "Ignored. Pass it as version to snow_app_repo_manage instead."
               }
             },
-            "required": [
-              "app_id"
-            ]
-          }
+            "required": []
+          },
+          "deprecated": true
         },
         {
           "name": "snow_list_applications",
@@ -8369,6 +8524,58 @@
             },
             "required": [
               "query"
+            ]
+          }
+        },
+        {
+          "name": "snow_describe_field",
+          "description": "Describe one field on one table, resolved through table inheritance. Walks sys_db_object.super_class to the root class, so fields declared on a parent are found (incident.short_description is declared on task, incident.state on task, cmdb_ci_win_server.name on cmdb_ci). Applies the sys_dictionary_override rows found anywhere on that chain, nearest table wins.\n\nReturns: the declaring table, the full parent-class chain, the effective column_label / internal_type / max_length / mandatory / read_only / default_value / reference target / reference qualifier / attributes after overrides, the raw dictionary row and the override rows it merged, and the field's sys_choice values.\n\nChoice handling: the nearest table on the chain that defines any sys_choice rows for the field supplies the list — a child's choices replace the parent's, they are not merged — and the count for every other table on the chain is reported too. Inactive choices are filtered out (opt in with include_inactive_choices), rows are matched on language, and each choice keeps its own dependent_value instead of being flattened. sys_dictionary.choice is returned as choice_mode with the instance's own label for it, so an empty choices array is distinguishable from a field that has no choice list.\n\nUse this instead of snow_discover_table_fields or snow_table_schema_discovery when you need one field's real definition: those two query sys_dictionary by table name only and therefore miss every inherited field.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "schema",
+            "field-definition",
+            "choice-list",
+            "discovery"
+          ],
+          "complexity": "intermediate",
+          "frequency": "high",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table the field is used on, e.g. 'incident'. The field may be declared on a parent table."
+              },
+              "field": {
+                "type": "string",
+                "description": "Column name (sys_dictionary element), e.g. 'state'. Not the column label."
+              },
+              "language": {
+                "type": "string",
+                "description": "Language code for choice labels. Choices with no language set are always included.",
+                "default": "en"
+              },
+              "include_inactive_choices": {
+                "type": "boolean",
+                "description": "Include sys_choice rows marked inactive (default: false)",
+                "default": false
+              },
+              "max_choices": {
+                "type": "number",
+                "description": "Maximum sys_choice rows to read across the whole chain (default: 500)",
+                "default": 500,
+                "minimum": 1,
+                "maximum": 5000
+              }
+            },
+            "required": [
+              "table",
+              "field"
             ]
           }
         },
@@ -18221,8 +18428,104 @@
       "displayName": "Reconciliation",
       "tools": [
         {
+          "name": "snow_cmdb_identify_reconcile",
+          "description": "Insert or update CIs through the CMDB Identification and Reconciliation Engine: POST /api/now/identifyreconcile. IRE runs each class's identifier rules against the payload, so a CI that already exists is matched and updated instead of duplicated, reconciliation rules decide whether this data source may overwrite each attribute, and the source is recorded in Source [sys_object_source].\n\nReturns the engine's verdict per payload item: operation (INSERT, UPDATE, NO_CHANGE, UPDATE_WITH_UPGRADE, UPDATE_WITH_DOWNGRADE, UPDATE_WITH_SWITCH, DELETE), sysId, identifierEntrySysId, each identification attempt with its attemptResult (MATCHED, MULTI_MATCH, NO_MATCH, SKIPPED) and the identifier rule it used, plus per-item errors and warnings. IRE answers HTTP 200 even when individual items fail identification, so this tool reports success only when no returned item, relation or additionally committed item carries an error or a non-zero errorCount.\n\ndry_run: true posts the same payload to /api/now/identifyreconcile/query instead, which returns the same insert/update decision without committing anything. Run that first before pushing a large payload — it is the only way to see what IRE would do without doing it.\n\ndata_source is required and must be an existing choice on cmdb_ci.discovery_source; this tool checks it against sys_choice before posting. Without sysparm_data_source the documented behaviour is to store the payload in the incomplete-payloads table rather than commit it, which looks like success and changes nothing.\n\nUse this instead of snow_create_ci and snow_update_ci, which write to a class table and never run identification. Do not reach for snow_reconcile_ci: despite the name it does not reconcile — it PUTs the caller's object onto base cmdb_ci and echoes its reconciliation_rule argument back untouched.\n\nThe ServiceNow account needs the itil or asset role.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "cmdb",
+            "identification",
+            "reconciliation",
+            "deduplication",
+            "discovery-integration"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "description": "CIs to identify and then insert or update. At least one entry.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "className": {
+                      "type": "string",
+                      "description": "Required. CMDB class/table of the CI, e.g. cmdb_ci_linux_server or cmdb_ci_win_server. Camel-cased key, snake_case table name."
+                    },
+                    "values": {
+                      "type": "object",
+                      "description": "Field name/value pairs to create or update on the CI. Reference fields take the referenced sys_id. The reference marks only className required, so this may be omitted when the CI is identified through lookup or sys_object_source_info instead — but an item with neither carries nothing for IRE to identify or write."
+                    },
+                    "internal_id": {
+                      "type": "string",
+                      "description": "Identifier for this item within this payload only. Any value, unique in the payload. Referenced by relations.parent_id/child_id and referenceItems."
+                    },
+                    "lookup": {
+                      "type": "array",
+                      "description": "Lookup-based identification records (e.g. cmdb_serial_number rows) used to identify the CI. Each entry takes className, values, and optionally internal_id and sys_object_source_info.",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "related": {
+                      "type": "array",
+                      "description": "Records on a table that references this CI, created or updated alongside it. Not used for identification; allowed types come from the Related Entry [cmdb_related_entry] table.",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "Per-item update restrictions: updateWithoutUpgrade, updateWithoutDowngrade, updateWithoutSwitch, skipReclassificationRestrictionRules. All booleans, all default false."
+                    },
+                    "sys_object_source_info": {
+                      "type": "object",
+                      "description": "Unique CI identifier for this data source: source_name (a cmdb_ci.discovery_source choice), source_native_key, optional source_feed, optional source_recency_timestamp as 'YYYY-MM-DD hh:mm:ss' UTC. Lets IRE match on the Source [sys_object_source] table instead of running identifier rules."
+                    }
+                  },
+                  "required": [
+                    "className"
+                  ]
+                }
+              },
+              "relations": {
+                "type": "array",
+                "description": "Relationships between payload items. Each entry needs type (a name from CI Relationship Type [cmdb_rel_type], e.g. 'Runs on::Runs') plus either parent/child as integer indexes into items, or parent_id/child_id as internal_id values (the only form that can point at a related or lookup item). Optional sys_rel_source_info { source_name, source_feed }.",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "referenceItems": {
+                "type": "array",
+                "description": "References between two payload items, resolved before identification: { referenced, referencedBy, referenceField } where referenced/referencedBy are internal_id values and referenceField is the reference column on the referencedBy class.",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "data_source": {
+                "type": "string",
+                "description": "Required. Sent as sysparm_data_source. Must be a choice value of cmdb_ci.discovery_source on this instance, e.g. 'ServiceNow'. Checked against sys_choice before the payload is posted."
+              },
+              "dry_run": {
+                "type": "boolean",
+                "description": "Post to /api/now/identifyreconcile/query instead: same identification, same per-item verdict, nothing committed.",
+                "default": false
+              }
+            },
+            "required": [
+              "items",
+              "data_source"
+            ]
+          }
+        },
+        {
           "name": "snow_reconcile_ci",
-          "description": "Reconcile CI data from multiple sources",
+          "description": "[DEPRECATED - use snow_cmdb_identify_reconcile] Does not reconcile. PUTs the given fields onto base cmdb_ci for one sys_id and echoes reconciliation_rule back untouched — no identifier or reconciliation rule runs, no Source [sys_object_source] row is written, and class-specific fields are dropped. Use snow_cmdb_identify_reconcile instead, which posts the payload to the Identification and Reconciliation Engine. Kept only for callers that already depend on this plain cmdb_ci update.",
           "permission": "write",
           "allowedRoles": [
             "developer",
@@ -18256,7 +18559,8 @@
               "ci_sys_id",
               "source_data"
             ]
-          }
+          },
+          "deprecated": true
         }
       ]
     },
@@ -18896,7 +19200,7 @@
       "tools": [
         {
           "name": "snow_scripted_rest_api",
-          "description": "Invoke a Scripted REST API resource at /api/<namespace>/<path> with chosen method (GET/POST/PUT/PATCH/DELETE) and optional JSON body. Use for instance-defined REST endpoints; for stock table API use snow_custom_api.",
+          "description": "Invoke an EXISTING Scripted REST API resource at /api/<namespace>/<path> with chosen method (GET/POST/PUT/PATCH/DELETE) and optional JSON body. This is a client: it calls endpoints, it does not create them — to author a Scripted REST API (sys_ws_definition + sys_ws_operation) use snow_scripted_rest_api_manage. For the stock table API use snow_custom_api.",
           "permission": "read",
           "allowedRoles": [
             "developer",
@@ -20155,6 +20459,121 @@
                 "default": false
               }
             }
+          }
+        }
+      ]
+    },
+    {
+      "name": "scripted-rest-api",
+      "displayName": "Scripted Rest Api",
+      "tools": [
+        {
+          "name": "snow_scripted_rest_api_manage",
+          "description": "Build and maintain inbound Scripted REST APIs on the instance: the sys_ws_definition record (list/get/create/update/delete) and its sys_ws_operation resources (add_operation/update_operation/delete_operation). Returns the operation_uri ServiceNow assigned to each resource, and — with verify_routing=true, or action=verify afterwards — whether that URL actually answers yet; a freshly created resource is routable only after a short delay, so it reports 'created but not yet routable' rather than claiming success it did not observe. Probing calls the resource for real, which runs whatever its script does. This tool AUTHORS endpoints. To CALL an endpoint that already exists, use snow_scripted_rest_api instead.",
+          "permission": "write",
+          "allowedRoles": [
+            "developer",
+            "admin"
+          ],
+          "useCases": [
+            "scripted-rest-api",
+            "inbound-api",
+            "custom-endpoint",
+            "web-service"
+          ],
+          "complexity": "advanced",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "get",
+                  "create",
+                  "update",
+                  "delete",
+                  "add_operation",
+                  "update_operation",
+                  "delete_operation",
+                  "verify"
+                ],
+                "description": "Action to perform. list/get/create/update/delete act on the API definition (sys_ws_definition); add_operation/update_operation/delete_operation act on its resources (sys_ws_operation); verify probes an existing resource's URL, which calls the resource."
+              },
+              "sys_id": {
+                "type": "string",
+                "description": "sys_id of the Scripted REST API definition (get/update/delete/add_operation). Alias: definition_sys_id. update_operation/delete_operation/verify also accept it when operation_sys_id is missing, but those actions need the RESOURCE's sys_id — passing the definition's there just 404s."
+              },
+              "name": {
+                "type": "string",
+                "description": "[create/update] Name of the API. ServiceNow derives the API ID from it when api_id is omitted. Also usable instead of sys_id to look a definition up."
+              },
+              "api_id": {
+                "type": "string",
+                "description": "[create] Explicit API ID (service_id column), the segment that appears in the URL. Leave empty to let ServiceNow derive it from the name."
+              },
+              "short_description": {
+                "type": "string",
+                "description": "[create/update] Short description of the API"
+              },
+              "active": {
+                "type": "boolean",
+                "description": "Whether the record is active. Applies to the definition on create/update, and to the resource on add_operation/update_operation. Defaults to true when creating; on the update actions it is left alone unless passed."
+              },
+              "filter": {
+                "type": "string",
+                "description": "[list] Encoded query against sys_ws_definition (e.g. \"nameLIKEorder\" or \"active=true\")"
+              },
+              "limit": {
+                "type": "number",
+                "description": "[list] Maximum definitions to return",
+                "default": 50
+              },
+              "operation_sys_id": {
+                "type": "string",
+                "description": "sys_id of the resource record (update_operation/delete_operation/verify)"
+              },
+              "operation_name": {
+                "type": "string",
+                "description": "[create/add_operation/update_operation] Name of the resource"
+              },
+              "http_method": {
+                "type": "string",
+                "enum": [
+                  "GET",
+                  "POST",
+                  "PUT",
+                  "PATCH",
+                  "DELETE"
+                ],
+                "description": "[create/add_operation/update_operation] HTTP method the resource implements. Creating without it gets GET. On update_operation, pass it only to change the method — it moves the endpoint."
+              },
+              "relative_path": {
+                "type": "string",
+                "description": "[create/add_operation/update_operation] Path relative to the API base, e.g. \"/orders\" or \"/orders/{id}\". Creating without it gets \"/\". On update_operation, pass it only to move the resource — every caller of the old path breaks."
+              },
+              "operation_script": {
+                "type": "string",
+                "description": "[create/add_operation/update_operation] The resource script, shaped as (function process(request, response) { ... })(request, response). Runs server-side on Rhino, so ES5 only — ES6+ syntax is reported back as a warning."
+              },
+              "requires_authentication": {
+                "type": "boolean",
+                "description": "[create/add_operation/update_operation] Require an authenticated caller. Creating without it requires authentication."
+              },
+              "requires_acl_authorization": {
+                "type": "boolean",
+                "description": "[create/add_operation/update_operation] Enforce rest_endpoint ACLs on the resource. Creating without it leaves the column unset — see the tool's response notes for why. Authentication alone authorises EVERY authenticated user, so put a gs.hasRole() check in the script if you leave this off. Passing false on update_operation actively turns enforcement off; the response always reports the value the instance stored, not the one you sent."
+              },
+              "verify_routing": {
+                "type": "boolean",
+                "description": "[create/add_operation/update_operation/verify] After writing, call the resource URL to see whether it routes yet. WARNING: this invokes your resource script for real, with whatever side effects it has.",
+                "default": false
+              }
+            },
+            "required": [
+              "action"
+            ]
           }
         }
       ]
@@ -24747,6 +25166,46 @@
               "table",
               "field",
               "value"
+            ]
+          }
+        },
+        {
+          "name": "snow_validate_query",
+          "description": "Check every field named in an encoded query against the table's sys_dictionary, walking the sys_db_object.super_class chain so inherited fields (incident.priority lives on task) resolve. ServiceNow does not error on a misspelled field in sysparm_query — by default it drops that condition and returns a WIDER result set — so run this before snow_bulk_update, snow_record_manage or snow_data_export act on the matched records. Returns one entry per clause marked known / unknown / unchecked (dot-walks, ^JOIN and RLQUERY blocks, ORDERBY, full-text search and task variables are reported as unchecked, never as errors), spelling suggestions for unknown fields, and how many records the query really matches.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "query-validation",
+            "encoded-query",
+            "bulk-update-safety",
+            "schema"
+          ],
+          "complexity": "intermediate",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "table": {
+                "type": "string",
+                "description": "Table the query will run against (e.g. incident, cmdb_ci_server)"
+              },
+              "query": {
+                "type": "string",
+                "description": "Encoded query to check, e.g. active=true^priority=1. An empty string is accepted and reported as 'matches every record'."
+              },
+              "count_matches": {
+                "type": "boolean",
+                "description": "Also run the query read-only (sysparm_limit=1) and report how many records it matches, taken from the X-Total-Count response header. Default true.",
+                "default": true
+              }
+            },
+            "required": [
+              "table",
+              "query"
             ]
           }
         },


### PR DESCRIPTION
Fixes #318

Six new tools. Three answer questions that previously had wrong answers — `snow_describe_field` (walks `super_class`, applies dictionary overrides, returns the real choice list), `snow_acl_explain`, `snow_validate_query`. Three cover documented APIs nothing here touched — `snow_scripted_rest_api_manage`, `snow_cmdb_identify_reconcile`, `snow_app_repo_manage`.

`snow_aggregate_metrics` is fixed. `snow_install_application` and `snow_reconcile_ci` are retired in place with a signpost rather than deleted, so existing callers get a redirect instead of an unknown-tool error, and their `sn-roles.manifest.json` entries stay valid.

Two things beyond the issue, both small and both about the same problem:

- The server sends no `instructions` on initialize. A model meeting a two-tool server has nothing telling it the catalog is deferred. It does now.
- `tool_search` changes what `tools/list` returns and never said so. `notifications/tools/list_changed` is now sent on the stdio path.

**Not verified against a live instance.** No PDI was available. Every table, column and REST path is sourced from ServiceNow documentation and cited in the file; the three write tools (`snow_scripted_rest_api_manage`, `snow_cmdb_identify_reconcile`, `snow_app_repo_manage`) are the ones worth a smoke test before anyone leans on them. `snow_scripted_rest_api_manage` mirrors `shared/scripted-exec.ts`, which does work.

New tool names are in `AWAITING_PROBE`. `tools.json` regenerated: 444 tools.