### PR TITLE
feat(mcp): snow_instance_visibility — what this connection can actually see

### DIFF
--- a/packages/servicenow-mcp/README.md
+++ b/packages/servicenow-mcp/README.md
@@ -81,6 +81,16 @@ It exits non-zero when something is wrong, prints nothing to stdout on the serve
 secret. `snow_diagnose_setup` returns the same report to the model — useful when the MCP client hides the
 server's stderr, which most of them do. That tool is stdio-only: the report describes the local process.
 
+Once the connection works the question changes — "it connects, so why is everything empty?" — and
+`snow_instance_visibility` answers that one instead. Per table: whether the read succeeds, the HTTP status
+if it does not, the row count behind it, and which role to ask for. Plus two things nothing else reports.
+Whether `javascript:` date functions resolve in an encoded query on this instance, tested with a single
+count whose clause cannot match anything: if that count comes back as the whole table, every "last 7 days"
+number you have is a whole-table number. And which invalid-query regime the instance runs — whether a
+condition on a column that does not exist is ignored, so the query answers for everything, or returns no
+rows, so it answers zero. It reads only the instance and never the machine, so unlike `snow_diagnose_setup`
+it runs on both transports.
+
 ## Use it as a library
 
 ESM only. The package exports named subpaths rather than one barrel, so importing blast-radius does not
@@ -105,10 +115,16 @@ Each tool is exported as a `*_def` / `*_exec` pair: the MCP tool definition and 
 | `/http`             | The streamable-HTTP transport, as a Hono app                  |
 | `/blast-radius`     | Impact-analysis tools, usable without the MCP layer           |
 | `/sn-roles`         | The ServiceNow roles each tool needs — see below              |
+| `/setup-doctor`     | The connection classifiers and instance probes, as functions  |
 | `/types`            | `ServiceNowContext`, `MCPToolDefinition`, …                   |
 | `/auth`             | OAuth + basic auth, token cache, authenticated Axios client   |
 | `/error-handler`    | Result envelopes and error classification                     |
 | `/enterprise-proxy` | Client for the licensed enterprise tool catalog               |
+
+`/setup-doctor` is the instance-reading half only. `runSetupDoctor` and `renderReport` walk environment
+variables and every `auth.json` on the machine, which on a server that serves more than one tenant answers
+about the server rather than about the asker — the same reason `snow_diagnose_setup` is stdio-only — so
+they are not published.
 
 ## A note on tenancy
 

--- a/packages/servicenow-mcp/package.json
+++ b/packages/servicenow-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@serac-labs/servicenow-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "mcpName": "io.github.serac-labs/servicenow-mcp",
   "description": "Unified ServiceNow MCP server (400+ snow_* tools), blast-radius analysis, stdio + HTTP transports.",
   "license": "Apache-2.0",
@@ -29,6 +29,7 @@
     "./enterprise-proxy": "./src/enterprise-proxy/index.ts",
     "./blast-radius": "./src/servicenow-mcp-unified/tools/blast-radius/index.ts",
     "./sn-roles": "./src/sn-roles.ts",
+    "./setup-doctor": "./src/servicenow-mcp-unified/shared/instance-diagnostics.ts",
     "./types": "./src/servicenow-mcp-unified/shared/types.ts",
     "./auth": "./src/servicenow-mcp-unified/shared/auth.ts",
     "./error-handler": "./src/servicenow-mcp-unified/shared/error-handler.ts",

--- a/packages/servicenow-mcp/script/probe-sn-roles/README.md
+++ b/packages/servicenow-mcp/script/probe-sn-roles/README.md
@@ -5,11 +5,12 @@ reading the live instance's ACL definitions directly. Output:
 `packages/servicenow-mcp/sn-roles.manifest.json`.
 
 It is a standalone artifact, not an input to `generate-tools-json.ts` — the two
-manifests are fetched separately and joined client-side. Both are read from
-`main` over raw.githubusercontent.com by the Serac Portal's tool-permissions
-proxy and by `docs.serac.build`, so the checked-in copy IS the published
-artifact. Moving or renaming it breaks production; see the consumer list in
-`../../README.md`.
+manifests are fetched separately and joined client-side. The roles manifest also
+ships inside the npm tarball, behind `exports["./sn-roles"]`, and that is the
+supported way for a service to read it. `docs.serac.build` still fetches both
+from `main` over raw.githubusercontent.com, so the checked-in copy IS the
+published artifact and moving or renaming it is still a production change; see
+the consumer list in `../../README.md`.
 
 ## Why ACL-based, not empirical?
 

--- a/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/sn-roles.test.ts
@@ -58,6 +58,7 @@ const AWAITING_PROBE = [
   "snow_fluent_install",
   "snow_fluent_status",
   "snow_fluent_transform",
+  "snow_instance_visibility",
   "snow_scripted_rest_api_manage",
   "snow_validate_query",
 ]

--- a/packages/servicenow-mcp/src/__tests__/snow-instance-visibility.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/snow-instance-visibility.test.ts
@@ -1,0 +1,417 @@
+/**
+ * snow_instance_visibility, driven end to end.
+ *
+ * Nothing is mocked. The verdicts are pinned against real payload shapes in
+ * `shared/__tests__/setup-doctor.test.ts`, where the classifiers are pure; what
+ * is left to prove is the part no pure test can see — that the tool reaches the
+ * instance through the shared authenticated client, that a refusal on one table
+ * does not take the call down, and that the numbers it reports are the ones the
+ * instance sent. So the instance is a real HTTP server on loopback, the same
+ * way the setup doctor's own end-to-end runs work, and the tool talks to it
+ * over basic auth through `getAuthenticatedClient`.
+ *
+ * The interesting shape is deliberately mixed: one readable table, one 403, a
+ * date canary that resolves, an instance that ignores an unknown column. A run
+ * where everything works proves less than one where something does not.
+ *
+ * Four of the instances below are the failures the pure tests could not see,
+ * because in every one of them the classifier was already right and the path
+ * feeding it was wrong: a sleeping instance whose HTML page never reached
+ * `htmlDiagnosis`, a refused held-role read that arrived as an empty list, a
+ * dead credential that failed before any probe ran, and a bounded count that
+ * came back 0 from a column the table does not have.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import * as http from "http"
+
+import {
+  execute,
+  toolDefinition,
+  type Visibility,
+} from "../servicenow-mcp-unified/tools/platform/snow_instance_visibility"
+import { type ServiceNowContext } from "../servicenow-mcp-unified/shared/types"
+
+const USER = `{"result":[{"sys_id":"6816f79cc0a8016401c5a33be04be441","user_name":"serac.integration","name":"Serac Integration","active":"true","sys_domain":"global","sys_domain.name":"TOP/Acme"}]}`
+const ROLES = `{"result":[{"role.name":"itil"},{"role.name":"update_set_admin"},{"role.name":"snc_internal"}]}`
+const PROPERTIES = `{"result":[{"name":"glide.buildname","value":"Zurich"},{"name":"glide.buildtag","value":"glide-zurich-06-25-2026__patch2.zip"},{"name":"glide.license.edition","value":"Enterprise"},{"name":"glide.product.description","value":"Service Management"}]}`
+const INSUFFICIENT_RIGHTS = `{"error":{"message":"Insufficient rights to query records","detail":"Field(s) present in the query do not have permission to be read"},"status":"failure"}`
+const UNAUTHORIZED = `{"error":{"message":"User Not Authenticated","detail":"Required to provide Auth information"},"status":"failure"}`
+const ROW = `{"result":[{"sys_id":"46b66a40a9fe198101f243dfbc79033d"}]}`
+
+/**
+ * What a hibernating developer instance answers to every request, REST
+ * included: HTTP 200, an HTML login page, no x-total-count.
+ */
+const HIBERNATING = `<!DOCTYPE html><html><head><title>Instance Hibernating page</title></head><body><h2>This instance is hibernating</h2><p>Please log in to wake it up.</p></body></html>`
+
+/** How many rows sys_user holds. The canaries are read against this number. */
+const USERS = 1247
+
+interface Answer {
+  status: number
+  body: string
+  total?: string
+  contentType?: string
+}
+
+/**
+ * An instance that can read sys_update_xml and refuses sys_update_set, applies
+ * date functions, and ignores a condition on a column it does not have.
+ */
+const instance = (url: string): Answer => {
+  const path = decodeURIComponent(url)
+  if (path.includes("sys_user_has_role")) return { status: 200, body: ROLES, total: "3" }
+  if (path.includes("sys_properties")) return { status: 200, body: PROPERTIES, total: "4" }
+  if (path.includes("v_plugin"))
+    return path.includes("com.glide.domain")
+      ? { status: 200, body: ROW, total: "1" }
+      : { status: 200, body: ROW, total: "412" }
+  if (path.includes("sys_update_set")) return { status: 403, body: INSUFFICIENT_RIGHTS }
+  if (path.includes("sys_update_xml")) return { status: 200, body: ROW, total: "8123" }
+  if (path.includes("sys_user")) {
+    // The self-contradictory clause matches nothing, which is what a working
+    // date function does. The unknown column is ignored and the condition
+    // falls away, so that read answers for the whole table.
+    if (path.includes("daysAgoStart")) return { status: 200, body: `{"result":[]}`, total: "0" }
+    return { status: 200, body: USER, total: String(USERS) }
+  }
+  return { status: 404, body: `{"error":{"message":"No such table"}}` }
+}
+
+/** The same instance, except that reading sys_user_has_role is refused. */
+const rolesRefused = (url: string): Answer =>
+  decodeURIComponent(url).includes("sys_user_has_role") ? { status: 403, body: INSUFFICIENT_RIGHTS } : instance(url)
+
+/** A hibernating instance: one HTML page, 200, for everything that is asked. */
+const hibernating = (): Answer => ({ status: 200, body: HIBERNATING, contentType: "text/html" })
+
+/** A credential the instance no longer accepts anywhere. */
+const dead = (): Answer => ({ status: 401, body: UNAUTHORIZED })
+
+/**
+ * An instance in the `returns_no_rows` regime, holding a view with no
+ * `sys_created_on`: the bounded count answers 0 for a table with 412 rows in
+ * it. Neither invalid-query regime answers 400, so nothing about the response
+ * says the clause was never applied.
+ */
+const noDateColumn = (url: string): Answer => {
+  const path = decodeURIComponent(url)
+  if (path.includes("u_genuinely_empty")) return { status: 200, body: `{"result":[]}`, total: "0" }
+  if (path.includes("v_plugin") && path.includes("daysAgoStart")) return { status: 200, body: `{"result":[]}`, total: "0" }
+  return instance(url)
+}
+
+const start = async (answer: (url: string) => Answer) => {
+  const hits: string[] = []
+  const sockets = new Set<import("net").Socket>()
+  const server = http.createServer((req, res) => {
+    hits.push(decodeURIComponent(req.url ?? ""))
+    const reply = answer(req.url ?? "")
+    res.writeHead(reply.status, {
+      "content-type": reply.contentType ?? "application/json",
+      ...(reply.total === undefined ? {} : { "x-total-count": reply.total }),
+    })
+    res.end(reply.body)
+  })
+  server.on("connection", (socket) => {
+    sockets.add(socket)
+    socket.on("close", () => sockets.delete(socket))
+  })
+  await new Promise<void>((ready) => server.listen(0, "127.0.0.1", ready))
+  const address = server.address()
+
+  return {
+    url: `http://127.0.0.1:${typeof address === "object" && address !== null ? address.port : 0}`,
+    hits,
+    stop: () =>
+      new Promise<void>((done) => {
+        sockets.forEach((socket) => socket.destroy())
+        server.close(() => done())
+      }),
+  }
+}
+
+const credentials = (url: string): ServiceNowContext => ({
+  instanceUrl: url,
+  clientId: "",
+  clientSecret: "",
+  username: "serac.integration",
+  password: "not-a-real-password",
+})
+
+describe("snow_instance_visibility against an instance", () => {
+  test("reports reach, roles, per-table access, both canaries and identity in one call", async () => {
+    const server = await start(instance)
+
+    const result = await execute(
+      { tables: ["sys_update_xml", "sys_update_set"], lifetime_days: 365 },
+      credentials(server.url),
+    )
+    const data = result.data as Visibility
+
+    // A 403 on one table is an answer, not a failed call.
+    expect(result.success).toBe(true)
+    expect(data.reach.code).toBe("api-ok")
+
+    expect(data.roles?.held).toEqual(["itil", "snc_internal", "update_set_admin"])
+    expect(data.roles?.heldTruncated).toBe(false)
+    expect(data.roles?.heldReadable).toBe(true)
+    expect(data.roles?.coverage?.resolved).toBeGreaterThan(100)
+    expect(data.roles?.manifest.validatedOn).toContain("glide-")
+
+    expect(data.tables[0]).toMatchObject({
+      table: "sys_update_xml",
+      readable: true,
+      lifetime: 8123,
+      lifetimeWindowDays: 365,
+      // The held update_set_admin covers this one, and a readable table is
+      // never advised about roles anyway.
+      missingRoles: [],
+    })
+    expect(data.tables[1]).toMatchObject({ table: "sys_update_set", readable: false, httpStatus: 403 })
+    expect(data.tables[1]?.error).toContain("Insufficient rights")
+    // The 403 is role-shaped and the held list came back complete, so a
+    // subtraction is allowed here. It comes out empty because the account
+    // already holds update_set_admin — the refusal is about something else.
+    expect(data.tables[1]?.missingRoles).toEqual([])
+
+    expect(data.dateFunctions).toMatchObject({ verdict: "resolved", canary: 0, total: USERS })
+    expect(data.invalidQuery).toMatchObject({ verdict: "ignores", matched: USERS, total: USERS })
+
+    expect(data.identity).toMatchObject({
+      release: "Zurich",
+      productDescription: "Service Management",
+      edition: "Enterprise",
+      pluginCount: 412,
+      domainSeparated: "separated",
+      integrationUserDomain: "TOP/Acme",
+    })
+
+    // The summary is what a person reads; the diagnosis must be in it rather
+    // than only in the payload.
+    expect(result.summary).toContain("sys_update_xml")
+    expect(result.summary).toContain("Insufficient rights")
+    expect(result.summary).toContain("Zurich")
+
+    await server.stop()
+  }, 30000)
+
+  test("it never asks for the integration account's name, and never reports one", async () => {
+    // Pinned on the REQUEST as well as the response, because the field list is
+    // the control: this output is stored and rendered rather than read once by
+    // the person who owns the credential, so the login and the human name
+    // behind it must not be collected at all. The fixture below sends both
+    // anyway — an instance answers what it likes — which is exactly why the
+    // response is checked too.
+    const server = await start(instance)
+
+    const result = await execute({ tables: [] }, credentials(server.url))
+    const reach = server.hits.find((hit) => hit.includes("gs.getUserID()"))
+    const fields = new URL(`http://instance${reach}`).searchParams.get("sysparm_fields")
+
+    // `active` stays: it is not personal, and it carries "that account is
+    // marked inactive", which is a real cause of an instance answering nothing.
+    expect(fields?.split(",")).toEqual(["active", "sys_domain", "sys_domain.name"])
+    expect(JSON.stringify(result)).not.toContain("Serac Integration")
+    expect(JSON.stringify(result)).not.toContain("serac.integration")
+    // The fact, not the person. classifyApiResponse still names the account for
+    // the stdio doctor, which prints it to whoever owns that credential.
+    expect((result.data as Visibility).reach.title).toBe("The REST API accepted this credential.")
+
+    await server.stop()
+  }, 30000)
+
+  test("a refused held-role read is reported as unknown, never as an account with no roles", async () => {
+    // Reading sys_user_has_role needs a role of its own. Before this, a 403
+    // there produced held: [], heldTruncated: false and a coverage block —
+    // byte-identical to an account that genuinely holds nothing, with a
+    // blocked count computed from a refusal and a missing-role sentence naming
+    // roles the account may already hold.
+    const server = await start(rolesRefused)
+
+    const result = await execute({ tables: ["sys_update_set"] }, credentials(server.url))
+    const data = result.data as Visibility
+
+    expect(result.success).toBe(true)
+    expect(data.roles).toMatchObject({ held: [], heldTruncated: false, heldReadable: false, heldHttpStatus: 403 })
+    expect(data.roles?.coverage).toBeUndefined()
+    // The manifest would name update_set_admin here, which this account holds.
+    expect(data.tables[0]?.missingRoles).toEqual([])
+
+    expect(result.summary).toContain("not an account that holds nothing")
+    expect(result.summary).not.toContain("resolvable tools in reach")
+    expect(result.summary).not.toContain("ask an admin for one of")
+
+    await server.stop()
+  }, 30000)
+
+  test("a hibernating instance is diagnosed as hibernating, not as a broken network", async () => {
+    // 13 of 14 production instances are developer PDIs, which hibernate. They
+    // answer 200 with an HTML login page, and the shared client used to throw
+    // a TypeError assigning `result` onto that string body — a synthetic error
+    // with no `.response`, so every probe filed it as a transport failure and
+    // htmlDiagnosis, exported for exactly this page, never ran.
+    const server = await start(hibernating)
+
+    const result = await execute({ tables: ["sys_update_xml"] }, credentials(server.url))
+    const data = result.data as Visibility
+
+    expect(result.success).toBe(true)
+    expect(data.reach.code).toBe("instance-hibernating")
+    expect(data.reach.title).toBe("The instance is hibernating.")
+    expect(JSON.stringify(result)).not.toContain("TypeError")
+
+    // A 200 that is not a read is the one row a consumer cannot classify from
+    // the status, so the html code rides along with it.
+    expect(data.tables[0]).toMatchObject({
+      table: "sys_update_xml",
+      readable: false,
+      httpStatus: 200,
+      code: "instance-hibernating",
+      lifetime: null,
+    })
+    // Same page, same reasoning: parsing it yields no rows, which is not an
+    // account that holds no roles.
+    expect(data.roles?.heldReadable).toBe(false)
+    expect(data.roles?.coverage).toBeUndefined()
+
+    expect(result.summary).toContain("hibernating")
+
+    await server.stop()
+  }, 30000)
+
+  test("a table that failed because the instance is asleep is not a missing-role problem", async () => {
+    // include_role_coverage is off, so the held list is not the thing
+    // withholding the advice — the shape of the failure is. Sending someone to
+    // an admin for update_set_previewer because their PDI is asleep is the
+    // wrong request to the wrong person.
+    const server = await start(hibernating)
+
+    const result = await execute(
+      { tables: ["sys_update_xml"], include_role_coverage: false },
+      credentials(server.url),
+    )
+    const data = result.data as Visibility
+
+    expect(data.roles).toBeUndefined()
+    expect(data.tables[0]?.missingRoles).toEqual([])
+    expect(result.summary).not.toContain("ask an admin for one of")
+
+    await server.stop()
+  }, 30000)
+
+  test("a 403 with the held list turned off still names the roles that could read the table", async () => {
+    // The other edge of the same rule, and the one over-suppression would
+    // silently take away: with include_role_coverage off there is no list to
+    // subtract from, and the schema says what happens then — every role that
+    // could read it, rather than none.
+    const server = await start(instance)
+
+    const result = await execute(
+      { tables: ["sys_update_set"], include_role_coverage: false },
+      credentials(server.url),
+    )
+    const data = result.data as Visibility
+
+    expect(data.tables[0]?.missingRoles).toContain("update_set_admin")
+    expect(result.summary).toContain("ask an admin for one of")
+
+    await server.stop()
+  }, 30000)
+
+  test("a dead credential carries its status in the metadata, not only in a sentence", async () => {
+    // Every endpoint answers 401, so the client is never built and no probe
+    // runs. The platform has to separate "the credential is dead" from "the
+    // instance could not be reached" — one is a re-auth, the other is a
+    // network — and regexing an error message is not a way to do that.
+    const server = await start(dead)
+
+    const result = await execute({ tables: ["sys_user"] }, credentials(server.url))
+
+    expect(result.success).toBe(false)
+    expect(result.metadata?.http_status).toBe(401)
+    expect(result.error).toContain("No authenticated client")
+    // One request: the credential test. Nothing below it was attempted.
+    expect(server.hits.length).toBe(1)
+
+    await server.stop()
+  }, 30000)
+
+  test("an unreachable instance has no status to report, and does not invent one", async () => {
+    // The other side of the test above: without a response there is no
+    // http_status at all, which is how a caller tells the two apart.
+    const result = await execute({ tables: [] }, credentials("http://127.0.0.1:1"))
+
+    expect(result.success).toBe(false)
+    expect(result.metadata?.http_status).toBeUndefined()
+  }, 30000)
+
+  test("a bounded count of zero is re-read unbounded before it is believed", async () => {
+    // sys_created_on>=javascript:gs.daysAgoStart(N) on a table that has no
+    // sys_created_on: under `ignores` the clause is dropped and the whole-table
+    // count comes back wearing the window's label, under `returns_no_rows` it
+    // comes back 0 on a full table. Neither answers 400, which was the only
+    // trigger for the unbounded re-read — so a view reported
+    // {readable: true, lifetime: 0, lifetimeWindowDays: 365} in the same
+    // payload whose identity block counted 412 active plugins.
+    const server = await start(noDateColumn)
+
+    const result = await execute(
+      { tables: ["v_plugin", "u_genuinely_empty"], lifetime_days: 365 },
+      credentials(server.url),
+    )
+    const data = result.data as Visibility
+
+    expect(data.tables[0]).toMatchObject({
+      table: "v_plugin",
+      readable: true,
+      lifetime: 412,
+      // Null, not 365: after a zero nothing here can show the window was ever
+      // applied, and a number under a window it did not apply is the bug.
+      lifetimeWindowDays: null,
+    })
+    expect(data.identity?.pluginCount).toBe(412)
+
+    // The re-read must not turn every zero into a number. A table that is
+    // empty unbounded too is still empty, and says so.
+    expect(data.tables[1]).toMatchObject({ table: "u_genuinely_empty", readable: true, lifetime: 0 })
+
+    await server.stop()
+  }, 30000)
+
+  test("the canaries are counted against the whole table, not the bounded window", async () => {
+    // A total already narrowed to lifetime_days describes a different
+    // population than the clause under test, and "the clause matched
+    // everything" is only a statement when both sides cover the same rows.
+    const server = await start(instance)
+
+    await execute({ tables: [], lifetime_days: 90 }, credentials(server.url))
+    const canaryReads = server.hits.filter((hit) => hit.includes("sys_user?") || hit.includes("sys_user&"))
+
+    expect(canaryReads.some((hit) => hit.includes("daysAgoStart(90)"))).toBe(false)
+    expect(canaryReads.some((hit) => hit.includes("serac_canary_no_such_field=1"))).toBe(true)
+
+    await server.stop()
+  }, 30000)
+
+  test("more tables than the cap is refused before a single call goes out", async () => {
+    // Each entry is a sequential GET. Truncating the list silently would
+    // answer a question the caller did not ask.
+    const result = await execute(
+      { tables: Array.from({ length: 21 }, (_, index) => `u_table_${index}`) },
+      credentials("http://127.0.0.1:1"),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("cap is 20")
+  })
+
+  test("it declares itself read-only and reachable from the read-only persona", () => {
+    expect(toolDefinition.permission).toBe("read")
+    expect(toolDefinition.allowedRoles).toContain("stakeholder")
+    // No transport allowlist: it reads the instance, never the machine the
+    // server runs on. transport-parity.test.ts pins the other direction.
+    expect(toolDefinition.transports).toBeUndefined()
+  })
+})

--- a/packages/servicenow-mcp/src/__tests__/snow-query-table-params.test.ts
+++ b/packages/servicenow-mcp/src/__tests__/snow-query-table-params.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The pure halves of snow_query_table: the arguments it turns into Table API
+ * parameters, and the total it reads back out of the response headers.
+ *
+ * Both were wrong in the same way — a plausible answer to a question nobody
+ * asked. `order_by: "sys_created_on"` emitted `^ORDERBYASC<field>`; ASC is not
+ * part of any ServiceNow operator, so the instance dropped the clause and
+ * answered in whatever order it liked, and "give me the oldest record" came
+ * back as an arbitrary one. The descending form, `ORDERBYDESC`, is spelled
+ * correctly, which is why the bug survived: half the callers got what they
+ * asked for. And `total` read `"100+"` whenever the page filled — a string
+ * that is not the count and not a bound anyone measured.
+ *
+ * Neither needs an instance to detect. Both are visible in what the tool
+ * builds before it sends anything.
+ */
+
+import { describe, expect, test } from "@jest/globals"
+import { buildQueryParams, readTotal } from "../servicenow-mcp-unified/tools/operations/snow_query_table"
+
+describe("buildQueryParams", () => {
+  test("regression: ascending order emits ORDERBY, not ORDERBYASC", () => {
+    expect(buildQueryParams({ table: "incident", order_by: "sys_created_on" }).params.sysparm_query).toBe(
+      "ORDERBYsys_created_on",
+    )
+  })
+
+  test("descending order emits ORDERBYDESC and strips the minus", () => {
+    expect(buildQueryParams({ table: "incident", order_by: "-sys_created_on" }).params.sysparm_query).toBe(
+      "ORDERBYDESCsys_created_on",
+    )
+  })
+
+  test("the caller's own query survives alongside the ordering", () => {
+    // The ordering is appended, never substituted: a filtered "oldest open
+    // incident" has to stay filtered.
+    expect(
+      buildQueryParams({ table: "incident", query: "active=true^priority=1", order_by: "sys_created_on" }).params
+        .sysparm_query,
+    ).toBe("active=true^priority=1^ORDERBYsys_created_on")
+  })
+
+  test("no query and no ordering sends no sysparm_query at all", () => {
+    expect(buildQueryParams({ table: "incident" }).params).not.toHaveProperty("sysparm_query")
+  })
+
+  test("a query with no ordering reaches the instance unchanged", () => {
+    expect(buildQueryParams({ table: "incident", query: "active=true" }).params.sysparm_query).toBe("active=true")
+  })
+
+  test("sys_id is always in the field list, wherever the caller put it", () => {
+    // Every follow-up operation needs it, and a caller asking for three
+    // columns is not asking to be unable to act on the rows.
+    expect(buildQueryParams({ table: "incident", fields: ["number", "state"] }).params.sysparm_fields).toBe(
+      "sys_id,number,state",
+    )
+    expect(buildQueryParams({ table: "incident", fields: ["number", "sys_id"] }).params.sysparm_fields).toBe(
+      "number,sys_id",
+    )
+  })
+
+  test("fields as a comma-separated string is accepted rather than spread character by character", () => {
+    expect(buildQueryParams({ table: "incident", fields: "number, state" }).params.sysparm_fields).toBe(
+      "sys_id,number,state",
+    )
+  })
+
+  test("the camelCase a model sends is read too", () => {
+    const params = buildQueryParams({ table: "incident", orderBy: "-number", displayValue: true }).params
+    expect(params.sysparm_query).toBe("ORDERBYDESCnumber")
+    expect(params.sysparm_display_value).toBe("true")
+  })
+
+  test("display values are only requested when they were asked for", () => {
+    expect(buildQueryParams({ table: "incident" }).params).not.toHaveProperty("sysparm_display_value")
+  })
+
+  test("a call with no table is refused rather than sent to /api/now/table/undefined", () => {
+    expect(() => buildQueryParams({})).toThrow(/table is required/)
+  })
+
+  test("regression: a string offset is a number by the time anyone adds to it", () => {
+    // `has_more` is `offset + records.length < total`. With the string an LLM
+    // sends, that is `"100" + 25 === "10025"`, which is not less than 8123 —
+    // so page two of a long table reports that there is nothing after it. The
+    // instance accepts the string happily; only the arithmetic on this side
+    // notices.
+    const plan = buildQueryParams({ table: "incident", offset: "100", limit: "50" })
+
+    expect(plan.offset).toBe(100)
+    expect(plan.limit).toBe(50)
+    expect(plan.offset + 25).toBe(125)
+  })
+
+  test("what is not a count falls back to the default rather than becoming one", () => {
+    // Number(null) is 0 and Number("") is 0, and a limit of 0 asks the
+    // instance for nothing at all.
+    expect(buildQueryParams({ table: "incident", limit: null, offset: undefined }).limit).toBe(100)
+    expect(buildQueryParams({ table: "incident", limit: "", offset: "  " }).limit).toBe(100)
+    expect(buildQueryParams({ table: "incident", limit: "twenty" }).limit).toBe(100)
+    expect(buildQueryParams({ table: "incident", offset: -5 }).offset).toBe(0)
+    expect(buildQueryParams({ table: "incident", limit: 25.7 }).limit).toBe(25)
+  })
+})
+
+describe("readTotal", () => {
+  test("the header is the total", () => {
+    expect(readTotal({ "x-total-count": "8123" })).toBe(8123)
+  })
+
+  test("regression: no header means no total, not a fabricated one", () => {
+    // The field is omitted entirely by the caller when this is undefined. The
+    // old behaviour returned the string "100+" as soon as the page filled,
+    // which reads like an answer and is not one.
+    expect(readTotal({})).toBeUndefined()
+    expect(readTotal(undefined)).toBeUndefined()
+  })
+
+  test("a header that is not a count is not a count", () => {
+    expect(readTotal({ "x-total-count": "" })).toBeUndefined()
+    expect(readTotal({ "x-total-count": "many" })).toBeUndefined()
+  })
+
+  test("the capitalised spelling some proxies send is read as well", () => {
+    expect(readTotal({ "X-Total-Count": "42" })).toBe(42)
+  })
+})

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/__tests__/setup-doctor.test.ts
@@ -19,20 +19,27 @@
 import { describe, expect, test } from "@jest/globals"
 import * as http from "http"
 import { spawn } from "node:child_process"
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs"
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import {
   classifyApiResponse,
+  classifyDateCanary,
+  classifyInvalidQuery,
   classifyReachability,
+  classifyTableRead,
   classifyTokenResponse,
   classifyTransportFailure,
+  heldRoles,
   inspectInstanceUrl,
   loadRolesManifest,
+  manifestStamp,
+  mapProperties,
   renderReport,
   runSetupDoctor,
   summarizeRoleCoverage,
+  summarizeTableAccess,
   type Observed,
 } from "../setup-doctor.js"
 
@@ -255,6 +262,270 @@ describe("role coverage, against the committed sn-roles.manifest.json", () => {
     expect(summarizeRoleCoverage(handBuilt, ["catalog_admin"]).blocked).toBe(2) // half a bundle unlocks nothing
     expect(summarizeRoleCoverage(handBuilt, ["catalog_admin", "catalog_editor"]).blocked).toBe(1)
     expect(summarizeRoleCoverage(handBuilt, []).unresolved).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The instance probes: what the caller's own credential can see
+// ---------------------------------------------------------------------------
+
+/** One row and a count header — what a bounded read of a populated table answers. */
+const ONE_ROW = `{"result":[{"sys_id":"46b66a40a9fe198101f243dfbc79033d"}]}`
+
+/** The four identity properties, as sys_properties returns them. */
+const PROPERTIES = `{"result":[{"name":"glide.buildname","value":"Zurich"},{"name":"glide.buildtag","value":"glide-zurich-06-25-2026__patch2-08-01-2026_08-14-2026_1417.zip"},{"name":"glide.license.edition","value":"Enterprise"},{"name":"glide.product.description","value":"Service Management"}]}`
+
+const answered = (status: number, body: string, totalCount?: string, contentType = "application/json") => ({
+  observed: { status, body, contentType, totalCount },
+})
+
+describe("one table read, classified", () => {
+  test("a 200 with a count is readable, and the count is the count", () => {
+    expect(classifyTableRead("sys_update_xml", 365, answered(200, ONE_ROW, "8123"))).toMatchObject({
+      table: "sys_update_xml",
+      readable: true,
+      httpStatus: 200,
+      lifetime: 8123,
+      lifetimeWindowDays: 365,
+    })
+  })
+
+  test("a 200 with no count header is readable with no number, never readable with zero", () => {
+    // A 0 here lands in the "this table holds nothing" branch on the other
+    // side, which is a diagnosis about the customer's instance made out of a
+    // missing header.
+    expect(classifyTableRead("sys_update_xml", 365, answered(200, ONE_ROW)).lifetime).toBeNull()
+  })
+
+  test("an unbounded read says so, rather than claiming a window it did not apply", () => {
+    expect(classifyTableRead("sys_update_set", null, answered(200, ONE_ROW, "12")).lifetimeWindowDays).toBeNull()
+  })
+
+  test("a 403 keeps its status and quotes what ServiceNow said", () => {
+    // The status is the difference between "ask for a role", "authenticate
+    // again" and "fix the query", and it must survive as a number rather than
+    // inside prose a caller has to regex.
+    const read = classifyTableRead("sys_user_has_role", 365, answered(403, INSUFFICIENT_RIGHTS))
+
+    expect(read.readable).toBe(false)
+    expect(read.httpStatus).toBe(403)
+    expect(read.error).toContain("HTTP 403")
+    expect(read.error).toContain("Insufficient rights to query records")
+  })
+
+  test("a hibernation page is not a readable empty table", () => {
+    // HTTP 200, HTML body, no count header: without the html check every table
+    // on a sleeping instance comes back readable and holding nothing.
+    const read = classifyTableRead("sys_user", 365, answered(200, HIBERNATING_PAGE, undefined, "text/html"))
+
+    expect(read.readable).toBe(false)
+    expect(read.error).toContain("hibernating")
+  })
+
+  test("a request that never arrived has no status to report", () => {
+    const read = classifyTableRead("sys_user", 365, {
+      failure: { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND dev12345.service-now.com" },
+    })
+
+    expect(read.readable).toBe(false)
+    expect(read.httpStatus).toBeUndefined()
+    expect(read.error).toContain("ENOTFOUND")
+  })
+})
+
+describe("do javascript: date functions resolve on this instance", () => {
+  test("a clause that cannot match matching nothing means the function resolved", () => {
+    expect(classifyDateCanary(0, 8123)).toBe("resolved")
+  })
+
+  test("a clause that cannot match matching the whole table means it was dropped", () => {
+    expect(classifyDateCanary(8123, 8123)).toBe("evaporated")
+  })
+
+  test("an empty table proves nothing either way", () => {
+    // Both regimes answer 0 on a table with no rows, so "resolved" here would
+    // hand a downgrade to every withheld figure on the instance on the
+    // strength of a measurement that measured nothing.
+    expect(classifyDateCanary(0, 0)).toBe("inconclusive")
+  })
+
+  test("a count that could not be made never becomes a verdict", () => {
+    expect(classifyDateCanary(null, 8123)).toBe("inconclusive")
+    expect(classifyDateCanary(0, null)).toBe("inconclusive")
+  })
+
+  test("a partial match is neither, and is not silently rounded to one of them", () => {
+    expect(classifyDateCanary(3, 8123)).toBe("inconclusive")
+  })
+})
+
+describe("which invalid-query regime the instance is in", () => {
+  test("a condition on a column that does not exist answering for the whole table is the ignore regime", () => {
+    expect(classifyInvalidQuery(8123, 8123)).toBe("ignores")
+  })
+
+  test("the same condition answering zero is glide.invalid_query.returns_no_rows", () => {
+    // The inverse signature, and the reason it is worth a call: under this
+    // regime a dropped clause reads as a confident 0 rather than a confident
+    // total, and nothing else in the response distinguishes the two.
+    expect(classifyInvalidQuery(0, 8123)).toBe("returns_no_rows")
+  })
+
+  test("an instance that refuses the query outright is neither", () => {
+    expect(classifyInvalidQuery(null, 8123)).toBe("unknown")
+  })
+
+  test("an empty table cannot separate the two", () => {
+    expect(classifyInvalidQuery(0, 0)).toBe("unknown")
+    expect(classifyInvalidQuery(0, null)).toBe("unknown")
+  })
+})
+
+describe("the held-role list is a floor, not an inventory", () => {
+  const page = (rows: number) =>
+    JSON.stringify({ result: Array.from({ length: rows }, (_, index) => ({ "role.name": `role_${index}` })) })
+
+  test("a short page is the whole list, sorted and deduplicated", () => {
+    const roles = heldRoles({ status: 200, body: `{"result":[{"role.name":"itil"},{"role.name":"admin"},{"role.name":"itil"}]}` })
+
+    expect(roles.held).toEqual(["admin", "itil"])
+    expect(roles.truncated).toBe(false)
+    expect(roles.readable).toBe(true)
+  })
+
+  test("a full page is flagged, because that is the case that matters", () => {
+    // The query asks for 500 rows with no ORDERBY, and it is admins who
+    // overflow it. Deciding "this account cannot read that table" from a cut
+    // off list is wrong in exactly the direction that hurts.
+    expect(heldRoles({ status: 200, body: page(500) }).truncated).toBe(true)
+    expect(heldRoles({ status: 200, body: page(499) }).truncated).toBe(false)
+  })
+
+  test("a refused read is not an account that holds no roles", () => {
+    // Reading sys_user_has_role needs a role of its own, so a 403 here says
+    // nothing at all about what the account holds.
+    const roles = heldRoles({ status: 403, body: INSUFFICIENT_RIGHTS })
+
+    expect(roles.readable).toBe(false)
+    expect(roles.held).toEqual([])
+    expect(roles.truncated).toBe(false)
+  })
+
+  test("neither is a hibernation page that happens to arrive with a 200", () => {
+    // The status alone said "readable" here, and the page parses to zero rows,
+    // so a sleeping instance reported an account with no roles — and every
+    // coverage number downstream was then computed from a login page. Same
+    // fabrication as the 403, through a different door.
+    const roles = heldRoles({ status: 200, body: HIBERNATING_PAGE, contentType: "text/html" })
+
+    expect(roles.readable).toBe(false)
+    expect(roles.httpStatus).toBe(200)
+    expect(roles.held).toEqual([])
+  })
+})
+
+describe("what the package publishes as /setup-doctor", () => {
+  // The module holds two halves: everything above the line reads THE MACHINE
+  // (`runSetupDoctor` walks environment variables and every auth.json on disk),
+  // everything below reads THE INSTANCE through the caller's own credential.
+  // That line is why snow_diagnose_setup is stdio-only. A subpath exporting the
+  // whole module hands the machine-reading half to every npm consumer including
+  // a multi-tenant backend, which is the same thing the stdio annotation
+  // refuses, arriving through the library door.
+  const manifest = JSON.parse(readFileSync(join(import.meta.dirname, "..", "..", "..", "..", "package.json"), "utf-8"))
+
+  test("the subpath resolves to the instance half, not to setup-doctor.ts", () => {
+    expect(manifest.exports["./setup-doctor"]).toBe("./src/servicenow-mcp-unified/shared/instance-diagnostics.ts")
+  })
+
+  test("the probes and classifiers are published", async () => {
+    const published = await import("../instance-diagnostics.js")
+
+    expect(Object.keys(published)).toEqual(
+      expect.arrayContaining(["probeReach", "probeHeldRoles", "probeTableRead", "classifyTableRead", "heldRoles"]),
+    )
+  })
+
+  test("runSetupDoctor and renderReport are not", async () => {
+    const published = await import("../instance-diagnostics.js")
+
+    expect(Object.keys(published)).not.toContain("runSetupDoctor")
+    expect(Object.keys(published)).not.toContain("renderReport")
+  })
+})
+
+describe("which instance answered", () => {
+  test("release is the build name, and the product description is kept apart from it", () => {
+    // The portal mapped its `version` column from glide.product.description
+    // with buildname only as a fallback, so every instance it discovered reads
+    // "Service Management" under a heading that says Release.
+    const identity = mapProperties({ status: 200, body: PROPERTIES })
+
+    expect(identity.release).toBe("Zurich")
+    expect(identity.buildName).toBe("Zurich")
+    expect(identity.productDescription).toBe("Service Management")
+    expect(identity.buildTag).toContain("glide-zurich")
+    expect(identity.edition).toBe("Enterprise")
+  })
+
+  test("a refused read names no field at all, rather than naming them empty", () => {
+    expect(Object.values(mapProperties({ status: 403, body: INSUFFICIENT_RIGHTS })).filter(Boolean)).toEqual([])
+  })
+
+  test("a property the instance does not carry is absent, not blank", () => {
+    const identity = mapProperties({ status: 200, body: `{"result":[{"name":"glide.buildname","value":""}]}` })
+
+    expect(identity.release).toBeUndefined()
+    expect(identity.edition).toBeUndefined()
+  })
+})
+
+describe("the manifest advises about a table, and never outranks the probe", () => {
+  const manifest = loadRolesManifest()
+
+  test("a table the manifest knows lists the roles that can read it", () => {
+    const advice = summarizeTableAccess(manifest, "sys_update_xml", [])
+
+    expect(advice.missingRoles).toEqual(["teamdev_user", "update_set_admin", "update_set_previewer", "upgrade_admin"])
+    expect(advice.scriptAcls).toBe(0)
+  })
+
+  test("held admin satisfies every table, including the ones no ACL names it on", () => {
+    // admin bypasses ACLs outright, so it appears in almost no ACL row —
+    // neither sys_update_set's nor sys_user_has_role's. A naive intersection
+    // calls an admin connection blocked on both, which is the modal connection
+    // and the two tables an operations pass exists to read.
+    expect(summarizeTableAccess(manifest, "sys_update_set", ["admin"]).missingRoles).toEqual([])
+    expect(summarizeTableAccess(manifest, "sys_user_has_role", ["admin"]).missingRoles).toEqual([])
+  })
+
+  test("one role off the list is enough, because the list is an OR", () => {
+    expect(summarizeTableAccess(manifest, "sys_update_xml", ["update_set_admin"]).missingRoles).toEqual([])
+    expect(summarizeTableAccess(manifest, "sys_update_xml", ["itil"]).missingRoles.length).toBeGreaterThan(0)
+  })
+
+  test("public is never offered as a role to ask for, and a table that names it needs none", () => {
+    // sys_user read folds to {public, snc_internal} on all nineteen of its
+    // primitives. Rendering "ask for snc_internal" would tell every connection
+    // on earth it cannot read a user record.
+    expect(summarizeTableAccess(manifest, "sys_user", []).missingRoles).toEqual([])
+  })
+
+  test("a table the manifest has never seen produces no advice rather than a guess", () => {
+    expect(summarizeTableAccess(manifest, "u_no_such_table", [])).toEqual({ missingRoles: [], scriptAcls: 0 })
+  })
+
+  test("scriptAcls comes back even where the role list is satisfied", () => {
+    // It is reported on every table, not only where it is non-zero: the count
+    // comes from the ACL `script` column alone, so 0 means "no scripted ACL
+    // was seen", never "no row filter applies".
+    expect(summarizeTableAccess(manifest, "sys_properties", ["snc_internal"]).scriptAcls).toBe(1)
+  })
+
+  test("the manifest's own age is passed through, because the advice expires", () => {
+    expect(manifestStamp(manifest).validatedOn).toContain("glide-")
+    expect(manifestStamp(manifest).testedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(manifestStamp(undefined)).toEqual({ validatedOn: undefined, testedAt: undefined })
   })
 })
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/auth.ts
@@ -53,6 +53,19 @@ function extractSnError(error: any): string {
   return error?.message || `HTTP ${status}`
 }
 
+/**
+ * Re-throwing loses the response, and the response is the only machine-
+ * readable half of an auth failure: 401 says the credential is dead, a missing
+ * status says the request never arrived, and a caller has to be able to tell
+ * those apart without parsing English. Attached rather than re-wrapped so the
+ * shape matches what the interceptors below already hand back.
+ */
+function attachResponse<E extends Error>(error: E, from: any): E {
+  if (from?.response) (error as any).response = from.response
+  if (from?.config) (error as any).config = from.config
+  return error
+}
+
 // Extended AxiosInstance with ServiceNow helper methods
 export interface ExtendedAxiosInstance extends AxiosInstance {
   getRecord(table: string, sys_id: string): Promise<any>
@@ -169,7 +182,17 @@ export class ServiceNowAuthManager {
 
         // Normalize response structure for consistent API handling
         // ServiceNow sometimes returns data directly without 'result' wrapper
-        if (response.data && response.data.result === undefined) {
+        //
+        // `typeof data === "object"` is load-bearing, not defensive noise. A
+        // hibernating instance answers 200 with an HTML login page, so `data`
+        // is a string primitive and `data.result = []` throws "Attempted to
+        // assign to readonly property" in strict mode. That synthetic
+        // TypeError carries no `.response`, so every caller files a sleeping
+        // instance as a transport failure and htmlDiagnosis — written for
+        // exactly this page — never runs. 13 of 14 production instances are
+        // developer PDIs, which hibernate. Leaving a non-object body untouched
+        // is what lets the HTML reach the classifiers.
+        if (response.data && typeof response.data === "object" && response.data.result === undefined) {
           // If response has sys_id directly or is an array, wrap it in result
           if (response.data.sys_id || Array.isArray(response.data)) {
             response.data = { result: response.data }
@@ -524,13 +547,19 @@ export class ServiceNowAuthManager {
         mcpDebug("[Auth] Basic auth successful")
         return accessToken
       } catch (testError: any) {
-        const detail = extractSnError(testError)
-        throw new Error(`Basic auth failed: ${detail}`)
+        // Carry the response, the way every interceptor above already does.
+        // "The credential is dead" (401 on every endpoint) and "the instance
+        // could not be reached" need different answers from a caller, and
+        // before this the only place that distinction survived was inside the
+        // prose of the message below — so a caller had to regex an error
+        // string to find the status. Same rule as snow_aggregate_metrics'
+        // http_status metadata.
+        throw attachResponse(new Error(`Basic auth failed: ${extractSnError(testError)}`), testError)
       }
     } catch (error: any) {
       const detail = extractSnError(error)
       mcpDebug("[Auth] Basic auth failed:", detail)
-      throw new Error(`Authentication failed: ${detail}`)
+      throw attachResponse(new Error(`Authentication failed: ${detail}`), error)
     }
   }
 
@@ -585,13 +614,12 @@ export class ServiceNowAuthManager {
         mcpDebug("[Auth] Username/password authentication successful")
         return accessToken
       } catch (testError: any) {
-        const detail = extractSnError(testError)
-        throw new Error(`Username/password authentication failed: ${detail}`)
+        throw attachResponse(new Error(`Username/password authentication failed: ${extractSnError(testError)}`), testError)
       }
     } catch (error: any) {
       const detail = extractSnError(error)
       mcpDebug("[Auth] Username/password authentication failed:", detail)
-      throw new Error(`Authentication failed: ${detail}`)
+      throw attachResponse(new Error(`Authentication failed: ${detail}`), error)
     }
   }
 

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/instance-diagnostics.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/instance-diagnostics.ts
@@ -1,0 +1,66 @@
+/**
+ * The published face of `setup-doctor.ts`: the half that reads THE INSTANCE.
+ *
+ * `setup-doctor.ts` holds two halves either side of a line it documents at
+ * length — everything above reads the machine (`runSetupDoctor` and
+ * `resolveChain` walk environment variables and every auth.json path on disk,
+ * with mtimes), everything below reads the instance through a client the
+ * caller's own credentials produced. That line is why `snow_diagnose_setup`
+ * carries `transports: ["stdio"]` and `snow_instance_visibility` does not.
+ *
+ * A subpath in package.json that exports the whole module hands the machine-
+ * reading half to every npm consumer, including a multi-tenant backend where
+ * one process serves every tenant and "which auth.json won" is the SERVER's
+ * answer, not the asker's. That is the same thing the stdio annotation
+ * refuses, arriving through the library door instead of the tool door. So
+ * `./setup-doctor` resolves here, and this file names what may cross.
+ *
+ * Deliberately absent, and to stay absent: `runSetupDoctor`, `renderReport`
+ * and `SetupReport`. Anything inside this package that wants them imports
+ * `./setup-doctor.js` directly — the relative path is not the boundary.
+ */
+
+export {
+  classifyApiResponse,
+  classifyDateCanary,
+  classifyInvalidQuery,
+  classifyReachability,
+  classifyRoles,
+  classifyTableRead,
+  classifyTokenResponse,
+  classifyTransportFailure,
+  dateFunctionCanary,
+  heldRoles,
+  htmlDiagnosis,
+  inspectInstanceUrl,
+  invalidQueryProbe,
+  loadRolesManifest,
+  manifestStamp,
+  mapProperties,
+  probeHeldRoles,
+  probeReach,
+  probeTableRead,
+  readInstanceIdentity,
+  summarizeRoleCoverage,
+  summarizeTableAccess,
+} from "./setup-doctor.js"
+
+export type {
+  Check,
+  CheckStatus,
+  CheckStep,
+  DateFunctions,
+  DateVerdict,
+  HeldRoles,
+  InstanceIdentity,
+  InvalidQuery,
+  InvalidQueryVerdict,
+  Observed,
+  Probed,
+  ProbeClient,
+  Reach,
+  RoleCoverage,
+  TableAdvice,
+  TableRead,
+  TransportFailure,
+} from "./setup-doctor.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/shared/setup-doctor.ts
@@ -63,6 +63,12 @@ export interface Observed {
   contentType?: string
   body: string
   location?: string
+  /**
+   * `x-total-count`, verbatim. Only the instance probes below ask for it — the
+   * setup walk reads one row and never counts — so it is absent on everything
+   * the six checks classify.
+   */
+  totalCount?: string
 }
 
 /** A request that never got a response: DNS, TCP, TLS, or a timeout. */
@@ -70,6 +76,9 @@ export interface TransportFailure {
   code?: string
   message: string
 }
+
+/** Either the instance answered, or the request never got there. Never both. */
+export type Probed = { observed: Observed } | { failure: TransportFailure }
 
 export interface SetupReport {
   ok: boolean
@@ -832,10 +841,7 @@ const summarizeAuthFile = (path: string): { instance?: string; modified: string 
 // Probing — observe only, decide nothing
 // ---------------------------------------------------------------------------
 
-const probe = async (
-  url: string,
-  authorization?: string,
-): Promise<{ observed: Observed } | { failure: TransportFailure }> =>
+const probe = async (url: string, authorization?: string): Promise<Probed> =>
   fetch(url, {
     headers: { Accept: "application/json", ...(authorization ? { Authorization: authorization } : {}) },
     // Manual: a redirect to a login page is a finding, and following it would
@@ -905,8 +911,13 @@ const transportFailure = (error: unknown): TransportFailure => {
  * answers every request — REST included — with an HTML page, so every tool
  * looks like it has a JSON parse bug. Detected by content, because the status
  * is usually 200 and the content-type is not always set.
+ *
+ * Exported because the instance probes below have to make the same call before
+ * they may report a 200 as a successful read: an HTML page carries no
+ * x-total-count, so a hibernating instance would otherwise come back as "every
+ * table readable, every table empty".
  */
-const htmlDiagnosis = (step: CheckStep, observed: Observed): Check | undefined => {
+export const htmlDiagnosis = (step: CheckStep, observed: Observed): Check | undefined => {
   const isHtml = (observed.contentType ?? "").includes("text/html") || /^\s*<(!doctype|html)/i.test(observed.body)
   if (!isHtml) return undefined
 
@@ -937,7 +948,51 @@ const htmlDiagnosis = (step: CheckStep, observed: Observed): Check | undefined =
   }
 }
 
-const classifyRoles = (observed: Observed): Check => {
+/**
+ * The roles the authenticated account holds, as the sys_user_has_role page
+ * came back — no verdict attached.
+ *
+ * Split out of `classifyRoles` so a caller can have the list and the
+ * truncation flag as data rather than as prose inside a report. `truncated` is
+ * the important half: the query asks for one ROLE_ROWS_CAP-row page with no
+ * ORDERBY, so a full page means the list is a floor and the account holds an
+ * unknown number more. Deciding anything from `held` alone on a truncated read
+ * — "this account cannot reach that table" — is wrong in exactly the direction
+ * that hurts, because the accounts that overflow the page are the admins.
+ */
+export interface HeldRoles {
+  /** Distinct role names, sorted. Empty when the read was refused. */
+  held: string[]
+  /** The page came back full: `held` is a floor, not an inventory. */
+  truncated: boolean
+  /**
+   * False when the instance refused the read — which needs a role of its own —
+   * or answered something that is not a role list at all.
+   */
+  readable: boolean
+  httpStatus: number
+}
+
+export const heldRoles = (observed: Observed): HeldRoles => {
+  const rows = asArray(asRecord(parseJson(observed.body))?.result) ?? []
+  return {
+    held: [
+      ...new Set(
+        rows.map((row) => str(asRecord(row)?.["role.name"])).filter((role): role is string => role !== undefined),
+      ),
+    ].sort(),
+    truncated: rows.length >= ROLE_ROWS_CAP,
+    // The status alone is not enough: a hibernating instance answers 200 with
+    // an HTML login page, which parses to zero rows. Reading that as "readable,
+    // holds nothing" is the same fabrication a 403 produces — an empty list
+    // presented as a measurement — and every role-coverage number downstream
+    // is then computed from a page that never mentioned roles.
+    readable: observed.status === 200 && htmlDiagnosis("roles", observed) === undefined,
+    httpStatus: observed.status,
+  }
+}
+
+export const classifyRoles = (observed: Observed): Check => {
   const html = htmlDiagnosis("roles", observed)
   if (html) return html
 
@@ -957,15 +1012,11 @@ const classifyRoles = (observed: Observed): Check => {
       ],
     }
 
-  const rows = asArray(asRecord(body)?.result) ?? []
-  const held = [
-    ...new Set(rows.map((row) => str(asRecord(row)?.["role.name"])).filter((role): role is string => role !== undefined)),
-  ].sort()
+  const { held, truncated } = heldRoles(observed)
 
-  const capped =
-    rows.length >= ROLE_ROWS_CAP
-      ? [`the query returned its full ${ROLE_ROWS_CAP}-row page, so this list is cut off and the counts below are a floor`]
-      : []
+  const capped = truncated
+    ? [`the query returned its full ${ROLE_ROWS_CAP}-row page, so this list is cut off and the counts below are a floor`]
+    : []
 
   // Admin accounts hold hundreds of roles; the list is a hint, not an inventory.
   const listed = held.length > 12 ? `${held.slice(0, 12).join(", ")} and ${held.length - 12} more` : held.join(", ")
@@ -1018,6 +1069,552 @@ const classifyRoles = (observed: Observed): Check => {
       "This is not a setup error — it is what the account can do. Ask an admin for the role a failing tool needs.",
     ],
   }
+}
+
+// ---------------------------------------------------------------------------
+// Instance probes — what the caller's own credential can see
+// ---------------------------------------------------------------------------
+
+/**
+ * WHERE THE LINE IS, and why it decides which transports a tool runs on.
+ *
+ * Everything above reads THE MACHINE. `runSetupDoctor` and `resolveChain` walk
+ * environment variables, every known auth.json path and its mtime, and report
+ * which of them won. On HTTP one process serves every tenant, so that report
+ * describes the SERVER's configuration to whoever asked — which is why
+ * `snow_diagnose_setup` carries `transports: ["stdio"]`.
+ *
+ * Everything below reads THE INSTANCE, through a client the caller's own
+ * credentials produced. It reads no file, no environment variable, and it must
+ * never call `runSetupDoctor` or `resolveChain` — the moment it does, the tool
+ * on top of it stops being HTTP-safe and the transport annotation that says so
+ * is nowhere near this file. That is the whole of why
+ * `snow_instance_visibility` runs on both transports and its neighbour does
+ * not. Keep the line where it is.
+ */
+
+/**
+ * Just enough of the authenticated axios client to issue a bounded GET.
+ *
+ * Structural on purpose: this module still imports nothing from `auth.ts`, the
+ * tool passes the real client in, and the probes stay callable with anything
+ * that answers a GET.
+ */
+export interface ProbeClient {
+  get(url: string, config?: { params?: Record<string, string | number> }): Promise<unknown>
+}
+
+/** A table read as the probe saw it. Advice from the manifest is not in here. */
+export interface TableRead {
+  table: string
+  /** True only for a 2xx that was not an HTML page. */
+  readable: boolean
+  /** Absent when the request never got an answer at all. */
+  httpStatus?: number
+  /**
+   * The machine-readable reason a 2xx was still not a read:
+   * `instance-hibernating` or `html-instead-of-json`, the same codes
+   * `htmlDiagnosis` puts on a Check. Absent otherwise, because every other
+   * refusal is already named by `httpStatus`.
+   *
+   * Without it `readable: false, httpStatus: 200` is the one row a consumer
+   * cannot classify from the status alone — and on a sleeping developer
+   * instance that is every row.
+   */
+  code?: string
+  /**
+   * Rows in scope, from `x-total-count`. `null` — never `0` — when the
+   * instance sent no count: "could not be counted" and "holds nothing" are
+   * opposite answers for anyone deciding whether a zero on this table is real.
+   */
+  lifetime: number | null
+  /**
+   * The window `lifetime` was counted over; `null` when it is the whole table.
+   *
+   * Read it beside the date canary. On an instance where `javascript:` does
+   * not resolve, a bounded count IS the whole table wearing a window's label,
+   * and the two are returned from the same call so nobody has to trust one
+   * without the other.
+   */
+  lifetimeWindowDays: number | null
+  /** What went wrong, verbatim, when the read did not succeed. */
+  error?: string
+}
+
+/** What the role manifest advises about reading a table. Advice, never evidence. */
+export interface TableAdvice {
+  /** Roles that would unlock the read, minus the ones the account already holds. */
+  missingRoles: string[]
+  /**
+   * How many of the matching ACLs carry a condition or an advanced script.
+   * Those run per record and the probe behind the manifest never evaluated
+   * them, so a role list with `scriptAcls > 0` is necessary but may not be
+   * sufficient — and `acl-resolve.ts` computes this from the `script` column
+   * alone, so the ordinary condition-based row filter is not even counted.
+   */
+  scriptAcls: number
+}
+
+export type DateVerdict = "resolved" | "evaporated" | "inconclusive"
+
+export interface DateFunctions {
+  /** The date function under test, as it appears in the clause. */
+  fn: string
+  verdict: DateVerdict
+  /** Rows matched by a clause that cannot match anything. `null` when the count failed. */
+  canary: number | null
+  /** Rows on the whole table — what a dropped clause returns instead. */
+  total: number | null
+}
+
+export type InvalidQueryVerdict = "ignores" | "returns_no_rows" | "unknown"
+
+export interface InvalidQuery {
+  verdict: InvalidQueryVerdict
+  /** The column that does not exist, so a reader can reproduce the call. */
+  field: string
+  /** Rows the instance matched for a condition on it. */
+  matched: number | null
+  total: number | null
+}
+
+export interface InstanceIdentity {
+  /** `glide.buildname` — the release family, e.g. "Zurich". */
+  release?: string
+  /** `glide.buildtag` — the exact build, patch and hotfix. */
+  buildTag?: string
+  /**
+   * `glide.buildname` again, under the name the portal's
+   * `servicenow_instance_discovered.build_name` column already carries. Same
+   * property, two readers: one wants the label "Release", the other wants its
+   * column filled with what was always meant to be in it.
+   */
+  buildName?: string
+  /** `glide.license.edition`. */
+  edition?: string
+  /**
+   * `glide.product.description` — the licensed product line ("Service
+   * Management"), NOT a release. Kept because it is worth showing, and named
+   * so nobody prints it under a Release heading again.
+   */
+  productDescription?: string
+  /** Active plugins, counted rather than listed. `null` when v_plugin refused. */
+  pluginCount: number | null
+  /**
+   * Whether domain separation is installed. There is no `not_separated`: the
+   * plugin id below is uncorroborated in ServiceNow's own documentation, so an
+   * absent row is "we did not find it", never "this instance does not have it".
+   */
+  domainSeparated: "separated" | "unknown"
+  /** The domain of the account the tools run as, when the instance names one. */
+  integrationUserDomain?: string
+}
+
+/** The four properties worth asking for, as one OR'd read. */
+const IDENTITY_PROPERTIES = ["glide.buildname", "glide.buildtag", "glide.license.edition", "glide.product.description"]
+
+/**
+ * A column no instance has. Asking for a condition on it is the only way to
+ * find out which of ServiceNow's two invalid-query regimes is in force, and
+ * the prefix makes it obvious in a log who asked and why.
+ */
+const CANARY_FIELD = "serac_canary_no_such_field"
+
+/** Whether the API answers this credential at all, and who it answers as. */
+export interface Reach {
+  check: Check
+  /** The caller's own domain, when the instance names one. */
+  domain?: string
+}
+
+/**
+ * The authenticated cousin of `classifyReachability`: that one asks whether the
+ * HOST behaves like a ServiceNow instance before any credential exists, this
+ * one asks whether the REST API accepts the credential in hand and who it
+ * thinks is calling. Every other probe below is worthless without it — a 401
+ * here means every table would come back unreadable for one reason that has
+ * nothing to do with the tables.
+ *
+ * The domain rides along because it comes off the same row: `sys_domain.name`
+ * where domain separation is installed, the raw reference otherwise, and
+ * nothing at all where the plugin is not there — ServiceNow drops an unknown
+ * field from `sysparm_fields` rather than refusing the read.
+ *
+ * WHAT THIS ROW IS NOT ALLOWED TO ASK FOR. `user_name` and `name` are absent
+ * on purpose: they are the integration account's login and the human display
+ * name behind it, and this Check is returned as data and rendered by whoever
+ * called — stored, not read once by the person who owns the credential, which
+ * is the whole difference from snow_diagnose_setup. The field list is the
+ * control, so the title is overridden below rather than the name being asked
+ * for and then dropped. `active` stays: it is not personal and it is the only
+ * way to report "that account is marked inactive", which is a real cause of an
+ * instance that answers nothing.
+ */
+export const probeReach = async (client: ProbeClient): Promise<Reach> => {
+  const seen = await answered(
+    client.get("/api/now/table/sys_user", {
+      params: {
+        sysparm_query: "sys_id=javascript:gs.getUserID()",
+        sysparm_fields: "active,sys_domain,sys_domain.name",
+        sysparm_limit: 1,
+      },
+    }),
+  )
+  if ("failure" in seen) return { check: classifyTransportFailure(seen.failure) }
+
+  // classifyApiResponse keeps naming the account — the stdio doctor prints it
+  // to the one person who owns that credential and wants to see which account
+  // it resolved to. Here the same sentence would travel, so the fact replaces
+  // the person. With no `user_name` in the row it would read "Authenticated as
+  // unknown" anyway.
+  const check = classifyApiResponse(seen.observed)
+  const user = asRecord(asArray(asRecord(parseJson(seen.observed.body))?.result)?.[0])
+  return {
+    check: check.code === "api-ok" ? { ...check, title: "The REST API accepted this credential." } : check,
+    domain: str(user?.["sys_domain.name"]) ?? str(user?.sys_domain),
+  }
+}
+
+/**
+ * The roles the authenticated account holds, read the way
+ * `snow_session_context` and the setup walk already read them: `user=` alone,
+ * no filter on `state`, one page of `ROLE_ROWS_CAP`.
+ *
+ * Reading sys_user_has_role needs a role of its own, so a refusal is a finding
+ * — `readable: false` with an empty list — and never an exception.
+ */
+export const probeHeldRoles = async (client: ProbeClient): Promise<HeldRoles> => {
+  const seen = await answered(
+    client.get("/api/now/table/sys_user_has_role", {
+      params: {
+        sysparm_query: "user=javascript:gs.getUserID()",
+        sysparm_fields: "role.name",
+        sysparm_limit: ROLE_ROWS_CAP,
+      },
+    }),
+  )
+  return "failure" in seen
+    ? { held: [], truncated: false, readable: false, httpStatus: 0 }
+    : heldRoles(seen.observed)
+}
+
+/**
+ * Can this connection read this table, and how much is in it?
+ *
+ * The sole authority on `readable`. A static role map cannot answer this —
+ * `admin` bypasses ACLs without appearing in any ACL row, `public` is not a
+ * grantable role, and the held-role list is capped — so anything that decides
+ * "unreadable" from the manifest is guessing, and guesses wrong on precisely
+ * the admin-credentialled developer instances most connections turn out to be.
+ *
+ * `lifetimeDays` bounds the count by `sys_created_on` (creation, not update:
+ * a lifetime is about when the rows came into existence). A table that refuses
+ * the bounded read is re-read UNBOUNDED before it is called unreadable — a
+ * view with no `sys_created_on` would otherwise be reported as "no read
+ * access" on the strength of a column the caller never asked about.
+ *
+ * A bounded read that comes back 0 is re-read for the same reason, and it is
+ * the more common half: NEITHER invalid-query regime answers 400. On a table
+ * without `sys_created_on` the ignore regime drops the clause and hands back
+ * the whole-table count wearing the window's label, and
+ * `glide.invalid_query.returns_no_rows` hands back 0 on a full table. The
+ * first is mislabelled and the second is a confident zero — the one answer a
+ * caller acts on directly ("the read succeeded and there is nothing here"),
+ * and therefore the one that must not be wrong. `v_plugin` demonstrates it:
+ * `{readable: true, lifetime: 0, lifetimeWindowDays: 365}` in the same payload
+ * whose identity block counts 412 active plugins.
+ *
+ * The cost is one extra GET on tables that would otherwise report zero. The
+ * unbounded number is reported with `lifetimeWindowDays: null`, because after
+ * a zero nothing here can show that the window was ever applied.
+ */
+export const probeTableRead = async (
+  client: ProbeClient,
+  table: string,
+  lifetimeDays: number,
+): Promise<TableRead> => {
+  const days = Number.isFinite(lifetimeDays) && lifetimeDays > 0 ? Math.floor(lifetimeDays) : 0
+  const bounded = days === 0 ? undefined : classifyTableRead(table, days, await count(client, table, since(days)))
+  if (bounded?.readable && bounded.lifetime !== 0) return bounded
+  // 400 is the instance saying it could not make sense of the request, which
+  // on a bounded read is far more likely to be the date column than the table:
+  // v_plugin is a view. A 401 or 403 is about the table itself and re-asking
+  // only spends another call to hear the same refusal.
+  if (bounded && !bounded.readable && bounded.httpStatus !== 400) return bounded
+
+  const unbounded = classifyTableRead(table, null, await count(client, table, ""))
+  // A bounded read that worked outranks an unbounded one that did not. The
+  // re-read is here to disambiguate a zero, never to demote a table that just
+  // answered into "no read access".
+  return bounded?.readable && !unbounded.readable ? bounded : unbounded
+}
+
+/** Does `javascript:` actually resolve in an encoded query on this instance? */
+export const dateFunctionCanary = async (
+  client: ProbeClient,
+  table: string,
+  fn: string,
+  total: number | null,
+): Promise<DateFunctions> => {
+  // ONE count, with a clause that contradicts itself: no row can be created
+  // both at or after an instant and before the same instant. Zero is the only
+  // correct answer, so anything else is the clause not being applied. The
+  // three-count partition this replaces raced against its own table — one row
+  // written between the counts satisfied none of its branches — and `sys_user`
+  // is the highest-churn table on any instance with LDAP, SSO or an HR import.
+  const clause = `sys_created_on>=javascript:${fn}(0)^sys_created_on<javascript:${fn}(0)`
+  const canary = counted(await count(client, table, clause))
+  return { fn, verdict: classifyDateCanary(canary, total), canary, total }
+}
+
+/**
+ * Which of the two invalid-query regimes this instance is in.
+ *
+ * Worth one call per pass because it inverts the reading of every other number
+ * here. Under the ignore regime a condition the instance cannot apply is
+ * dropped and the query answers for the whole table; under
+ * `glide.invalid_query.returns_no_rows` the same condition answers zero. A
+ * confident `0` and a confident total are the same failure wearing opposite
+ * clothes, and nothing in the response distinguishes them.
+ */
+export const invalidQueryProbe = async (
+  client: ProbeClient,
+  table: string,
+  total: number | null,
+): Promise<InvalidQuery> => {
+  const matched = counted(await count(client, table, `${CANARY_FIELD}=1`))
+  return { field: CANARY_FIELD, verdict: classifyInvalidQuery(matched, total), matched, total }
+}
+
+/**
+ * Which instance this is: release, build, edition, plugin count, domain scope.
+ *
+ * `domain` is the caller's own, taken from the `sys_user` row the reach check
+ * already read rather than costing a second one.
+ */
+export const readInstanceIdentity = async (client: ProbeClient, domain?: string): Promise<InstanceIdentity> => {
+  const properties = await answered(
+    client.get("/api/now/table/sys_properties", {
+      params: {
+        sysparm_query: `nameIN${IDENTITY_PROPERTIES.join(",")}`,
+        sysparm_fields: "name,value",
+        sysparm_limit: IDENTITY_PROPERTIES.length,
+      },
+    }),
+  )
+
+  // Two bounded counts rather than one page of rows. discoverPlugins reads 50
+  // plugins ordered by sys_updated_on under a comment that already anticipates
+  // "200+ entries", so both the count and the com.glide.domain test would be
+  // decided by a recency window that can exclude the very row being looked for.
+  const plugins = counted(await count(client, "v_plugin", "active=true"))
+  const domains = counted(await count(client, "v_plugin", "active=true^id=com.glide.domain"))
+
+  return {
+    ...("failure" in properties ? {} : mapProperties(properties.observed)),
+    pluginCount: plugins,
+    domainSeparated: domains > 0 ? "separated" : "unknown",
+    integrationUserDomain: domain,
+  }
+}
+
+/**
+ * The four properties, mapped onto the names a reader means by them.
+ *
+ * `release` is `glide.buildname`. It is NOT `glide.product.description`, which
+ * holds the licensed product line — the portal's own discovery mapped its
+ * `version` column from the description with buildname as a fallback, which is
+ * why every instance it stored reads "Service Management" under a heading that
+ * says Release. Both come back here so no consumer has to choose.
+ */
+export const mapProperties = (observed: Observed): Partial<InstanceIdentity> => {
+  const rows = observed.status === 200 ? (asArray(asRecord(parseJson(observed.body))?.result) ?? []) : []
+  const values = new Map(rows.map((row) => [str(asRecord(row)?.name), str(asRecord(row)?.value)]))
+  return {
+    release: values.get("glide.buildname"),
+    buildTag: values.get("glide.buildtag"),
+    buildName: values.get("glide.buildname"),
+    edition: values.get("glide.license.edition"),
+    productDescription: values.get("glide.product.description"),
+  }
+}
+
+/** What the probe saw, turned into a verdict. Pure — the network part only observes. */
+export const classifyTableRead = (table: string, lifetimeWindowDays: number | null, probed: Probed): TableRead => {
+  if ("failure" in probed)
+    return {
+      table,
+      readable: false,
+      lifetime: null,
+      lifetimeWindowDays,
+      error: `${probed.failure.code ? `${probed.failure.code}: ` : ""}${probed.failure.message}`,
+    }
+
+  const observed = probed.observed
+  const html = htmlDiagnosis("api", observed)
+  if (html)
+    return {
+      table,
+      readable: false,
+      httpStatus: observed.status,
+      code: html.code,
+      lifetime: null,
+      lifetimeWindowDays,
+      error: html.title,
+    }
+
+  if (observed.status < 200 || observed.status > 299)
+    return {
+      table,
+      readable: false,
+      httpStatus: observed.status,
+      lifetime: null,
+      lifetimeWindowDays,
+      error: [`HTTP ${observed.status}`, said(observed)].filter(Boolean).join(" — "),
+    }
+
+  return { table, readable: true, httpStatus: observed.status, lifetime: counted(probed), lifetimeWindowDays }
+}
+
+/**
+ * `L === 0` is tested FIRST, against the order the design prose gives.
+ *
+ * On an empty table the self-contradictory clause answers 0 whether it was
+ * applied or dropped, so the count is evidence of nothing and calling it
+ * `resolved` would hand a downgrade to every suspect figure on the instance.
+ * A table with rows separates the two: 0 means the clause was applied, and the
+ * whole table means it was not.
+ *
+ * One interaction worth knowing rather than encoding: under
+ * `glide.invalid_query.returns_no_rows` a clause the instance cannot apply
+ * also answers 0, so `resolved` on such an instance means "either the function
+ * resolves or nothing survives an unusable clause". `invalidQueryProbe` names
+ * that regime in the same pass; folding it in here would hide which of the two
+ * measurements the verdict came from.
+ */
+export const classifyDateCanary = (canary: number | null, total: number | null): DateVerdict => {
+  if (canary === null || total === null || total === 0) return "inconclusive"
+  if (canary === 0) return "resolved"
+  if (canary === total) return "evaporated"
+  // Unreachable on a still table: a dropped clause returns everything and an
+  // applied one returns nothing. Reached when rows were written mid-probe.
+  return "inconclusive"
+}
+
+/**
+ * A 400 lands here as `unknown`: an instance that refuses an unknown column
+ * outright is a third behaviour, and the two names below would both be lies
+ * about it.
+ */
+export const classifyInvalidQuery = (matched: number | null, total: number | null): InvalidQueryVerdict => {
+  if (matched === null || total === null || total === 0) return "unknown"
+  if (matched === total) return "ignores"
+  if (matched === 0) return "returns_no_rows"
+  return "unknown"
+}
+
+/**
+ * What the manifest says about reading one table, folded across every tool
+ * that reads it, minus what the account already holds.
+ *
+ * Advice, not evidence: it answers "which role would you ask for", never
+ * "can you read this" — `probeTableRead` owns that. Three of the manifest's
+ * own properties are honoured here rather than in the caller, because getting
+ * any of them wrong turns advice into a wrong refusal:
+ *
+ *  - held `admin` satisfies everything. It bypasses ACLs outright and
+ *    therefore appears in almost no ACL row: `admin` is in the read list of
+ *    exactly one of the ten tables an operations pass looks at.
+ *  - `public` is ServiceNow's "no authentication required" marker, not a role
+ *    anyone can be granted, so it never appears in advice — and a primitive
+ *    that names it needs nothing, the way the manifest's own `minimumBundle`
+ *    already treats it.
+ *  - a primitive whose role list is EMPTY means ACL rows exist and name no
+ *    role, which any authenticated caller passes.
+ *
+ * Both of the last two would otherwise demand a role for a table that needs
+ * none: `sys_user` read folds to {public, snc_internal} on every one of its
+ * nineteen primitives, so a naive subtraction tells every connection on earth
+ * to go ask for snc_internal before it can read a user record.
+ */
+export const summarizeTableAccess = (manifest: unknown, table: string, held: string[]): TableAdvice => {
+  const primitives = Object.values(asRecord(asRecord(manifest)?.tools) ?? {})
+    .flatMap((tool) => asArray(asRecord(tool)?.primitives) ?? [])
+    .map((primitive) => asRecord(primitive))
+    .filter((primitive) => str(primitive?.table) === table && str(primitive?.operation) === "read")
+
+  const roles = primitives.map((primitive) => (asArray(primitive?.roles) ?? []).map(String))
+  const grantable = [...new Set(roles.flat().filter((role) => role !== "public"))].sort()
+  const owned = new Set(held)
+  const satisfied =
+    owned.has("admin") ||
+    roles.some((list) => list.length === 0 || list.includes("public")) ||
+    grantable.length === 0 ||
+    grantable.some((role) => owned.has(role))
+
+  return {
+    missingRoles: satisfied ? [] : grantable,
+    scriptAcls: primitives.reduce(
+      (worst, primitive) => Math.max(worst, typeof primitive?.scriptAcls === "number" ? primitive.scriptAcls : 0),
+      0,
+    ),
+  }
+}
+
+/** The manifest's own staleness signal, passed through to whoever renders its advice. */
+export const manifestStamp = (manifest: unknown): { validatedOn?: string; testedAt?: string } => ({
+  validatedOn: str(asRecord(manifest)?.validatedOn),
+  testedAt: str(asRecord(manifest)?.testedAt),
+})
+
+/** One bounded read whose answer is the `x-total-count` header, not the row. */
+const count = (client: ProbeClient, table: string, query: string): Promise<Probed> =>
+  answered(
+    client.get(`/api/now/table/${encodeURIComponent(table)}`, {
+      params: { ...(query === "" ? {} : { sysparm_query: query }), sysparm_limit: 1, sysparm_fields: "sys_id" },
+    }),
+  )
+
+/**
+ * A GET that resolves either way. Axios rejects on 4xx, and the shared
+ * client's interceptor rejects a 200 whose body carries a ServiceNow error as
+ * well; both attach the response, and a refusal is a finding here rather than
+ * an exception.
+ */
+const answered = (result: Promise<unknown>): Promise<Probed> =>
+  result
+    .then((response): Probed => ({ observed: observe(response) }))
+    .catch((error: unknown): Probed => {
+      const response = asRecord(error)?.response
+      return response ? { observed: observe(response) } : { failure: transportFailure(error) }
+    })
+
+/** An axios response as an `Observed`, so the classifiers above work unchanged. */
+const observe = (response: unknown): Observed => {
+  const record = asRecord(response)
+  const headers = asRecord(record?.headers)
+  const data = record?.data
+  return {
+    status: typeof record?.status === "number" ? record.status : 0,
+    contentType: str(headers?.["content-type"]),
+    body: (typeof data === "string" ? data : JSON.stringify(data ?? null)).slice(0, BODY_CAP),
+    totalCount: str(headers?.["x-total-count"]),
+  }
+}
+
+const since = (days: number) => `sys_created_on>=javascript:gs.daysAgoStart(${days})`
+
+/** The count a probe came back with, or null — never 0 — when there was none. */
+const counted = (probed: Probed): number | null => {
+  if ("failure" in probed) return null
+  const total = probed.observed.totalCount
+  return probed.observed.status === 200 && total !== undefined && /^\d+$/.test(total) ? Number(total) : null
+}
+
+/** What ServiceNow said about a refusal, when it said anything. */
+const said = (observed: Observed): string => {
+  const error = asRecord(parseJson(observed.body)?.error)
+  return str(error?.message) ?? str(error?.detail) ?? ""
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/aggregators/snow_aggregate_metrics.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/aggregators/snow_aggregate_metrics.ts
@@ -113,7 +113,17 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       // A rejected call is nearly always about the parameters, so carry the
       // same request detail the success path carries. Arguments refused before
       // the request went out have none, and get an empty metadata object.
-      error?.snow_request ?? {},
+      //
+      // http_status rides along beside it because 403, 401 and 400 need three
+      // different responses — ask for a role, re-authenticate, fix the query —
+      // and the only other place that distinction survives is inside the
+      // prose. A caller should not have to regex an error message to find out
+      // which of the three happened; a call refused before it went out has no
+      // status, and the field is absent rather than guessed at.
+      {
+        ...(error?.snow_request ?? {}),
+        ...(typeof error?.response?.status === "number" ? { http_status: error.response.status } : {}),
+      },
     )
   })
 }
@@ -314,5 +324,5 @@ function summarize(
   ].join("\n")
 }
 
-export const version = "1.1.0"
+export const version = "1.2.0"
 export const author = "Serac SDK Migration"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/snow_query_table.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/operations/snow_query_table.ts
@@ -126,66 +126,94 @@ export const toolDefinition: MCPToolDefinition = {
   },
 }
 
-export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
-  const {
-    table,
-    query = "",
-    limit = 100,
-    offset = 0,
-    truncate_output = true,
-  } = args
+/**
+ * Translate the tool's arguments into Table API query parameters.
+ *
+ * Exported and pure for the same reason `buildStatsParams` is: the ordering
+ * clause is the whole of what this tool got wrong, and it is decidable without
+ * an instance. `order_by: "sys_created_on"` used to emit
+ * `^ORDERBYASCsys_created_on` — ASC is not part of any ServiceNow operator, so
+ * the instance dropped the clause and answered in its own order. The caller
+ * asked for the oldest record and got an arbitrary one, with nothing in the
+ * response to say so; the descending direction, spelled ORDERBYDESC, worked
+ * the whole time, which is why this survived.
+ *
+ * Throws on input the API cannot act on, the way buildStatsParams does.
+ */
+export function buildQueryParams(args: any) {
+  const table = String(args.table ?? "").trim()
+  if (!table) throw new Error("table is required")
 
   // Be permissive: LLMs routinely send snake_case OR camelCase, and `fields`
   // as array OR comma-separated string. Normalize before use — a wrongly-typed
   // string would otherwise spread character-by-character into params.
-  const rawFields = args.fields ?? []
-  const fields: string[] = Array.isArray(rawFields)
-    ? rawFields
-    : typeof rawFields === "string"
-    ? rawFields.split(",").map((s) => s.trim()).filter(Boolean)
+  const raw = args.fields ?? []
+  const fields: string[] = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+    ? raw.split(",").map((s) => s.trim()).filter(Boolean)
     : []
-  const order_by: string | undefined = args.order_by ?? args.orderBy
-  const display_value: boolean = args.display_value ?? args.displayValue ?? false
+  const order: string = String(args.order_by ?? args.orderBy ?? "").trim()
+  const display: boolean = args.display_value ?? args.displayValue ?? false
+  const query = String(args.query ?? "").trim()
+  // Coerced here, once, because these two leave this function as numbers used
+  // in arithmetic: `has_more` is `offset + records.length < total`, and a
+  // string offset makes that `"100" + 25 === "10025"` — "there is no more" on
+  // page two of a long table, silently. Same reason `limit` is coerced: it is
+  // compared with `===` against a length. LLM callers send both as strings.
+  const limit = numeric(args.limit, 100)
+  const offset = numeric(args.offset, 0)
+
+  // ORDERBY<field> ascending, ORDERBYDESC<field> descending — those are the two
+  // operators. It joins onto the caller's own conditions with ^, and stands
+  // alone when there are none rather than leading with a bare separator.
+  const ordered = order === "" ? "" : `ORDERBY${order.startsWith("-") ? "DESC" : ""}${order.replace(/^-/, "")}`
+  const conditions = [query, ordered].filter(Boolean).join("^")
+
+  const params: any = { sysparm_limit: limit, sysparm_offset: offset }
+  if (conditions) params.sysparm_query = conditions
+  // ALWAYS include sys_id - it's essential for follow-up operations
+  if (fields.length > 0) params.sysparm_fields = (fields.includes("sys_id") ? fields : ["sys_id", ...fields]).join(",")
+  if (display) params.sysparm_display_value = "true"
+
+  return { table, query, fields, limit, offset, params }
+}
+
+/** A non-negative whole number, or the default. Anything else is not a count. */
+function numeric(raw: unknown, fallback: number): number {
+  const value =
+    typeof raw === "number" ? raw : typeof raw === "string" && raw.trim() !== "" ? Number(raw.trim()) : Number.NaN
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : fallback
+}
+
+/**
+ * How many records the query really matches, from `x-total-count`. Undefined
+ * rather than a number when the instance did not send the header, so the
+ * caller sees no total at all instead of a made-up one: this field used to
+ * read `"100+"` whenever the page filled, a string that is not the count, not
+ * a bound anyone verified, and not distinguishable from a real answer.
+ */
+export function readTotal(headers: Record<string, unknown> | undefined): number | undefined {
+  const total = headers?.["x-total-count"] ?? headers?.["X-Total-Count"]
+  return typeof total === "string" && /^\d+$/.test(total) ? Number(total) : undefined
+}
+
+export async function execute(args: any, context: ServiceNowContext): Promise<ToolResult> {
+  const truncate_output = args.truncate_output ?? true
 
   try {
     const client = await getAuthenticatedClient(context)
-
-    // Build query parameters
-    const params: any = {
-      sysparm_limit: limit,
-      sysparm_offset: offset,
-    }
-
-    if (query) {
-      params.sysparm_query = query
-    }
-
-    if (fields.length > 0) {
-      // ALWAYS include sys_id - it's essential for follow-up operations
-      const fieldsWithSysId = fields.includes("sys_id") ? fields : ["sys_id", ...fields]
-      params.sysparm_fields = fieldsWithSysId.join(",")
-    }
-
-    if (order_by) {
-      // Handle descending order (prefix with -)
-      const direction = order_by.startsWith("-") ? "DESC" : "ASC"
-      const field = order_by.replace(/^-/, "")
-      params.sysparm_query = (params.sysparm_query || "") + `^ORDERBY${direction}${field}`
-    }
-
-    if (display_value) {
-      params.sysparm_display_value = "true"
-    }
+    const plan = buildQueryParams(args)
 
     // Execute query
-    const response = await client.get(`/api/now/table/${table}`, { params })
+    const response = await client.get(`/api/now/table/${plan.table}`, { params: plan.params })
 
     const rawRecords = response.data.result
     const records = truncateRecords(rawRecords, truncate_output)
 
     // Build a human-readable summary with record preview
     const summaryLines: string[] = []
-    summaryLines.push(`Found ${records.length} record(s) in ${table}`)
+    summaryLines.push(`Found ${records.length} record(s) in ${plan.table}`)
 
     if (records.length > 0) {
       summaryLines.push("")
@@ -218,25 +246,22 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
       }
     }
 
-    if (records.length === limit) {
+    if (records.length === plan.limit) {
       summaryLines.push("")
       summaryLines.push(`Note: Results may be limited. Use offset parameter to paginate.`)
     }
+
+    const total = readTotal(response.headers)
 
     return createSuccessResult(
       {
         records,
         count: records.length,
-        total: records.length < limit ? records.length : "100+", // Actual total requires additional query
-        has_more: records.length === limit,
+        ...(total === undefined ? {} : { total }),
+        has_more: total === undefined ? records.length === plan.limit : plan.offset + records.length < total,
         truncated: truncate_output,
       },
-      {
-        table,
-        query,
-        limit,
-        offset,
-      },
+      { table: plan.table, query: plan.query, limit: plan.limit, offset: plan.offset },
       summaryLines.join("\n"),
     )
   } catch (error: any) {
@@ -244,5 +269,5 @@ export async function execute(args: any, context: ServiceNowContext): Promise<To
   }
 }
 
-export const version = "1.0.0"
+export const version = "1.1.0"
 export const author = "Serac SDK Migration"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/index.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/index.ts
@@ -12,6 +12,10 @@ export {
   execute as snow_session_context_exec,
 } from "./snow_session_context.js"
 export {
+  toolDefinition as snow_instance_visibility_def,
+  execute as snow_instance_visibility_exec,
+} from "./snow_instance_visibility.js"
+export {
   toolDefinition as snow_create_script_include_def,
   execute as snow_create_script_include_exec,
 } from "./snow_create_script_include.js"

--- a/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_instance_visibility.ts
+++ b/packages/servicenow-mcp/src/servicenow-mcp-unified/tools/platform/snow_instance_visibility.ts
@@ -1,0 +1,405 @@
+/**
+ * snow_instance_visibility — what can this connection actually SEE on this
+ * instance, are its filters real, and what instance is it?
+ *
+ * The question behind it is the one nothing answers today: "I pointed an agent
+ * at my ServiceNow instance, why does everything come back empty?" There are
+ * four different answers — the account cannot read the table, the table is
+ * genuinely empty, the filter was silently dropped so the number is about a
+ * different population than you think, or this is not the instance you meant —
+ * and a tool that reports a confident `0` for all four is worse than one that
+ * says which.
+ *
+ * So the call reports, per table, whether the read succeeds and how much sits
+ * behind it; whether `javascript:` date functions resolve at all in an encoded
+ * query; which of ServiceNow's two invalid-query regimes the instance is in;
+ * and which release, build and edition answered.
+ *
+ * WHY THIS RUNS ON HTTP AND snow_diagnose_setup DOES NOT. That tool reports the
+ * credential CHAIN — environment variables, every auth.json on the machine and
+ * its mtime — which on HTTP is the server's own configuration handed to
+ * whichever tenant asked, and its stdio-only annotation says exactly that. This
+ * one reads nothing but the instance, through the caller's own credential, so
+ * it declares no transport restriction at all. The dividing line is drawn in
+ * `shared/setup-doctor.ts`, above the probes this file calls. Do not reach
+ * across it: `runSetupDoctor` and `resolveChain` are on the other side.
+ *
+ * WHY NOT snow_check_connection. `main` already ships snow_test_connection,
+ * snow_check_health, snow_validate_live_connection, snow_auth_diagnostics and
+ * snow_diagnose_setup. A sixth name for "is it working" makes the catalog
+ * worse; this one is named for the answer it gives, not for the question.
+ */
+
+import { type MCPToolDefinition, type ServiceNowContext, type ToolResult } from "../../shared/types.js"
+import { getAuthenticatedClient } from "../../shared/auth.js"
+import { createSuccessResult, createErrorResult } from "../../shared/error-handler.js"
+import {
+  dateFunctionCanary,
+  invalidQueryProbe,
+  loadRolesManifest,
+  manifestStamp,
+  probeHeldRoles,
+  probeReach,
+  probeTableRead,
+  readInstanceIdentity,
+  summarizeRoleCoverage,
+  summarizeTableAccess,
+  type Check,
+  type DateFunctions,
+  type HeldRoles,
+  type InstanceIdentity,
+  type InvalidQuery,
+  type ProbeClient,
+  type RoleCoverage,
+  type TableAdvice,
+  type TableRead,
+} from "../../shared/setup-doctor.js"
+
+/**
+ * Every table costs one sequential GET, and a second one when the bounded read
+ * comes back 400 or 0 — the two answers that can be about the date column
+ * rather than about the table. Twenty is already a visible pause against a
+ * waking developer instance, so the cap is declared in the schema — a caller
+ * meets it before the call rather than in the latency.
+ */
+const TABLE_CAP = 20
+
+/** What one call answers. Everything optional is something the caller turned off. */
+export interface Visibility {
+  reach: Check
+  roles?: {
+    held: string[]
+    /** The held-role page came back full: `held` is a floor, not an inventory. */
+    heldTruncated: boolean
+    /**
+     * False when the instance REFUSED the held-role read — which needs a role
+     * of its own, so it is the low-privilege accounts that hit it.
+     *
+     * Carried because without it a refusal is byte-identical to an account
+     * that genuinely holds nothing: `held: []`, `heldTruncated: false`, and a
+     * coverage block computed from the empty list. A refused list is strictly
+     * less knowable than a truncated one, and the truncated one already
+     * renders as unknown rather than as blocked.
+     */
+    heldReadable: boolean
+    /** The status behind `heldReadable`. 0 when the request never arrived. */
+    heldHttpStatus: number
+    /**
+     * Absent when the held-role read was refused. `blocked: 247` computed from
+     * a refusal is not a measurement of anything, and it is the number the
+     * summary line prints.
+     */
+    coverage?: RoleCoverage
+    /** How old the advice is. Roles move between ServiceNow families. */
+    manifest: { validatedOn?: string; testedAt?: string }
+  }
+  tables: (TableRead & TableAdvice)[]
+  dateFunctions?: DateFunctions
+  invalidQuery?: InvalidQuery
+  identity?: InstanceIdentity
+  instanceUrl: string
+}
+
+export const toolDefinition: MCPToolDefinition = {
+  name: "snow_instance_visibility",
+  description:
+    "Report what this ServiceNow connection can actually see: per table whether the read succeeds (with the HTTP status and the row count behind it), which roles the account holds and which ones a refused table needs, whether javascript: date filters resolve on this instance or are silently dropped, whether a condition on an unknown column is ignored or returns no rows, and which release, build, edition and plugin count answered. Call this when queries come back empty or a filtered count looks wrong, before trusting any number from this instance. Read-only: every call is a GET.",
+  category: "platform",
+  subcategory: "diagnostics",
+  use_cases: [
+    "empty results",
+    "permissions",
+    "roles",
+    "reachability",
+    "filters",
+    "instance identity",
+    "troubleshooting",
+  ],
+  complexity: "beginner",
+  frequency: "medium",
+  permission: "read",
+  // A status surface has to exist for the read-only persona: "why is this
+  // empty" is the first question a stakeholder asks, and sending them to a
+  // developer to find out is how the answer stops being asked for.
+  allowedRoles: ["developer", "stakeholder", "admin"],
+  inputSchema: {
+    type: "object",
+    properties: {
+      tables: {
+        type: "array",
+        items: { type: "string" },
+        maxItems: TABLE_CAP,
+        default: [],
+        description: `Tables to probe for read access, one GET each (max ${TABLE_CAP}). Omit to skip the per-table probe and report only roles, filters and identity.`,
+      },
+      lifetime_days: {
+        type: "number",
+        default: 365,
+        minimum: 0,
+        description:
+          "Bound each table's row count to rows created within this many days. 0 counts the whole table. A table that refuses the bounded read, or answers 0 to it, is re-read unbounded before that answer is reported: on a table with no sys_created_on the clause is silently dropped or matches nothing, and neither shows up as an error.",
+      },
+      date_canary: {
+        type: "boolean",
+        default: true,
+        description:
+          "Test whether javascript: date functions resolve, with one count whose clause cannot match anything. Costs two calls.",
+      },
+      canary_table: {
+        type: "string",
+        default: "sys_user",
+        description:
+          "Table the date and invalid-column canaries run against. It has to hold rows to be conclusive, and it has to be one this connection can read.",
+      },
+      invalid_query_probe: {
+        type: "boolean",
+        default: true,
+        description:
+          "Test what the instance does with a condition on a column that does not exist: ignore it and answer for the whole table, or return no rows. Costs one call.",
+      },
+      include_identity: {
+        type: "boolean",
+        default: true,
+        description: "Read release, build tag, edition, active-plugin count and domain scope. Costs three calls.",
+      },
+      include_role_coverage: {
+        type: "boolean",
+        default: true,
+        description:
+          "Read the roles the account holds and fold them against the shipped role manifest. Costs one call. With this off, a refused table lists every role that could read it instead of only the ones this account is missing.",
+      },
+    },
+  },
+}
+
+export async function execute(args: Record<string, unknown>, context: ServiceNowContext): Promise<ToolResult> {
+  const tables = names(args.tables)
+  if (tables.length > TABLE_CAP)
+    return createErrorResult(
+      `tables holds ${tables.length} entries and the cap is ${TABLE_CAP} — each one is a sequential GET. Split the call.`,
+    )
+
+  const canary = text(args.canary_table) ?? "sys_user"
+  const lifetimeDays = typeof args.lifetime_days === "number" ? args.lifetime_days : 365
+  const wantsCanary = args.date_canary !== false
+  const wantsInvalid = args.invalid_query_probe !== false
+
+  // The auth manager's own failure message names the likely cause and points
+  // at snow_diagnose_setup. Flattening it into a generic error would send the
+  // reader back to exactly the opaque failure this tool exists to replace.
+  const authenticated = await getAuthenticatedClient(context).then(
+    (client) => ({ client }),
+    (error: unknown) => ({
+      failure: error instanceof Error ? error.message : String(error),
+      status: httpStatus(error),
+    }),
+  )
+  // The status rides in the metadata rather than only in the sentence. This is
+  // the hardest failure to act on — a dead credential answers 401 everywhere,
+  // so no probe below ever runs — and "the credential is dead" and "the
+  // instance could not be reached" call for opposite responses. Same rule as
+  // snow_aggregate_metrics' error metadata: nobody should have to regex an
+  // error message for a number the response already carried.
+  if ("failure" in authenticated)
+    return createErrorResult(
+      `No authenticated client for ${context.instanceUrl}: ${authenticated.failure}`,
+      authenticated.status === undefined ? {} : { http_status: authenticated.status },
+    )
+  const client: ProbeClient = authenticated.client
+
+  const reach = await probeReach(client)
+  const roles = args.include_role_coverage !== false ? await probeHeldRoles(client) : undefined
+  const manifest = loadRolesManifest()
+
+  // Sequential on purpose. These probes run against instances that are waking
+  // up, and a burst of parallel reads from a diagnostic is how the diagnostic
+  // becomes the reason the next tool call times out.
+  const reads: TableRead[] = []
+  for (const table of tables) reads.push(await probeTableRead(client, table, lifetimeDays))
+
+  // The canaries compare against the WHOLE canary table, so it gets its own
+  // unbounded count: a total already narrowed to lifetime_days describes a
+  // different population than the clause under test, and "the clause matched
+  // everything" is only a statement when both sides cover the same rows.
+  const total = wantsCanary || wantsInvalid ? (await probeTableRead(client, canary, 0)).lifetime : null
+
+  const data: Visibility = {
+    reach: reach.check,
+    roles: roles
+      ? {
+          held: roles.held,
+          heldTruncated: roles.truncated,
+          heldReadable: roles.readable,
+          heldHttpStatus: roles.httpStatus,
+          coverage: manifest && roles.readable ? summarizeRoleCoverage(manifest, roles.held) : undefined,
+          manifest: manifestStamp(manifest),
+        }
+      : undefined,
+    tables: reads.map((read) => ({ ...read, ...advice(manifest, read, roles) })),
+    dateFunctions: wantsCanary ? await dateFunctionCanary(client, canary, "gs.daysAgoStart", total) : undefined,
+    invalidQuery: wantsInvalid ? await invalidQueryProbe(client, canary, total) : undefined,
+    identity: args.include_identity !== false ? await readInstanceIdentity(client, reach.domain) : undefined,
+    instanceUrl: context.instanceUrl,
+  }
+
+  // Always a success envelope: the diagnosis ran. A refused table is the
+  // answer, not a failure of the tool, and an error envelope here reads as
+  // "try again" for a result that will not change.
+  return createSuccessResult(
+    data,
+    { tables: data.tables.length, readable: data.tables.filter((table) => table.readable).length },
+    summarize(data),
+  )
+}
+
+/**
+ * The manifest half of a table row, subject to three rules the manifest cannot
+ * enforce on itself.
+ *
+ * The probe outranks the manifest: a table that was just read needs no advice
+ * about roles, whatever a static role map says about it.
+ *
+ * A subtraction needs a list to subtract. A truncated held-role list cannot
+ * support one — the page caps at 500 with no ORDERBY and it is admins who
+ * overflow it, so "you are missing these roles" would be a guess dressed as
+ * advice, aimed at the one account that is missing nothing — and a REFUSED
+ * list supports it even less: there, `held` is empty because the instance said
+ * no, so every role the manifest names would be printed as missing, including
+ * the ones the account already holds. `include_role_coverage: false` is the
+ * one case where an empty list is not a claim, and the schema says what
+ * happens then: the full list of roles that could read the table.
+ *
+ * And a refusal has to be role-shaped before roles are the answer. 401 and 403
+ * are about this account; a 404 is about the table, a 400 about the query, and
+ * a 200 that did not parse is a hibernating instance answering with a login
+ * page. Telling someone to go ask an admin for `update_set_admin` because
+ * their PDI is asleep sends them to the wrong person with the wrong request.
+ */
+const advice = (manifest: unknown, read: TableRead, roles: HeldRoles | undefined): TableAdvice => {
+  const summary = manifest ? summarizeTableAccess(manifest, read.table, roles?.held ?? []) : EMPTY_ADVICE
+  return refusedForRoles(read) && knowsWhatIsHeld(roles) ? summary : { ...summary, missingRoles: [] }
+}
+
+/** ServiceNow answers an ACL failure on a table read with one of these two. */
+const ROLE_SHAPED = [401, 403]
+
+const refusedForRoles = (read: TableRead): boolean => !read.readable && ROLE_SHAPED.includes(read.httpStatus ?? 0)
+
+const knowsWhatIsHeld = (roles: HeldRoles | undefined): boolean =>
+  roles === undefined || (roles.readable && !roles.truncated)
+
+const EMPTY_ADVICE: TableAdvice = { missingRoles: [], scriptAcls: 0 }
+
+const names = (raw: unknown): string[] =>
+  Array.isArray(raw)
+    ? raw.map(String).map((name) => name.trim()).filter(Boolean)
+    : typeof raw === "string"
+      ? raw.split(",").map((name) => name.trim()).filter(Boolean)
+      : []
+
+const text = (raw: unknown): string | undefined => (typeof raw === "string" && raw.trim() !== "" ? raw.trim() : undefined)
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null
+
+/** The HTTP status an auth failure carried, when it carried one. */
+const httpStatus = (error: unknown): number | undefined => {
+  const response = isRecord(error) ? error.response : undefined
+  const status = isRecord(response) ? response.status : undefined
+  return typeof status === "number" ? status : undefined
+}
+
+/**
+ * The report as a human reads it. Plain text for the same reason
+ * `renderReport` is: it comes back as the MCP summary and is printed by
+ * clients that assume nothing about a terminal.
+ */
+const summarize = (data: Visibility): string => {
+  const lines = [
+    `  ${label("api access")} ${data.reach.title}`,
+    ...(data.roles ? [`  ${label("roles")} ${held(data.roles)}`] : []),
+    ...(data.identity ? [`  ${label("identity")} ${identity(data.identity)}`] : []),
+    ...(data.dateFunctions
+      ? [
+          `  ${label("date filters")} ${DATE_VERDICTS[data.dateFunctions.verdict]} (${data.dateFunctions.fn}: ${
+            data.dateFunctions.canary ?? "?"
+          } of ${data.dateFunctions.total ?? "?"} rows matched a clause that cannot match)`,
+        ]
+      : []),
+    ...(data.invalidQuery ? [`  ${label("bad columns")} ${REGIMES[data.invalidQuery.verdict]}`] : []),
+    ...(data.tables.length > 0 ? ["", "  tables"] : []),
+    ...data.tables.map((table) => `    ${(table.readable ? "ok" : String(table.httpStatus ?? "—")).padEnd(5)} ${row(table)}`),
+    // Said once, and said even where every count is zero: the number comes
+    // from the ACL `script` column alone, so a 0 means no scripted ACL was
+    // seen — never that no row-level filter applies to what you just counted.
+    ...(data.tables.some((table) => table.readable)
+      ? ["", "  Scripted-ACL counts cover the ACL script column only. Row-level conditions are invisible to this check."]
+      : []),
+  ]
+
+  return ["ServiceNow MCP — instance visibility", "", ...lines].join("\n")
+}
+
+// 13 characters, so continuation lines land under the text rather than under
+// the label — the same measure renderReport uses.
+const label = (name: string) => name.padEnd(13)
+
+/**
+ * The roles line. A refusal is reported as a refusal: "0 held", with a
+ * coverage figure beside it, is this tool inventing the one number a reader
+ * acts on out of an answer that was never given.
+ */
+const held = (roles: NonNullable<Visibility["roles"]>): string => {
+  if (roles.heldReadable)
+    return `${roles.held.length} held${roles.heldTruncated ? " (full page — a floor, not an inventory)" : ""}${
+      roles.coverage ? `; ${roles.coverage.unlocked} of ${roles.coverage.resolved} resolvable tools in reach` : ""
+    }`
+
+  const why =
+    roles.heldHttpStatus === 0
+      ? "the request never got an answer"
+      : ROLE_SHAPED.includes(roles.heldHttpStatus)
+        ? `the read was refused (HTTP ${roles.heldHttpStatus}); reading sys_user_has_role needs a role of its own`
+        : `HTTP ${roles.heldHttpStatus}, but not a role list`
+  return `unknown — ${why}. That is not an account that holds nothing.`
+}
+
+const identity = (identity: InstanceIdentity): string =>
+  [
+    identity.release,
+    identity.edition,
+    identity.productDescription,
+    identity.pluginCount === null ? undefined : `${identity.pluginCount} active plugins`,
+    identity.domainSeparated === "separated" ? "domain separation installed" : undefined,
+    identity.integrationUserDomain ? `domain ${identity.integrationUserDomain}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ") || "nothing readable in sys_properties"
+
+const row = (table: TableRead & TableAdvice): string =>
+  `${table.table.padEnd(30)} ${
+    table.readable
+      ? [
+          table.lifetime === null
+            ? "readable, but the instance sent no count"
+            : `${table.lifetime} rows${table.lifetimeWindowDays === null ? "" : ` over ${table.lifetimeWindowDays}d`}`,
+          `${table.scriptAcls} scripted ACL(s)`,
+        ].join(" · ")
+      : `${table.error ?? "not readable"}${
+          table.missingRoles.length > 0 ? ` · ask an admin for one of: ${table.missingRoles.join(", ")}` : ""
+        }`
+  }`
+
+const DATE_VERDICTS: Record<DateFunctions["verdict"], string> = {
+  resolved: "resolve — a windowed count on this instance really is windowed",
+  evaporated: "DROPPED — the instance ignored the date clause and answered for the whole table",
+  inconclusive: "inconclusive — nothing was shown either way",
+}
+
+const REGIMES: Record<InvalidQuery["verdict"], string> = {
+  ignores: "ignored — a condition on a column that does not exist answers for the whole table",
+  returns_no_rows: "no rows — a condition the instance cannot apply answers 0 rather than everything",
+  unknown: "unknown — the probe could not tell which regime this instance is in",
+}
+
+export const version = "1.0.0"
+export const author = "Serac"

--- a/packages/servicenow-mcp/src/sn-roles.ts
+++ b/packages/servicenow-mcp/src/sn-roles.ts
@@ -9,10 +9,18 @@
  * CI, and why `validatedOn` / `testedAt` are part of the payload — they are the
  * only staleness signal a consumer gets. See README.md, "The roles manifest".
  *
- * This module sits at the top of `src/` rather than under `shared/` because the
- * manifest sits at the package root — live services fetch it from `main` at a
- * literal raw.githubusercontent.com URL, so it cannot move. `../` from here
- * resolves to that root both from `src/` and from the published `dist/`.
+ * This module sits at the top of `src/` because the manifest sits at the
+ * package root: `../` from here resolves to that root both from `src/` in a
+ * checkout and from `dist/` in the published tarball, which is what lets one
+ * path serve both.
+ *
+ * The supported way to read it is this module, from the installed package —
+ * that is what `exports["./sn-roles"]` and the `files` entry are for. It is
+ * ALSO fetched from `main` over raw.githubusercontent.com by docs.serac.build,
+ * so moving the file is still a production change rather than a refactor (the
+ * consumer table in README.md is the list). What is no longer true is that a
+ * literal GitHub URL is the only way in: a consumer reaching for one should
+ * take the dependency instead.
  */
 
 import { readFileSync } from "node:fs"

--- a/packages/servicenow-mcp/tools.json
+++ b/packages/servicenow-mcp/tools.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-25T09:17:49.808Z",
-  "count": 445,
+  "generatedAt": "2026-08-25T21:56:04.196Z",
+  "count": 446,
   "groups": [
     {
       "name": "access-control",
@@ -8381,6 +8381,72 @@
           "inputSchema": {
             "type": "object",
             "properties": {}
+          }
+        },
+        {
+          "name": "snow_instance_visibility",
+          "description": "Report what this ServiceNow connection can actually see: per table whether the read succeeds (with the HTTP status and the row count behind it), which roles the account holds and which ones a refused table needs, whether javascript: date filters resolve on this instance or are silently dropped, whether a condition on an unknown column is ignored or returns no rows, and which release, build, edition and plugin count answered. Call this when queries come back empty or a filtered count looks wrong, before trusting any number from this instance. Read-only: every call is a GET.",
+          "permission": "read",
+          "allowedRoles": [
+            "developer",
+            "stakeholder",
+            "admin"
+          ],
+          "useCases": [
+            "empty results",
+            "permissions",
+            "roles",
+            "reachability",
+            "filters",
+            "instance identity",
+            "troubleshooting"
+          ],
+          "complexity": "beginner",
+          "frequency": "medium",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "tables": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 20,
+                "default": [],
+                "description": "Tables to probe for read access, one GET each (max 20). Omit to skip the per-table probe and report only roles, filters and identity."
+              },
+              "lifetime_days": {
+                "type": "number",
+                "default": 365,
+                "minimum": 0,
+                "description": "Bound each table's row count to rows created within this many days. 0 counts the whole table. A table that refuses the bounded read, or answers 0 to it, is re-read unbounded before that answer is reported: on a table with no sys_created_on the clause is silently dropped or matches nothing, and neither shows up as an error."
+              },
+              "date_canary": {
+                "type": "boolean",
+                "default": true,
+                "description": "Test whether javascript: date functions resolve, with one count whose clause cannot match anything. Costs two calls."
+              },
+              "canary_table": {
+                "type": "string",
+                "default": "sys_user",
+                "description": "Table the date and invalid-column canaries run against. It has to hold rows to be conclusive, and it has to be one this connection can read."
+              },
+              "invalid_query_probe": {
+                "type": "boolean",
+                "default": true,
+                "description": "Test what the instance does with a condition on a column that does not exist: ignore it and answer for the whole table, or return no rows. Costs one call."
+              },
+              "include_identity": {
+                "type": "boolean",
+                "default": true,
+                "description": "Read release, build tag, edition, active-plugin count and domain scope. Costs three calls."
+              },
+              "include_role_coverage": {
+                "type": "boolean",
+                "default": true,
+                "description": "Read the roles the account holds and fold them against the shipped role manifest. Costs one call. With this off, a refused table lists every role that could read it instead of only the ones this account is missing."
+              }
+            }
           }
         },
         {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.serac-labs/servicenow-mcp",
   "title": "Serac ServiceNow",
   "description": "400+ ServiceNow tools over stdio or streamable HTTP, plus blast-radius impact analysis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "websiteUrl": "https://docs.serac.build",
   "repository": {
     "url": "https://github.com/serac-labs/serac",
@@ -15,7 +15,7 @@
     {
       "registryType": "npm",
       "identifier": "@serac-labs/servicenow-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Fixes #331

New tool, `permission: "read"`, stakeholder-allowed, both transports. It reuses the setup doctor's pure classifiers but reads only the instance and the caller's own credential — never the process — which is why it can go on HTTP where `snow_diagnose_setup` cannot.

Returns per-table readability with the HTTP status and the roles that would open each blocked one, the held-role list with a truncation flag, a one-call date-function canary, the instance's invalid-query regime, and identity (release, build tag, edition, plugin count, domain separation).

The two probes worth explaining: a `javascript:` date function that does not resolve, and a condition naming an unknown column, both make ServiceNow return *more* rows rather than an error. So a filter that silently evaporates produces a large confident wrong number. Nothing in the catalog could detect either before.

## Three things review caught

- **A refused `sys_user_has_role` read was byte-identical to an account holding no roles.** `held: []`, no flag, and a coverage block reporting `blocked: 247` computed from a refusal — then advice to request roles the account already held. Now reports `unknown` and withholds coverage. A second door existed: a hibernating instance answers 200 with a login page that parses to zero rows, so `readable` keyed on status alone fabricated the same thing.
- **A hibernating instance produced `TypeError: Attempted to assign to readonly property` as its diagnosis.** `auth.ts` assigned into `response.data` without checking it was an object; on an HTML body it is a string, and the synthetic error carried no `.response`, so `htmlDiagnosis` never ran. The guard fixes every tool on a hibernating instance — 13 of 14 known production instances are PDIs.
- **The reach probe requested the integration user's display name** and printed it into the summary. It asks for `sys_domain` and `active` now. `classifyApiResponse` still names the account for the stdio doctor, where the reader owns the credential.

Each has a test that fails without the fix, driven against a real loopback server rather than a mock.

## Also here

- `snow_query_table` emitted `ORDERBYASC<field>` for an ascending sort — not a ServiceNow operator, silently dropped, so "oldest" returned an arbitrary row. `total` no longer fabricates `"100+"`; it reads `x-total-count` and omits the field when absent. `offset`/`limit` are coerced, so `offset: "100"` no longer string-concatenates.
- `snow_aggregate_metrics` carries the HTTP status on failure so callers stop regexing prose.
- `exports["./setup-doctor"]` was going to publish `runSetupDoctor` and `renderReport` — the machine-reading half — to every consumer. Narrowed to a new `./instance-diagnostics` subpath instead, with tests pinning both directions of the surface. The subpath is new on this branch so nothing depended on it.

## Notes for whoever releases

`sn-roles.manifest.json` is **not** regenerated — that needs a live probe. Version is `0.2.2` in `package.json` and both `server.json` fields. The `latest` dist-tag does not move on its own; `publish-mcp.yml` must be dispatched with `dist_tag=latest`, or consumers stay on 0.2.1.

`bun test` 491 pass / 0 fail (baseline 477) · typecheck · build · `generate:tools-json:check` (446 tools) · `check:registry-manifest` all clean.