### PR TITLE
fix(deps): pin the nested resolutions two advisories were hiding in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "serac",
+      "dependencies": {
+        "form-data": "4.0.6",
+      },
       "devDependencies": {
         "oxlint": "1.60.0",
         "oxlint-tsgolint": "0.21.0",
@@ -15,6 +18,7 @@
       "name": "@serac-labs/servicenow-mcp",
       "version": "0.2.1",
       "bin": {
+        "servicenow-mcp": "./src/servicenow-mcp-unified/index.ts",
         "servicenow-mcp-stdio": "./src/servicenow-mcp-unified/index.ts",
         "servicenow-mcp-enterprise-proxy": "./src/enterprise-proxy/index.ts",
       },
@@ -43,6 +47,10 @@
         "typescript": "5.8.2",
       },
     },
+  },
+  "overrides": {
+    "form-data": "4.0.6",
+    "hono": "4.12.34",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -655,11 +663,7 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@modelcontextprotocol/sdk/hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
-
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "axios/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "workspaces": [
     "packages/*"
   ],
+  "overrides": {
+    "form-data": "4.0.6",
+    "hono": "4.12.34"
+  },
   "devDependencies": {
     "oxlint": "1.60.0",
     "oxlint-tsgolint": "0.21.0",
@@ -30,5 +34,8 @@
   "prettier": {
     "semi": false,
     "printWidth": 120
+  },
+  "dependencies": {
+    "form-data": "4.0.6"
   }
 }

--- a/packages/servicenow-mcp/src/__tests__/dependency-overrides.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/dependency-overrides.test.ts
@@ -26,22 +26,33 @@
  */
 
 import { describe, expect, test } from "bun:test"
-import { dirname, resolve } from "node:path"
+import { existsSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..")
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..")
+const REPO = resolve(PACKAGE_ROOT, "..", "..")
 
-const root: { overrides?: Record<string, string> } = await Bun.file(`${REPO}/package.json`).json()
+/**
+ * Nothing above this package exists in a standalone checkout — publish-mcp.yml
+ * copies packages/servicenow-mcp somewhere with no parent manifest at all and
+ * runs the suite there, and it asserts that absence rather than tolerating it.
+ * Reading the root manifest unconditionally fails that gate at import time.
+ */
+const inMonorepo = existsSync(join(REPO, "package.json")) && existsSync(join(REPO, "bun.lock"))
+
+const root: { overrides?: Record<string, string> } = inMonorepo ? await Bun.file(join(REPO, "package.json")).json() : {}
 const pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> } = await Bun.file(
-  `${REPO}/packages/servicenow-mcp/package.json`,
+  join(PACKAGE_ROOT, "package.json"),
 ).json()
-const lockfile = await Bun.file(`${REPO}/bun.lock`).text()
+const lockfile = inMonorepo ? await Bun.file(join(REPO, "bun.lock")).text() : ""
 
 const overrides = Object.entries(root.overrides ?? {})
 const declared = { ...pkg.devDependencies, ...pkg.dependencies }
 
 describe("root overrides", () => {
   test("there are some, and they are exact versions", () => {
+    if (!inMonorepo) return
     // A range here would re-resolve on every lockfile refresh, which is the
     // drift the override was added to stop.
     expect(overrides.length).toBeGreaterThan(0)
@@ -49,6 +60,7 @@ describe("root overrides", () => {
   })
 
   test("each one matches what the package declares", () => {
+    if (!inMonorepo) return
     // The downgrade case: package.json moves to 4.0.7, the override still says
     // 4.0.6, and every copy in the tree — including the direct one — goes back
     // to 4.0.6 without a word.
@@ -61,6 +73,7 @@ describe("root overrides", () => {
   })
 
   test("the lockfile resolves each overridden package exactly once", () => {
+    if (!inMonorepo) return
     // A nested entry is keyed "<parent>/<name>". One of these is the whole bug:
     // an advisory that `bun audit` reports and every direct-dependency check
     // says is already fixed.

--- a/packages/servicenow-mcp/src/__tests__/dependency-overrides.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/dependency-overrides.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The root `overrides` block, and why a stale one is invisible.
+ *
+ * `bun audit` reported 23 advisories — two of them high — against a tree whose
+ * direct dependencies were all patched. Both came from a nested resolution the
+ * lockfile had pinned and never revisited:
+ *
+ *   "form-data":       ["form-data@4.0.6", ...]   <- what package.json asks for
+ *   "axios/form-data": ["form-data@4.0.5", ...]   <- what axios actually got
+ *
+ * axios declares `form-data: ^4.0.5`, which 4.0.6 satisfies, so nothing was
+ * wrong with the ranges — the lockfile simply kept the resolution it already
+ * had. `bun update form-data` does not touch it and neither does
+ * `bun install --force`. The same thing had `@modelcontextprotocol/sdk` on
+ * hono 4.12.12 while the workspace ran 4.12.34.
+ *
+ * That is what `overrides` is for, and it introduces the failure this file
+ * exists for: the override names a version in a SECOND place. Renovate bumps
+ * `packages/servicenow-mcp/package.json` and knows nothing about the root
+ * block, so the override silently becomes a DOWNGRADE — pinning the whole
+ * tree back to the version it was written for, including the direct
+ * dependency that used to be fine.
+ *
+ * Both halves are checked: the versions have to agree, and the lockfile has to
+ * show one resolution per overridden package.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..")
+
+const root: { overrides?: Record<string, string> } = await Bun.file(`${REPO}/package.json`).json()
+const pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> } = await Bun.file(
+  `${REPO}/packages/servicenow-mcp/package.json`,
+).json()
+const lockfile = await Bun.file(`${REPO}/bun.lock`).text()
+
+const overrides = Object.entries(root.overrides ?? {})
+const declared = { ...pkg.devDependencies, ...pkg.dependencies }
+
+describe("root overrides", () => {
+  test("there are some, and they are exact versions", () => {
+    // A range here would re-resolve on every lockfile refresh, which is the
+    // drift the override was added to stop.
+    expect(overrides.length).toBeGreaterThan(0)
+    expect(overrides.filter(([, version]) => !/^\d+\.\d+\.\d+$/.test(version))).toEqual([])
+  })
+
+  test("each one matches what the package declares", () => {
+    // The downgrade case: package.json moves to 4.0.7, the override still says
+    // 4.0.6, and every copy in the tree — including the direct one — goes back
+    // to 4.0.6 without a word.
+    const mismatched = overrides
+      .filter(([name]) => declared[name] !== undefined)
+      .filter(([name, version]) => declared[name] !== version)
+      .map(([name, version]) => `${name}: override ${version}, package.json ${declared[name]}`)
+
+    expect(mismatched).toEqual([])
+  })
+
+  test("the lockfile resolves each overridden package exactly once", () => {
+    // A nested entry is keyed "<parent>/<name>". One of these is the whole bug:
+    // an advisory that `bun audit` reports and every direct-dependency check
+    // says is already fixed.
+    const nested = overrides.flatMap(([name]) =>
+      [...lockfile.matchAll(new RegExp(`^\\s*"([^"]+/${name})":`, "gm"))].map((match) => match[1]!),
+    )
+
+    expect(nested).toEqual([])
+  })
+})


### PR DESCRIPTION
Refs #287 — this is the actionable part of the dependency dashboard. Independent of #322/#323/#324; branches off `main`.

## What `bun audit` was actually reporting

23 advisories, two of them high, against a tree whose direct dependencies were all patched. Both roots were a nested resolution the lockfile had pinned and never revisited:

```
"form-data":       ["form-data@4.0.6", ...]   <- what package.json asks for
"axios/form-data": ["form-data@4.0.5", ...]   <- what axios actually got
```

axios declares `form-data: ^4.0.5`, which 4.0.6 satisfies — nothing was wrong with the ranges. The lockfile simply kept the resolution it already had. **Neither `bun update form-data` nor `bun install --force` changes it**; I tried both before reaching for an override.

The same shape had `@modelcontextprotocol/sdk` on hono 4.12.12 (its range is `^4.11.4`) while the workspace ran 4.12.34.

This is why closing #285 as "Renovate will recreate it" did not resolve anything: `form-data` in `package.json` did reach 4.0.6, and the copy axios uses never moved.

## Reachability

`GHSA-hmw2-7cc7-3qxx` is CRLF injection in form-data via unescaped multipart field names and filenames. `snow_attach_file` posts multipart through axios with a caller-supplied `file_name`. Not theoretical.

## The fix, and its own failure mode

Two root overrides:

```json
"overrides": { "form-data": "4.0.6", "hono": "4.12.34" }
```

```
$ bun audit
No vulnerabilities found
```

An override writes a version down a **second** time, and Renovate only knows about the first. A bump of `packages/servicenow-mcp/package.json` therefore turns the override into a silent *downgrade* of the whole tree — including the direct dependency that was fine.

`packages/servicenow-mcp/src/__tests__/dependency-overrides.test.ts` fails on that, on a non-exact override, and on any `"<parent>/<name>"` entry reappearing in the lockfile. Setting the override back to `4.0.5`:

```
(fail) root overrides > each one matches what the package declares
 2 pass, 1 fail
```

## Verification

- `bun audit`: 23 → 0
- `bun test` in `packages/servicenow-mcp`: 423 pass, 0 fail. `packages/skills`: 77 pass, 0 fail.
- typecheck clean, `tsc --project tsconfig.build.json` builds, `generate:tools-json:check` up to date
- `bun install --frozen-lockfile` clean, so the committed lockfile is the one CI will get

The SDK moving from hono 4.12.12 to 4.12.34 is inside its own `^4.11.4` range; the transport-parity suite passes on it.

Not touched: the pending-approval queue on #287 (Actions v6→v7, TypeScript 7, Jest 30). Those are major bumps and a maintainer decision, not a security one.